### PR TITLE
[INJICERT-236] throw error when unsupported wellknown version requested

### DIFF
--- a/certify-core/src/main/java/io/mosip/certify/core/constants/ErrorConstants.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/constants/ErrorConstants.java
@@ -22,4 +22,5 @@ public class ErrorConstants {
     public static final String PROOF_HEADER_INVALID_ALG = "proof_header_invalid_alg";
     public static final String PROOF_HEADER_INVALID_KEY = "proof_header_invalid_key";
     public static final String PROOF_HEADER_AMBIGUOUS_KEY = "proof_header_ambiguous_key";
+    public static final String UNSUPPORTED_OPENID_VERSION = "unsupported_openid_version";
 }

--- a/certify-core/src/main/java/io/mosip/certify/core/constants/ErrorConstants.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/constants/ErrorConstants.java
@@ -22,5 +22,5 @@ public class ErrorConstants {
     public static final String PROOF_HEADER_INVALID_ALG = "proof_header_invalid_alg";
     public static final String PROOF_HEADER_INVALID_KEY = "proof_header_invalid_key";
     public static final String PROOF_HEADER_AMBIGUOUS_KEY = "proof_header_ambiguous_key";
-    public static final String UNSUPPORTED_OPENID_VERSION = "unsupported_openid_version";
+    public static final String UNSUPPORTED_OPENID_VERSION = "unsupported_openid4vci_draft_version";
 }

--- a/certify-service/src/main/java/io/mosip/certify/services/VCIssuanceServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/VCIssuanceServiceImpl.java
@@ -112,7 +112,7 @@ public class VCIssuanceServiceImpl implements VCIssuanceService {
     public Map<String, Object> getCredentialIssuerMetadata(String version) {
        if(issuerMetadata.containsKey(version))
            return issuerMetadata.get(version);
-       return issuerMetadata.get("latest");
+       throw new InvalidRequestException(ErrorConstants.UNSUPPORTED_OPENID_VERSION);
     }
 
     private VCResult<?> getVerifiableCredential(CredentialRequest credentialRequest, CredentialMetadata credentialMetadata,

--- a/certify-service/src/test/java/io/mosip/certify/controller/VCIssuanceControllerTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/controller/VCIssuanceControllerTest.java
@@ -86,7 +86,7 @@ public class VCIssuanceControllerTest {
     }
 
     @Test
-    public void getIssuerMetadata_withInvalidQueryParam_thenPass() throws Exception {
+    public void getIssuerMetadata_withInvalidQueryParam_thenFail() throws Exception {
         Exception e = new InvalidRequestException(ErrorConstants.UNSUPPORTED_OPENID_VERSION);
         Mockito.when(vcIssuanceService.getCredentialIssuerMetadata("v123")).thenThrow(e);
         mockMvc.perform(get("/issuance/.well-known/openid-credential-issuer?version=v123"))

--- a/certify-service/src/test/java/io/mosip/certify/controller/VCIssuanceControllerTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/controller/VCIssuanceControllerTest.java
@@ -91,7 +91,6 @@ public class VCIssuanceControllerTest {
         Mockito.when(vcIssuanceService.getCredentialIssuerMetadata("v123")).thenThrow(e);
         mockMvc.perform(get("/issuance/.well-known/openid-credential-issuer?version=v123"))
                 .andExpect(status().is4xxClientError());
-        Mockito.verify(vcIssuanceService).getCredentialIssuerMetadata("v123");
     }
 
     @Test


### PR DESCRIPTION
Earlier `/issuance/.well-known/openid-credential-issuer?version=v123` would return the latest versioned issuer metadata earlier if it was not valid, now returns an error.