### PR TITLE
[INJIMOB-1578] add google tink dependency for ed25519 support and use BouncyCastle for es256k verification

### DIFF
--- a/certify-service/pom.xml
+++ b/certify-service/pom.xml
@@ -62,6 +62,11 @@
             <artifactId>ld-signatures-java</artifactId>
             <version>1.0.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.crypto.tink</groupId>
+            <artifactId>tink</artifactId>
+            <version>1.13.0</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Changes in this PR:

- Added Google Think dependency for ED25519 support.
https://connect2id.com/products/nimbus-jose-jwt/examples/jwt-with-eddsa

- Using BouncyCastle for ES256K
https://connect2id.com/products/nimbus-jose-jwt/examples/jwt-with-es256k-signature
This change is needed as with JAVA 21, secp256k1 signatures can't be verified by nimbus-jose-jwt alone.