### PR TITLE
[INJICERT-495] Added template exception for handling invalid id exceptions for template

### DIFF
--- a/certify-core/src/main/java/io/mosip/certify/core/constants/ErrorConstants.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/constants/ErrorConstants.java
@@ -25,5 +25,4 @@ public class ErrorConstants {
     public static final String UNSUPPORTED_OPENID_VERSION = "unsupported_openid4vci_draft_version";
     public static final String INVALID_TEMPLATE_ID = "template_with_id_not_found";
     public static final String EMPTY_TEMPLATE_CONTENT = "empty_template_content";
-    public static final String EMPTY_TEMPLATE_NAME = "empty_template_name";
 }

--- a/certify-core/src/main/java/io/mosip/certify/core/exception/TemplateException.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/exception/TemplateException.java
@@ -1,0 +1,21 @@
+package io.mosip.certify.core.exception;
+
+import io.mosip.certify.core.constants.ErrorConstants;
+
+public class TemplateException extends RuntimeException {
+    private String errorCode;
+
+    public TemplateException() {
+        super(ErrorConstants.UNKNOWN_ERROR);
+        this.errorCode = ErrorConstants.UNKNOWN_ERROR;
+    }
+
+    public TemplateException(String errorCode) {
+        super(errorCode);
+        this.errorCode = errorCode;
+    }
+
+    public String getErrorCode() {
+        return errorCode;
+    }
+}

--- a/certify-service/src/main/java/io/mosip/certify/advice/ExceptionHandlerAdvice.java
+++ b/certify-service/src/main/java/io/mosip/certify/advice/ExceptionHandlerAdvice.java
@@ -11,6 +11,7 @@ import io.mosip.certify.core.dto.VCError;
 import io.mosip.certify.core.exception.CertifyException;
 import io.mosip.certify.core.exception.InvalidRequestException;
 import io.mosip.certify.core.exception.NotAuthenticatedException;
+import io.mosip.certify.core.exception.TemplateException;
 import io.mosip.certify.core.util.CommonUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.TypeMismatchException;
@@ -129,6 +130,9 @@ public class ExceptionHandlerAdvice extends ResponseEntityExceptionHandler imple
         if(ex instanceof CertifyException) {
             String errorCode = ((CertifyException) ex).getErrorCode();
             return new ResponseEntity<ResponseWrapper>(getResponseWrapper(errorCode, getMessage(errorCode)), HttpStatus.OK);
+        }
+        if(ex instanceof TemplateException) {
+            return new ResponseEntity<>(getResponseWrapper(INVALID_REQUEST, ex.getMessage()) ,HttpStatus.NOT_FOUND);
         }
         if(ex instanceof AuthenticationCredentialsNotFoundException) {
             return new ResponseEntity<ResponseWrapper>(getResponseWrapper(HttpStatus.UNAUTHORIZED.name(),

--- a/certify-service/src/main/java/io/mosip/certify/controller/SvgTemplateController.java
+++ b/certify-service/src/main/java/io/mosip/certify/controller/SvgTemplateController.java
@@ -7,6 +7,7 @@ package io.mosip.certify.controller;
 
 import io.mosip.certify.core.entity.SvgTemplate;
 import io.mosip.certify.core.exception.CertifyException;
+import io.mosip.certify.core.exception.TemplateException;
 import io.mosip.certify.core.spi.SvgTemplateService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,10 +31,10 @@ public class SvgTemplateController {
     SvgTemplateService svgTemplateService;
 
     @GetMapping("/svg-template/{id}")
-    public ResponseEntity<String> serveSvgTemplate(@PathVariable UUID id) throws CertifyException {
+    public ResponseEntity<String> serveSvgTemplate(@PathVariable UUID id) throws TemplateException {
         SvgTemplate template = svgTemplateService.getSvgTemplate(id);
         return ResponseEntity.ok()
-                .header(HttpHeaders.CONTENT_TYPE, "image/svg")
+                .header(HttpHeaders.CONTENT_TYPE, "image/svg+xml")
                 .cacheControl(CacheControl.maxAge(1, TimeUnit.DAYS).cachePublic())
                 .lastModified(template.getUpdatedtimes().atZone(ZoneId.systemDefault()).toInstant())
                 .body(template.getTemplate());

--- a/certify-service/src/main/java/io/mosip/certify/services/SvgTemplateServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/SvgTemplateServiceImpl.java
@@ -8,6 +8,7 @@ package io.mosip.certify.services;
 import io.mosip.certify.core.constants.ErrorConstants;
 import io.mosip.certify.core.entity.SvgTemplate;
 import io.mosip.certify.core.exception.CertifyException;
+import io.mosip.certify.core.exception.TemplateException;
 import io.mosip.certify.core.repository.SvgTemplateRepository;
 import io.mosip.certify.core.spi.SvgTemplateService;
 import lombok.extern.slf4j.Slf4j;
@@ -27,7 +28,7 @@ public class SvgTemplateServiceImpl implements SvgTemplateService {
     @Override
     public SvgTemplate getSvgTemplate(UUID id) {
         Optional<SvgTemplate> optional = svgRenderTemplateRepository.findById(id);
-        SvgTemplate svgRenderTemplate = optional.orElseThrow(() -> new CertifyException(ErrorConstants.INVALID_TEMPLATE_ID));
+        SvgTemplate svgRenderTemplate = optional.orElseThrow(() -> new TemplateException(ErrorConstants.INVALID_TEMPLATE_ID));
 
         return svgRenderTemplate;
 

--- a/certify-service/src/test/java/io/mosip/certify/controller/SvgTemplateControllerTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/controller/SvgTemplateControllerTest.java
@@ -1,0 +1,72 @@
+package io.mosip.certify.controller;
+
+import io.mosip.certify.core.constants.ErrorConstants;
+import io.mosip.certify.core.dto.ParsedAccessToken;
+import io.mosip.certify.core.entity.SvgTemplate;
+import io.mosip.certify.core.exception.TemplateException;
+import io.mosip.certify.core.spi.SvgTemplateService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.net.http.HttpHeaders;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(value=SvgTemplateController.class)
+public class SvgTemplateControllerTest {
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    SvgTemplateService svgTemplateService;
+
+    @MockBean
+    ParsedAccessToken parsedAccessToken;
+
+    @Test
+    public void  getSvgTemplate_withValidId_thenPass() throws Exception {
+        SvgTemplate svgTemplate = new SvgTemplate();
+        UUID id = UUID.randomUUID();
+        svgTemplate.setId(id);
+        String template = """
+                    <svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"200\\" height=\\"200\\">
+                    <rect width=\\"200\\" height=\\"200\\" fill=\\"#ff6347\\"/>
+                    <text x=\\"100\\" y=\\"100\\" font-size=\\"30\\" text-anchor=\\"middle\\" fill=\\"white\\">
+                    Hello, SVG!
+                    </text></svg>
+                """;
+        svgTemplate.setTemplate(template);
+        LocalDateTime date = LocalDateTime.now();
+        svgTemplate.setCreatedtimes(date);
+        svgTemplate.setUpdatedtimes(date);
+
+        Mockito.when(svgTemplateService.getSvgTemplate(Mockito.any())).thenReturn(svgTemplate);
+
+        mockMvc.perform(get("/public/svg-template/" + id))
+                .andExpect(status().isOk())
+                .andExpect(content().string(svgTemplate.getTemplate()))
+                .andExpect(content().contentType("image/svg+xml"))
+                .andExpect(header().string("Cache-Control", "max-age=86400, public"));
+    }
+
+    @Test
+    public void  getSvgTemplate_withInValidId_thenFail() throws Exception {
+        TemplateException templateException = new TemplateException(ErrorConstants.INVALID_TEMPLATE_ID);
+        UUID id = UUID.randomUUID();
+        Mockito.when(svgTemplateService.getSvgTemplate(id)).thenThrow(templateException);
+
+        mockMvc.perform(get("/public/svg-template/" + id))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/certify-service/src/test/java/io/mosip/certify/services/SvgRenderTemplateServiceTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/SvgRenderTemplateServiceTest.java
@@ -2,7 +2,7 @@ package io.mosip.certify.services;
 
 import io.mosip.certify.core.constants.ErrorConstants;
 import io.mosip.certify.core.entity.SvgTemplate;
-import io.mosip.certify.core.exception.CertifyException;
+import io.mosip.certify.core.exception.TemplateException;
 import io.mosip.certify.core.repository.SvgTemplateRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Assert;
@@ -51,10 +51,10 @@ public class SvgRenderTemplateServiceTest {
     @Test
     public void getSvgTemplate_withInvalidId_thenFail() {
         Mockito.when(svgRenderTemplateRepository.findById(Mockito.any())).thenReturn(Optional.empty());
-        CertifyException certifyException = Assert.assertThrows(CertifyException.class, () -> {
+        TemplateException templateException = Assert.assertThrows(TemplateException.class, () -> {
             svgRenderTemplateService.getSvgTemplate(UUID.randomUUID());
         });
-        Assert.assertEquals(ErrorConstants.INVALID_TEMPLATE_ID, certifyException.getErrorCode());
+        Assert.assertEquals(ErrorConstants.INVALID_TEMPLATE_ID, templateException.getErrorCode());
     }
 
 }


### PR DESCRIPTION
[INJICERT-495] Added template exceptions for handling id not found.

[INJICERT-495]: https://mosip.atlassian.net/browse/INJICERT-495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ