### PR TITLE
[INJICERT-567]

### DIFF
--- a/docker-compose/docker-compose-injistack/README.md
+++ b/docker-compose/docker-compose-injistack/README.md
@@ -11,7 +11,7 @@ Before running the docker-compose, you need to build the inji-web-proxy image:
 
 ```bash
 # Clone the repository
-git clone https://github.com/mosip/inji-web.git -b develop
+git clone https://github.com/mosip/inji-web.git -b release-0.11.x
 cd inji-web/inji-web-proxy
 
 # Build the Docker image
@@ -54,6 +54,8 @@ You have two options for the certify plugin:
 
 ### Option 2: Create Custom Plugin
 You can create your own plugin by implementing the following interface and place the resultant jar in loader_path:
+
+Reference Implementation: [CSVDataProviderPlugin](https://github.com/mosip/digital-credential-plugins/blob/develop/mock-certify-plugin/src/main/java/io.mosip.certify.mock.integration/service/MockCSVDataProviderPlugin.java)
 ```java
 public interface DataProviderPlugin {
     // Implement your custom logic here
@@ -69,6 +71,7 @@ public interface DataProviderPlugin {
   ```
   certs/oidckeystore.p12
   ```
+  [Collab Env OIDCKeystore](https://docs.inji.io/inji-wallet/inji-mobile/customization-overview/credential_providers#onboarding-mimoto-as-oidc-client-for-a-new-issuer)
 
 ### 2. Configuration Files
 Ensure all configuration files are properly updated in the config directory:
@@ -79,6 +82,8 @@ Ensure all configuration files are properly updated in the config directory:
 - mimoto-trusted-verifiers.json
 - credential-template.html
 
+[Mimoto Docker Compose Configuration Docs](https://github.com/mosip/mimoto/tree/release-0.15.x/docker-compose)
+[Inji Certify Configuration Docs](../../README.md)
 ## Running the Application
 
 ### 1. Start the Services
@@ -151,4 +156,4 @@ docker-compose down -v
 
 
 ## Additional Resources
-- [Inji Documentation](https://docs.mosip.io/inji)
+- [Inji Documentation](https://docs.inji.io/)

--- a/docker-compose/docker-compose-injistack/README.md
+++ b/docker-compose/docker-compose-injistack/README.md
@@ -1,0 +1,154 @@
+# Inji Stack Setup
+
+This guide provides instructions for setting up and running Inji Stack.
+
+## Prerequisites
+- Docker and Docker Compose installed on your system
+- Git (to clone the repository)
+- Basic understanding of Docker and container operations
+### Building inji-web-proxy
+Before running the docker-compose, you need to build the inji-web-proxy image:
+
+```bash
+# Clone the repository
+git clone https://github.com/mosip/inji-web.git -b develop
+cd inji-web/inji-web-proxy
+
+# Build the Docker image
+docker build -t inji-web-proxy:local .
+```
+
+## Directory Structure Setup
+Create the following directory structure before proceeding:
+
+```
+docker-compose-injistack/
+├── data/
+│   └── CERTIFY_PKCS12/(p12 file generated at runtime)
+├── certs/
+│   └── oidckeystore.p12 (to be obtained during onboarding of mimoto to esignet)
+├── loader_path/
+│   └── certify/ (plugin jar to be placed here)
+├── config/ (default setup should work as is for csvplugin, any other config changes user can make as per their setup)
+│   ├── certify-default.properties
+│   ├── certify-mock-identity.properties
+│   ├── mimoto-default.properties
+│   ├── mimoto-issuers-config.json
+│   ├── mimoto-trusted-verifiers.json
+│   └── credential-template.html
+├── nginx.conf
+├── certify_init.sql
+└── docker-compose.yml
+```
+
+## Mock Certify Plugin Setup
+You have two options for the certify plugin:
+
+### Option 1: Use Existing Mock Plugin
+- Supported versions: 0.3.0 and above
+- Download the snapshot JAR from:
+  ```
+  https://oss.sonatype.org/content/repositories/snapshots/io/mosip/certify/mock-certify-plugin/0.3.0-SNAPSHOT/
+  ```
+- Place the downloaded JAR in `loader_path/certify/`
+
+### Option 2: Create Custom Plugin
+You can create your own plugin by implementing the following interface and place the resultant jar in loader_path:
+```java
+public interface DataProviderPlugin {
+    // Implement your custom logic here
+}
+```
+
+## Configuration Setup
+
+
+
+### 1. Certificate Setup
+- Place your PKCS12 certificate file (obtained from esignet onboarding) in:
+  ```
+  certs/oidckeystore.p12
+  ```
+
+### 2. Configuration Files
+Ensure all configuration files are properly updated in the config directory:
+- certify-default.properties
+- certify-mock-identity.properties
+- mimoto-default.properties
+- mimoto-issuers-config.json
+- mimoto-trusted-verifiers.json
+- credential-template.html
+
+## Running the Application
+
+### 1. Start the Services
+```bash
+docker-compose up -d
+```
+
+### 2. Verify Services
+Check if all services are running:
+```bash
+docker-compose ps
+```
+
+## Service Endpoints
+The following services will be available:
+- Database (PostgreSQL): `localhost:5433`
+- Certify Service: `localhost:8090`
+- Nginx: `localhost:80`
+- Mimoto Service: `localhost:8099`
+- Inji Web Proxy: `localhost:3010`
+- Inji Web: `localhost:3001`
+
+## Using the Application
+
+### Accessing the Web Interface
+1. Open your browser and navigate to `http://localhost:3001`
+2. You can:
+    - Download credentials
+    - View credential status
+    - Manage your digital identity
+
+## Troubleshooting
+
+### Common Issues and Solutions
+1. Container startup issues:
+   ```bash
+   docker-compose logs [service_name]
+   ```
+
+2. Database connection issues:
+    - Verify PostgreSQL container is running
+    - Check database credentials in configuration
+
+3. Plugin loading issues:
+    - Verify plugin JAR is in the correct directory
+    - Check plugin version compatibility
+
+### Health Checks
+Monitor service health:
+```bash
+docker-compose ps
+docker logs [container_name]
+```
+
+## Stopping the Application
+To stop all services:
+```bash
+docker-compose down
+```
+
+To stop and remove all containers and volumes:
+```bash
+docker-compose down -v
+```
+
+## Security Considerations
+- Keep your PKCS12 certificate secure
+- Regularly update configurations and credentials
+- Monitor service logs for security issues
+
+
+## Additional Resources
+- [Inji Documentation](https://docs.mosip.io/inji)

--- a/docker-compose/docker-compose-injistack/certify_init.sql
+++ b/docker-compose/docker-compose-injistack/certify_init.sql
@@ -1,0 +1,166 @@
+CREATE DATABASE inji_certify
+  ENCODING = 'UTF8'
+  LC_COLLATE = 'en_US.UTF-8'
+  LC_CTYPE = 'en_US.UTF-8'
+  TABLESPACE = pg_default
+  OWNER = postgres
+  TEMPLATE  = template0;
+
+COMMENT ON DATABASE inji_certify IS 'certify related data is stored in this database';
+
+\c inji_certify postgres
+
+DROP SCHEMA IF EXISTS certify CASCADE;
+CREATE SCHEMA certify;
+ALTER SCHEMA certify OWNER TO postgres;
+ALTER DATABASE inji_certify SET search_path TO certify,pg_catalog,public;
+
+CREATE TABLE certify.key_alias(
+                                  id character varying(36) NOT NULL,
+                                  app_id character varying(36) NOT NULL,
+                                  ref_id character varying(128),
+                                  key_gen_dtimes timestamp,
+                                  key_expire_dtimes timestamp,
+                                  status_code character varying(36),
+                                  lang_code character varying(3),
+                                  cr_by character varying(256) NOT NULL,
+                                  cr_dtimes timestamp NOT NULL,
+                                  upd_by character varying(256),
+                                  upd_dtimes timestamp,
+                                  is_deleted boolean DEFAULT FALSE,
+                                  del_dtimes timestamp,
+                                  cert_thumbprint character varying(100),
+                                  uni_ident character varying(50),
+                                  CONSTRAINT pk_keymals_id PRIMARY KEY (id),
+                                  CONSTRAINT uni_ident_const UNIQUE (uni_ident)
+);
+
+CREATE TABLE certify.key_policy_def(
+                                       app_id character varying(36) NOT NULL,
+                                       key_validity_duration smallint,
+                                       is_active boolean NOT NULL,
+                                       pre_expire_days smallint,
+                                       access_allowed character varying(1024),
+                                       cr_by character varying(256) NOT NULL,
+                                       cr_dtimes timestamp NOT NULL,
+                                       upd_by character varying(256),
+                                       upd_dtimes timestamp,
+                                       is_deleted boolean DEFAULT FALSE,
+                                       del_dtimes timestamp,
+                                       CONSTRAINT pk_keypdef_id PRIMARY KEY (app_id)
+);
+
+CREATE TABLE certify.key_store(
+                                  id character varying(36) NOT NULL,
+                                  master_key character varying(36) NOT NULL,
+                                  private_key character varying(2500) NOT NULL,
+                                  certificate_data character varying NOT NULL,
+                                  cr_by character varying(256) NOT NULL,
+                                  cr_dtimes timestamp NOT NULL,
+                                  upd_by character varying(256),
+                                  upd_dtimes timestamp,
+                                  is_deleted boolean DEFAULT FALSE,
+                                  del_dtimes timestamp,
+                                  CONSTRAINT pk_keystr_id PRIMARY KEY (id)
+);
+
+CREATE TABLE certify.svg_template (
+                                    id UUID NOT NULL,
+                                    template VARCHAR NOT NULL,
+                                    cr_dtimes timestamp NOT NULL,
+                                    upd_dtimes timestamp,
+                                    CONSTRAINT pk_svgtmp_id PRIMARY KEY (id)
+);
+
+CREATE TABLE certify.template_data(
+                                    context character varying(1024) NOT NULL,
+                                    credential_type character varying(512) NOT NULL,
+                                    template VARCHAR NOT NULL,
+                                    cr_dtimes timestamp NOT NULL default now(),
+                                    upd_dtimes timestamp,
+                                    CONSTRAINT pk_template PRIMARY KEY (context, credential_type)
+);
+
+INSERT INTO certify.template_data (context, credential_type, template, cr_dtimes, upd_dtimes) VALUES ('https://vharsh.github.io/DID/mock-context.json,https://www.w3.org/2018/credentials/v1', 'MockVerifiableCredential,VerifiableCredential', '{
+    "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://vharsh.github.io/DID/mock-context.json"],
+    "issuer": "${issuer}",
+    "type": ["VerifiableCredential", "MockVerifiableCredential"],
+    "issuanceDate": "${validFrom}",
+    "expirationDate": "${validUntil}",
+    "credentialSubject": {
+        "gender": ${gender},
+        "postalCode": ${postalCode},
+        "fullName": ${fullName},
+        "dateOfBirth": "${dateOfBirth}",
+        "province": ${province},
+        "phone": "${phone}",
+        "addressLine1": ${addressLine1},
+        "region": ${region},
+        "vcVer": "${vcVer}",
+        "UIN": ${UIN},
+        "email": "${email}",
+        "face": "${face}"
+    }
+}', '2024-10-22 17:08:17.826851', NULL);
+INSERT INTO certify.template_data (context, credential_type, template, cr_dtimes, upd_dtimes) VALUES ('https://vharsh.github.io/DID/mock-context.json,https://www.w3.org/ns/credentials/v2', 'MockVerifiableCredential,VerifiableCredential', '{
+    "@context": [
+            "https://www.w3.org/ns/credentials/v2", "https://vharsh.github.io/DID/mock-context.json"],
+    "issuer": "${issuer}",
+    "type": ["VerifiableCredential", "MockVerifiableCredential"],
+    "validFrom": "${validFrom}",
+    "validUntil": "${validUntil}",
+    "credentialSubject": {
+    "gender": ${gender},
+        "postalCode": ${postalCode},
+        "fullName": ${fullName},
+        "dateOfBirth": "${dateOfBirth}",
+        "province": ${province},
+        "phone": "${phone}",
+        "addressLine1": ${addressLine1},
+        "region": ${region},
+        "vcVer": "${vcVer}",
+        "UIN": ${UIN},
+        "email": "${email}",
+        "face": "${face}"
+    }
+}', '2024-10-22 17:08:17.826851', NULL);
+INSERT INTO certify.template_data (context, credential_type, template, cr_dtimes, upd_dtimes) VALUES ('https://www.w3.org/2018/credentials/v1', 'FarmerCredential,VerifiableCredential', '{
+     "@context": [
+                "https://www.w3.org/2018/credentials/v1",
+                "https://vharsh.github.io/DID/farmer.json",
+    "https://w3id.org/security/suites/ed25519-2020/v1"
+        ],
+        "issuer": "${issuer}",
+        "type": [
+            "VerifiableCredential",
+            "FarmerCredential"
+        ],
+        "issuanceDate": "${validFrom}",
+        "expirationDate": "${validUntil}",
+        "credentialSubject": {
+            "name": "${name}",
+            "dateOfBirth": "${dateOfBirth}",
+            "highestEducation": "${highestEducation}",
+            "maritalStatus": "${maritalStatus}",
+            "typeOfHouse": "${typeOfHouse}",
+            "numberOfDependents": "${numberOfDependents}",
+            "phoneNumber": "${phoneNumber}",
+            "works": "${works}",
+            "landArea": "${landArea}",
+            "landOwnershipType": "${landOwnershipType}",
+            "primaryCropType": "${primaryCropType}",
+            "secondaryCropType": "${secondaryCropType}"
+        }
+}
+', '2024-10-24 12:32:38.065994', NULL);
+
+
+INSERT INTO certify.key_policy_def(APP_ID,KEY_VALIDITY_DURATION,PRE_EXPIRE_DAYS,ACCESS_ALLOWED,IS_ACTIVE,CR_BY,CR_DTIMES) VALUES('ROOT', 2920, 1125, 'NA', true, 'mosipadmin', now());
+INSERT INTO certify.key_policy_def(APP_ID,KEY_VALIDITY_DURATION,PRE_EXPIRE_DAYS,ACCESS_ALLOWED,IS_ACTIVE,CR_BY,CR_DTIMES) VALUES('CERTIFY_SERVICE', 1095, 60, 'NA', true, 'mosipadmin', now());
+INSERT INTO certify.key_policy_def(APP_ID,KEY_VALIDITY_DURATION,PRE_EXPIRE_DAYS,ACCESS_ALLOWED,IS_ACTIVE,CR_BY,CR_DTIMES) VALUES('CERTIFY_PARTNER', 1095, 60, 'NA', true, 'mosipadmin', now());
+INSERT INTO certify.key_policy_def(APP_ID,KEY_VALIDITY_DURATION,PRE_EXPIRE_DAYS,ACCESS_ALLOWED,IS_ACTIVE,CR_BY,CR_DTIMES) VALUES('CERTIFY_MOCK_RSA', 1095, 60, 'NA', true, 'mosipadmin', now());
+INSERT INTO certify.key_policy_def(APP_ID,KEY_VALIDITY_DURATION,PRE_EXPIRE_DAYS,ACCESS_ALLOWED,IS_ACTIVE,CR_BY,CR_DTIMES) VALUES('CERTIFY_MOCK_ED25519', 1095, 60, 'NA', true, 'mosipadmin', now());
+INSERT INTO certify.key_policy_def(APP_ID,KEY_VALIDITY_DURATION,PRE_EXPIRE_DAYS,ACCESS_ALLOWED,IS_ACTIVE,CR_BY,CR_DTIMES) VALUES('BASE', 1095, 60, 'NA', true, 'mosipadmin', now());
+

--- a/docker-compose/docker-compose-injistack/config/certify-default.properties
+++ b/docker-compose/docker-compose-injistack/config/certify-default.properties
@@ -1,0 +1,168 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+## Application Name
+spring.application.name=certify
+spring.cloud.config.uri=http://localhost:8888
+
+server.port=8090
+server.servlet.path=/v1/certify
+
+openapi.info.title=Certify Service
+openapi.info.description=Rest Endpoints for operations related to certify
+openapi.info.version=1.0
+openapi.info.license.name=Mosip
+openapi.info.license.url=https://docs.mosip.io/platform/license
+mosipbox.public.url=http://certify:${server.port}
+openapi.service.server.url=${mosipbox.public.url}${server.servlet.path}
+openapi.service.server.description=Certify Service
+springdoc.swagger-ui.disable-swagger-default-url=true
+spring.mvc.servlet.path=${server.servlet.path}
+
+spring.messages.basename=messages
+spring.messages.encoding=UTF-8
+
+spring.main.allow-bean-definition-overriding=true
+spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER
+
+
+
+## -------------------------------------- Authentication & Authorization -----------------------------------------------
+
+mosip.certify.security.auth.post-urls={}
+mosip.certify.security.auth.put-urls={}
+mosip.certify.security.auth.get-urls={}
+
+mosip.certify.security.ignore-csrf-urls=**/actuator/**,/favicon.ico,**/error,\
+  **/swagger-ui/**,**/v3/api-docs/**,\
+  **/issuance/**
+
+mosip.certify.security.ignore-auth-urls=**/actuator/**,**/error,**/swagger-ui/**,\
+  **/v3/api-docs/**, **/issuance/**,/public/**, **/system-info/**
+
+
+## ------------------------------------------ Discovery openid-configuration -------------------------------------------
+mosip.certify.discovery.issuer-id=${mosipbox.public.url}${server.servlet.path}
+mosip.certify.authorization.url=https://esignet-mock.dev1.mosip.net
+
+##--------------change this later---------------------------------
+mosip.certify.supported.jwt-proof-alg={'RS256','PS256'}
+mosip.certify.issuer=CertifyIssuer
+
+
+##----- These are reference to the oauth resource server providing jwk----------------------------------##
+mosip.certify.cnonce-expire-seconds=40
+
+mosip.certify.identifier=${mosipbox.public.url}
+mosip.certify.authn.filter-urls={ '${server.servlet.path}/issuance/credential', '${server.servlet.path}/issuance/vd11/credential', '${server.servlet.path}/issuance/vd12/credential' }
+mosip.certify.authn.issuer-uri=${mosip.certify.authorization.url}/v1/esignet
+mosip.certify.authn.jwk-set-uri=https://esignet-mock.dev1.mosip.net/v1/esignet/oauth/.well-known/jwks.json
+mosip.certify.authn.allowed-audiences={ '${mosipbox.public.url}${server.servlet.path}/issuance/credential', '${mosip.certify.authorization.url}/v1/esignet/vci/credential' }
+
+#------------------------------------ Key-manager specific properties --------------------------------------------------
+#Crypto asymmetric algorithm name
+mosip.kernel.crypto.asymmetric-algorithm-name=RSA/ECB/OAEPWITHSHA-256ANDMGF1PADDING
+#Crypto symmetric algorithm name
+mosip.kernel.crypto.symmetric-algorithm-name=AES/GCM/NoPadding
+#Keygenerator asymmetric algorithm name
+mosip.kernel.keygenerator.asymmetric-algorithm-name=RSA
+#Keygenerator symmetric algorithm name
+mosip.kernel.keygenerator.symmetric-algorithm-name=AES
+#Asymmetric algorithm key length
+mosip.kernel.keygenerator.asymmetric-key-length=2048
+#Symmetric algorithm key length
+mosip.kernel.keygenerator.symmetric-key-length=256
+#Encrypted data and encrypted symmetric key separator
+mosip.kernel.data-key-splitter=#KEY_SPLITTER#
+#GCM tag length
+mosip.kernel.crypto.gcm-tag-length=128
+#Hash algo name
+mosip.kernel.crypto.hash-algorithm-name=PBKDF2WithHmacSHA512
+#Symmtric key length used in hash
+mosip.kernel.crypto.hash-symmetric-key-length=256
+#No of iterations in hash
+mosip.kernel.crypto.hash-iteration=100000
+#Sign algo name
+mosip.kernel.crypto.sign-algorithm-name=RS256
+#Certificate Sign algo name
+mosip.kernel.certificate.sign.algorithm=SHA256withRSA
+
+mosip.kernel.keymanager.hsm.config-path=CERTIFY_PKCS12/local.p12
+mosip.kernel.keymanager.hsm.keystore-type=PKCS12
+mosip.kernel.keymanager.hsm.keystore-pass=local
+
+#Type of keystore, Supported Types: PKCS11, PKCS12, Offline, JCE
+#mosip.kernel.keymanager.hsm.keystore-type=PKCS11
+# For PKCS11 provide Path of config file.
+# For PKCS12 keystore type provide the p12/pfx file path. P12 file will be created internally so provide only file path & file name.
+# For Offline & JCE property can be left blank, specified value will be ignored.
+#mosip.kernel.keymanager.hsm.config-path=/config/softhsm-application.conf
+# Passkey of keystore for PKCS11, PKCS12
+# For Offline & JCE proer can be left blank. JCE password use other JCE specific properties.
+#mosip.kernel.keymanager.hsm.keystore-pass=${softhsm.certify.mock.security.pin}
+
+
+mosip.kernel.keymanager.certificate.default.common-name=www.example.com
+mosip.kernel.keymanager.certificate.default.organizational-unit=EXAMPLE-CENTER
+mosip.kernel.keymanager.certificate.default.organization=IIITB
+mosip.kernel.keymanager.certificate.default.location=BANGALORE
+mosip.kernel.keymanager.certificate.default.state=KA
+mosip.kernel.keymanager.certificate.default.country=IN
+
+mosip.kernel.keymanager.softhsm.certificate.common-name=www.example.com
+mosip.kernel.keymanager.softhsm.certificate.organizational-unit=Example Unit
+mosip.kernel.keymanager.softhsm.certificate.organization=IIITB
+mosip.kernel.keymanager.softhsm.certificate.country=IN
+
+# Application Id for PMS master key.
+mosip.kernel.partner.sign.masterkey.application.id=PMS
+mosip.kernel.partner.allowed.domains=DEVICE
+
+mosip.kernel.keymanager-service-validate-url=https://${mosip.hostname}/keymanager/validate
+mosip.kernel.keymanager.jwtsign.validate.json=false
+mosip.keymanager.dao.enabled=false
+crypto.PrependThumbprint.enable=true
+
+mosip.kernel.keymgr.hsm.health.check.enabled=true
+mosip.kernel.keymgr.hsm.health.key.app-id=CERTIFY_SERVICE
+mosip.kernel.keymgr.hsm.healthkey.ref-id=TRANSACTION_CACHE
+
+mosip.kernel.keymgr.hsm.health.check.encrypt=true
+
+mosip.certify.cache.security.secretkey.reference-id=TRANSACTION_CACHE
+
+##----------------------------------------- Database properties --------------------------------------------------------
+
+mosip.certify.database.hostname=database
+mosip.certify.database.port=5432
+spring.datasource.url=jdbc:postgresql://${mosip.certify.database.hostname}:${mosip.certify.database.port}/inji_certify?currentSchema=certify
+spring.datasource.username=postgres
+spring.datasource.password=postgres
+
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.show-sql=false
+spring.jpa.hibernate.ddl-auto=none
+spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
+
+## ---------------------------------------- Cache configuration --------------------------------------------------------
+spring.cache.type=simple
+spring.data.redis.host=cache
+spring.data.redis.port=6379
+spring.data.redis.password=redis
+
+#spring.cache.type=simple
+spring.cache.cache-names=${mosip.certify.cache.names}
+
+management.health.redis.enabled=false
+
+mosip.certify.access-token-expire-seconds=86400
+
+mosip.certify.cache.names=userinfo,vcissuance
+# Cache size setup is applicable only for 'simple' cache type.
+# Cache size configuration will not be considered with 'Redis' cache type
+mosip.certify.cache.size={'userinfo': 200, 'vcissuance' : 2000 }
+
+
+# Cache expire in seconds is applicable for both 'simple' and 'Redis' cache type
+mosip.certify.cache.expire-in-seconds={'userinfo': ${mosip.certify.access-token-expire-seconds}, 'vcissuance': ${mosip.certify.access-token-expire-seconds}}

--- a/docker-compose/docker-compose-injistack/config/certify-mock-identity.properties
+++ b/docker-compose/docker-compose-injistack/config/certify-mock-identity.properties
@@ -14,7 +14,6 @@ mosip.certify.mock.vciplugin.issuer.key-cert="dummy-issuer-cert"
 mosip.certify.mock.vciplugin.ca.key-cert=dummy
 mosip.certify.svg-templates=insurance-svg-template.json
 mosip.certify.identifier=http://localhost:8090
-mosip.certify.dataprovider.types={'MockVerifiableCredential','StudentCredential','FarmerProfileCredential'}
 
 mosip.certify.issuer.uri=did:web:vharsh.github.io:DID:harsh
 mosip.certify.issuer.pub.key=did:web:vharsh.github.io:DID:harsh#key-0

--- a/docker-compose/docker-compose-injistack/config/certify-mock-identity.properties
+++ b/docker-compose/docker-compose-injistack/config/certify-mock-identity.properties
@@ -1,0 +1,103 @@
+## ------------------------------------------- Mock ID Integration properties ------------------------------------------------------------
+mosip.certify.integration.scan-base-package=io.mosip.certify.mock.integration
+mosip.certify.integration.audit-plugin=LoggerAuditService
+mosip.certify.integration.vci-plugin=MockVCIssuancePlugin
+
+## ------------------------------------------- Mock ID plugin related properties ------------------------------------------------------------
+mosip.certify.mock.vciplugin.verification-method=${mosip.certify.authn.jwk-set-uri}
+mosip.certify.mock.authenticator.get-identity-url=http://mock-identity-system:8082/v1/mock-identity-system/identity
+mosip.certify.cache.security.algorithm-name=AES/ECB/PKCS5Padding
+mosip.certify.cache.secure.individual-id=false
+mosip.certify.cache.store.individual-id=true
+# TODO: Onboard secrets for local build
+mosip.certify.mock.vciplugin.issuer.key-cert="dummy-issuer-cert"
+mosip.certify.mock.vciplugin.ca.key-cert=dummy
+mosip.certify.svg-templates=insurance-svg-template.json
+mosip.certify.identifier=http://localhost:8090
+mosip.certify.dataprovider.types={'MockVerifiableCredential','StudentCredential','FarmerProfileCredential'}
+
+mosip.certify.issuer.uri=did:web:vharsh.github.io:DID:harsh
+mosip.certify.issuer.pub.key=did:web:vharsh.github.io:DID:harsh#key-0
+
+mosip.certify.issuer=CertifyIssuer
+mosip.certify.integration.data-provider-plugin=MockCSVDataProviderPlugin
+mosip.certify.issuer.vc-sign-algo=Ed25519Signature2020
+## CSV specific config
+mosip.certify.data-provider.identifier.column=id
+mosip.certify.data-provider.fields.include=id,name,phoneNumber,dateOfBirth,highestEducation,typeOfHouse,numberOfDependents,works,landArea,landOwnershipType,primaryCropType,secondaryCropType,maritalStatus
+mosip.certify.plugin.csv.file.uri=https://raw.githubusercontent.com/jainhitesh9998/digital-credential-plugins/refs/heads/develop/mock-certify-plugin/src/test/resources/farmer_identity_data.csv
+mosip.certify.issuer.svg.template.id=
+mosip.certify.key-values={\
+   'vd12' : {\
+              'credential_issuer': '${mosip.certify.identifier}',\
+              'authorization_servers': {'${mosip.certify.authorization.url}'},\
+              'credential_endpoint': '${mosipbox.public.url}${server.servlet.path}/issuance/vd12/credential',\
+              'display': {{'name': 'Insurance', 'locale': 'en'}},\
+              'credentials_supported' : {\
+                 'FarmerProfileCredential' : {\
+                    'format': 'ldp_vc',\
+                    'scope' : 'farmer_vc_ldp',\
+                    'cryptographic_binding_methods_supported': {'did:jwk'},\
+                    'cryptographic_suites_supported': {'RsaSignature2018'},\
+                    'proof_types_supported': {'jwt'},\
+                    'credential_definition': {\
+                      'type': {'VerifiableCredential','FarmerCredential'},\
+                      'credentialSubject': {\
+                            'name': {'display': {{'name': 'Name','locale': 'en'}}}, \
+                            'highestEducation': {'display': {{'name': 'Highest Education','locale': 'en'}}},\
+                            'dateOfBirth': {'display': {{'name': 'Date of Birth','locale': 'en'}}},\
+                            'maritalStatus': {'display': {{'name': 'Marital Status','locale': 'en'}}},\
+                            'typeOfHouse': {'display': {{'name': 'Type of House','locale': 'en'}}},\
+                            'numberOfDependents': {'display': {{'name': 'Number of Dependents','locale': 'en'}}},\
+                            'phoneNumber': {'display': {{'name': 'Phone Number','locale': 'en'}}},\
+                            'knowsLanguage': {'display': {{'name': 'Knows Language','locale': 'en'}}},\
+                            'works': {'display': {{'name': 'Employment Type','locale': 'en'}}},\
+                            'farmingType': {'display': {{'name': 'Farming Type','locale': 'en'}}},\
+                            'landArea': {'display': {{'name': 'Land Area','locale': 'en'}}},\
+                            'landOwnershipType': {'display': {{'name': 'Land Ownership Type','locale': 'en'}}},\
+                            'primaryCropType': {'display': {{'name': 'Primary Crop Name','locale': 'en'}}},\
+                            'secondaryCropType': {'display': {{'name': 'Secondary Crop type','locale': 'en'}}}\
+                     }},\
+                    'display': {{'name': 'Farmer Profile Verifiable Credential', \
+                                  'locale': 'en', \
+                                  'logo': {'url': 'https://sunbird.org/images/sunbird-logo-new.png','alt_text': 'a square logo of a Sunbird'},\
+                                  'background_color': '#FDFAF9',\
+                                  'text_color': '#7C4616'}},\
+                    'order' : {'fullName','policyName','policyExpiresOn','policyIssuedOn','policyNumber','mobile','dob','gender','benefits','email'}\
+                 }}},\
+  'latest' : {\
+              'credential_issuer': '${mosip.certify.identifier}',   \
+              'authorization_servers': {'${mosip.certify.authorization.url}'}, \
+              'credential_endpoint': '${mosipbox.public.url}${server.servlet.path}/issuance/credential', \
+              'display': {{'name': 'Insurance', 'locale': 'en'}},\
+              'credential_configurations_supported' : { \
+                 'FarmerProfileCredential' : {\
+                    'format': 'ldp_vc',\
+                    'scope' : 'mock_identity_vc_ldp',\
+                    'cryptographic_binding_methods_supported': {'did:jwk'},\
+                    'credential_signing_alg_values_supported': {'RsaSignature2018'},\
+                    'proof_types_supported': {'jwt': {'proof_signing_alg_values_supported': {'RS256', 'PS256'}}},\
+                    'credential_definition': {\
+                      'type': {'VerifiableCredential','FarmerCredential'},\
+                      'credentialSubject': {\
+                            'name': {'display': {{'name': 'Name','locale': 'en'}}}, \
+                            'highestEducation': {'display': {{'name': 'Highest Education','locale': 'en'}}},\
+                            'dateOfBirth': {'display': {{'name': 'Date of Birth','locale': 'en'}}},\
+                            'maritalStatus': {'display': {{'name': 'Marital Status','locale': 'en'}}},\
+                            'typeOfHouse': {'display': {{'name': 'Type of House','locale': 'en'}}},\
+                            'numberOfDependents': {'display': {{'name': 'Number of Dependents','locale': 'en'}}},\
+                            'phoneNumber': {'display': {{'name': 'Phone Number','locale': 'en'}}},\
+                            'knowsLanguage': {'display': {{'name': 'Knows Language','locale': 'en'}}},\
+                            'works': {'display': {{'name': 'Employment Type','locale': 'en'}}},\
+                            'farmingType': {'display': {{'name': 'Farming Type','locale': 'en'}}},\
+                            'landArea': {'display': {{'name': 'Land Area','locale': 'en'}}},\
+                            'landOwnershipType': {'display': {{'name': 'Land Ownership Type','locale': 'en'}}},\
+                            'primaryCropType': {'display': {{'name': 'Primary Crop Name','locale': 'en'}}},\
+                            'secondaryCropType': {'display': {{'name': 'Secondary Crop type','locale': 'en'}}}\
+                     }},\
+                    'display': {{'name': 'Farmer Profile Verifiable Credential', \
+                                  'locale': 'en', \
+                                  'logo': {'url': 'https://sunbird.org/images/sunbird-logo-new.png','alt_text': 'a square logo of a Sunbird'},\
+                                  'background_color': '#FDFAF9',\
+                                  'background_image': { 'uri': 'https://sunbird.org/images/sunbird-logo-new.png' }, \
+                                  'text_color': '#7C4616'}}}}}}

--- a/docker-compose/docker-compose-injistack/config/credential-template.html
+++ b/docker-compose/docker-compose-injistack/config/credential-template.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8" />
+    <title>$titleName</title>
+</head>
+<body #if ($textColor) style="color: $textColor;" #end>
+<div #if ($backgroundColor) style="background: $backgroundColor; border: 1px $textolor solid; border-radius: 15px; padding: 10px;" #else style="border: 2px black solid; border-radius: 15px; padding: 10px;" #end>
+    <div style="text-align: center; padding-top: 10px; font-weight: bold;">
+        <span style="font-size: 16px; vertical-align: middle;">$titleName</span>
+    </div>
+    <div style="display: flex; flex-direction: row; justify-content: space-between;">
+        <div style="margin: 30px; justify-content: center; align-items: center;">
+            #if (!$face)
+            <div style="float: left; height:100px;width:100px;background-color:white;border-radius:10px;border:1px solid grey">
+                <img style="margin: 25px;width: 50px; height:50px;" src="https://raw.githubusercontent.com/challabeehyv/mimoto-config/main/user-icon.png" alt="Logo" />
+            </div>
+            #else
+            <img style="height:100px;width:100px; border-radius:10px;" src="$face" alt="Logo" />
+            #end
+            <div style="float: left; height:100px;width:100px; border-radius:10px; margin-top: 20px;">
+                <img style="width: 100px; height:auto;" src="$logoUrl" alt="Logo" />
+            </div>
+        </div>
+        <div style="margin-left: 30px; padding-top: 30px">
+            #foreach($entry in $rowProperties.entrySet())
+            #if($entry.value)
+            <div style="margin-bottom: 10px; float: left; width: 450px;">
+                <div style="font-weight: bold; font-size: 16px; margin-bottom: 5px; word-wrap: break-word;">$entry.key</div>
+                <div style="font-size: 16px; word-wrap: break-word;">$entry.value</div>
+            </div>
+            #end
+            #end
+        </div>
+    </div>
+    <img src="data:image/png;base64,$qrCodeImage" alt="QR Code"/>
+</div>
+</body>
+</html>

--- a/docker-compose/docker-compose-injistack/config/farmer_identity_data.csv
+++ b/docker-compose/docker-compose-injistack/config/farmer_identity_data.csv
@@ -1,0 +1,8 @@
+id,name,phoneNumber,dateOfBirth,highestEducation,typeOfHouse,numberOfDependents,works,landArea,landOwnershipType,primaryCropType,secondaryCropType,maritalStatus
+4567538768,John Doe,9876543210,1980-05-15,Bachelors Degree,Farmhouse,3,Full-time,50.5,Self-owned,Wheat,Vegetables,Married
+4567538769,Mary Smith,8765432109,1975-08-22,High School,Ranch,4,Full-time,25.75,Leased,Rice,Pulses,Married
+4567538770,Raj Patel,7654321098,1990-03-10,Primary Education,Cottage,2,Part-time,15.25,Family Owned,Cotton,Maize,Married
+4567538771,Sarah Johnson,6543210987,1985-11-30,Diploma,Ranch,1,Full-time,35.5,Self-owned,Sugarcane,Rice,Single
+4567538772,Kumar Swamy,5432109876,1970-04-18,No Formal Education,Cottage,5,Full-time,45.0,Self-owned,Maize,Wheat,Married
+4567538773,Li Wei,4321098765,1988-09-25,Masters Degree,Farmhouse,2,Part-time,20.5,Leased,Vegetables,Fruits,Married
+4567538774,Arun Kumar,9876543211,1987-06-20,Diploma,Cottage,2,Part-time,22.75,Family Owned,Rice,Cotton,Married

--- a/docker-compose/docker-compose-injistack/config/mimoto-default.properties
+++ b/docker-compose/docker-compose-injistack/config/mimoto-default.properties
@@ -1,0 +1,290 @@
+server.port=8099
+server.servlet.context-path=/v1/mimoto
+health.config.enabled=false
+mosip.service.end-points=/**/*
+
+mosipbox.public.url=http://localhost:${server.port}
+mosip.api.public.url=http://localhost:${server.port}
+mosip.resident.url=https://api.collab.mosip.net/v1/resident
+mosip.esignet.host=https://esignet.collab.mosip.net
+keycloak.external.url=https://iam.collab.mosip.net/
+mosip.kernel.authmanager.url=http://authmanager.kernel/
+mosip.websub.url=http://websub.websub/
+
+# START inji-default.properties
+
+mosip.inji.allowedAuthType=demo,otp,bio-Finger,bio-Iris,bio-Face
+mosip.inji.allowedEkycAuthType=demo,otp,bio-Finger,bio-Iris,bio-Face
+mosip.inji.allowedInternalAuthType=otp,bio-Finger,bio-Iris,bio-Face
+mosip.inji.faceSdkModelUrl=https://api.collab.mosip.net/inji
+# maximum number of retry for downloading vc
+mosip.inji.vcDownloadMaxRetry=10
+# pool interval in milli seconds
+mosip.inji.vcDownloadPoolInterval=6000
+# validate binding audience url to be sent in token
+mosip.inji.audience=ida-binding
+# issuer to be sent in token
+mosip.inji.issuer=residentapp
+# warning screen domain name
+mosip.inji.warningDomainName=${mosip.api.public.url}
+#timeout for vc download api via openid4vci flow in milliseconds
+mosip.inji.openId4VCIDownloadVCTimeout=30000
+# inji documentation url
+mosip.inji.aboutInjiUrl=https://docs.mosip.io/inji/inji-mobile-wallet/overview
+# minimum storage space required for making audit entry in MB
+mosip.inji.minStorageRequiredForAuditEntry=2
+# minimum storage space required for downloading / receiving vc in MB
+mosip.inji.minStorageRequired=2
+
+# END inji-default.properties
+
+
+# START bootstrap.properties
+
+spring.cloud.config.uri=http://nginx/
+spring.cloud.config.name=mimoto,inji
+spring.application.name=mimoto
+
+#config.server.file.storage.uri=https://raw.githubusercontent.com/mosip/mosip-config/collab1/
+config.server.file.storage.uri=http://nginx/
+
+management.endpoint.health.show-details=always
+management.endpoints.web.exposure.include=info,health,refresh
+
+openapi.info.title=${spring.application.name}
+openapi.info.description=${spring.application.name}
+openapi.info.version=1.0
+openapi.info.license.name=Mosip
+openapi.info.license.url=https://docs.mosip.io/platform/license
+openapi.service.servers[0].url=${mosip.api.public.url}${server.servlet.context-path}
+openapi.service.servers[0].description=${spring.application.name}
+openapi.group.name=${openapi.info.title}
+openapi.group.paths[0]=/**
+springdoc.swagger-ui.disable-swagger-default-url=true
+springdoc.swagger-ui.tagsSorter=alpha
+springdoc.swagger-ui.operationsSorter=alpha
+
+# END bootstrap.properties
+
+# MOSIP
+
+public.url=${mosip.api.public.url}/v1/mimoto
+mosip.resident.base.url=${mosip.resident.url}/resident/v1
+idp.binding.base.url=https://${mosip.esignet.host}/v1/esignet/binding
+mosip.iam.adapter.disable-self-token-rest-template=true
+
+RESIDENT_OTP=${mosip.resident.base.url}/req/otp
+RESIDENT_CREDENTIAL_REQUEST=${mosip.resident.base.url}/req/credential
+RESIDENT_CREDENTIAL_REQUEST_STATUS=${RESIDENT_CREDENTIAL_REQUEST}/status
+RESIDENT_VID=${mosip.resident.base.url}/vid
+RESIDENT_AUTH_LOCK=${mosip.resident.base.url}/req/auth-lock
+RESIDENT_AUTH_UNLOCK=${mosip.resident.base.url}/req/auth-unlock
+RESIDENT_INDIVIDUALID_OTP=${mosip.resident.base.url}/individualId/otp
+RESIDENT_AID_GET_INDIVIDUALID=${mosip.resident.base.url}/aid/status
+BINDING_OTP=${idp.binding.base.url}/binding-otp
+WALLET_BINDING=${idp.binding.base.url}/wallet-binding
+
+
+# Resident App
+credential.template=template.json
+credential.sample=sample_credential.json
+credential.data.path=data
+safetynet.api.key=
+safetynet.api.url=https://www.googleapis.com/androidcheck/v1/attestations/verify?key=${safetynet.api.key}
+
+registration.processor.print.textfile=registration-processor-print-text-file.json
+
+# Websub
+mosip.event.hubUrl=${mosip.websub.url}/hub/
+mosip.event.hub.subUrl=${mosip.event.hubUrl}
+mosip.event.hub.pubUrl=${mosip.event.hubUrl}
+
+
+# MOSIP partner
+mosip.partner.id=mpartner-default-mobile
+mosip.event.callBackUrl=${public.url}/credentialshare/callback/notify
+mosip.event.topic=${mosip.partner.id}/CREDENTIAL_ISSUED
+mosip.event.secret=Kslk30SNF2AChs2
+
+
+mosip.partner.crypto.p12.filename=keystore.p12
+mosip.partner.crypto.p12.password=1234cryptopwd
+mosip.partner.crypto.p12.alias=partner
+mosip.partner.encryption.key=${mosip.partner.crypto.p12.password}
+mosip.partner.prependThumbprint=true
+
+
+mosip.datashare.partner.id=mpartner-default-resident
+mosip.datashare.policy.id=mpolicy-default-resident
+
+
+csrf.disabled=true
+# Delayed websub subscription. Default is 5 seconds in ms.
+mosip.event.delay-millisecs=5000
+# Websub re-subscription workaround for losing subscribed topic when MOSIP websub update or restart. Default is 5 minutes in ms.
+websub-resubscription-delay-millisecs=86400000
+
+#-------------TOKEN GENERATION----------------
+#Token generation request id
+token.request.id=io.mosip.registration.processor
+#Token generation app id
+token.request.appid=regproc
+#Token generation username
+token.request.username=registrationprocessor
+#Token generation password
+token.request.password=abc123
+#Token generation version
+token.request.version=1.0
+#Token generation Client Id
+token.request.clientId=mosip-regproc-client
+#Token generation secret key
+token.request.secretKey=abc123
+#Token generation issuer url
+token.request.issuerUrl=${keycloak.internal.url}/auth/realms/mosip
+
+#Audit Service
+AUDIT=${mosip.kernel.auditmanager.url}/v1/auditmanager/audits
+AUDIT_URL=${mosip.kernel.auditmanager.url}/v1/auditmanager/audits
+KEYBASEDTOKENAPI=${mosip.kernel.authmanager.url}/v1/authmanager/authenticate/clientidsecretkey
+
+#Master Data Services
+# MASTER=http://kernel-masterdata-service/v1/masterdata
+MASTER=${mosip.kernel.masterdata.url}/v1/masterdata
+TEMPLATES=${MASTER}/templates
+
+#Packet receiver application version
+mosip.print.application.version=1.0
+#Request Date Time format
+mosip.print.datetime.pattern=yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
+
+
+#-------------Printing Service--------------------
+mosip.print.service.id=mosip.print
+
+#Audit request id
+mosip.print.audit.id=mosip.applicanttype.getApplicantType
+mosip.country.code=MOR
+
+#Kernel Crypto signature
+registration.processor.signature.isEnabled=true
+
+# Language Supported By Platform - ISO
+mosip.supported-languages=eng,ara,fra
+
+mosip.template-language=eng
+mosip.optional-languages=fra,ara
+mosip.mandatory-languages=eng
+
+# mosip.primary-language=eng
+# mosip.secondary-language=ara
+
+#----------------------- CBEFF Util--------------------------------------------------
+# Cbeff URL where the files will be stored in git, change it accordingly in case of change of storage location.
+# mosip.kernel.xsdstorage-uri=${spring.cloud.config.uri}/${spring.application.name}/${spring.profiles.active}/${spring.cloud.config.label}/
+mosip.kernel.xsdstorage-uri=https://raw.githubusercontent.com/mosip/mosip-config/develop/
+# Cbeff XSD file name in config server
+mosip.kernel.xsdfile=mosip-cbeff.xsd
+
+#----------------------------- Applicant Type --------------------------------------------------
+mosip.kernel.applicant.type.age.limit = 5
+
+#----------------------------- Static PIN --------------------------------------------------
+mosip.kernel.pin.length=6
+
+#-----------------------------TOKEN-ID Properties---------------------------------
+#length of the token id
+mosip.kernel.tokenid.length=36
+
+# log level
+logging.level.root=WARN
+logging.level.io.mosip=INFO
+# logging.level.io.mosip.kernel.auth.defaultadapter.filter=INFO
+logging.level.io.mosip.kernel.auth.defaultadapter=DEBUG
+logging.level.org.springframework.http.client=DEBUG
+logging.level.io.mosip.residentapp=INFO
+logging.level.reactor.netty.http.client=INFO
+# tomcat access logs
+server.tomcat.accesslog.enabled=true
+server.tomcat.accesslog.directory=/dev
+server.tomcat.accesslog.prefix=stdout
+server.tomcat.accesslog.buffered=false
+server.tomcat.accesslog.suffix=
+server.tomcat.accesslog.file-date-format=
+server.tomcat.accesslog.pattern={"@timestamp":"%{yyyy-MM-dd'T'HH:mm:ss.SSS'Z'}t","level":"ACCESS","level_value":70000,"traceId":"%{X-B3-TraceId}i","statusCode":%s,"req.requestURI":"%U","bytesSent":%b,"timeTaken":%T,"appName":"${spring.application.name}"}
+server.tomcat.accesslog.className=io.mosip.kernel.core.logger.config.SleuthValve
+registration.processor.unMaskedUin.length=5
+
+IDSchema.Version=1.0
+registration.processor.identityjson=identity-mapping.json
+registration.processor.demographic.identity=identity
+CREATEDATASHARE=${mosip.datashare.url}/v1/datashare/create
+DECRYPTPINBASSED=${mosip.kernel.keymanager.url}/v1/keymanager/decryptWithPin
+
+
+#Auth Adapter rest template authentication configs
+mosip.iam.adapter.appid=partner
+mosip.iam.adapter.clientid=mpartner-default-mobile
+mosip.iam.adapter.clientsecret=1234secret
+auth.server.admin.issuer.uri=${keycloak.external.url}/auth/realms/
+
+mosip.iam.adapter.issuerURL=${keycloak.internal.url}/auth/realms/mosip
+mosip.authmanager.base-url=${mosip.kernel.authmanager.url}/v1/authmanager
+mosip.authmanager.client-token-endpoint=${mosip.authmanager.base-url}/authenticate/clientidsecretkey
+auth.server.admin.validate.url=${mosip.kernel.authmanager.url}/v1/authmanager/authorize/admin/validateToken
+
+
+# in minutes
+mosip.iam.adapter.validate-expiry-check-rate=1440
+
+# in minutes
+mosip.iam.adapter.renewal-before-expiry-interval=1440
+
+#this should be false if you don?t use this restTemplate true if you do
+
+mosip.iam.adapter.self-token-renewal-enable=true
+mosip.auth.filter_disable=true
+mosip.auth.adapter.impl.basepackage=io.mosip.kernel.auth.defaultadapter
+mosip.kernel.auth.appids.realm.map={prereg:'mosip',ida:'mosip',registrationclient:'mosip',regproc:'mosip',partner:'mosip',resident:'mosip',admin:'mosip',crereq:'mosip',creser:'mosip',datsha:'mosip',idrepo:'mosip'}
+
+vercred.type.vid=VID
+mosip.idp.partner.id=mpartner-default-mobile
+mosip.idp.partner.encryption.key=Aci9jg28B8mO_LDfDXo3ZTp5_HKgEMun2tYyHCa1e8k
+wallet.binding.partner.id=mpartner-default-mimotokeybinding
+wallet.binding.partner.api.key=1234walletbindingkey
+
+#mosip notification otp channel config
+mosip.notificationtype=SMS|EMAIL|PHONE
+
+# Configurations related to openid4vc
+mosip.openid.issuers=mimoto-issuers-config.json
+mosip.openid.htmlTemplate=credential-template.html
+mosip.oidc.client.assertion.type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer
+mosip.oidc.p12.filename=oidckeystore.p12
+mosip.oidc.p12.password=mosip123
+mosip.oidc.p12.path=certs/
+
+
+#OpenId4VP related Configuration START
+
+#File name for the mimoto trusted verifiers
+mosip.openid.verifiers=mimoto-trusted-verifiers.json
+
+#Inji Web Config
+mosip.inji.web.url=https://injiweb.collab.mosip.net
+mosip.inji.web.redirect.url=https://injiweb.collab.mosip.net/authorize
+mosip.inji.qr.data.size.limit=10000
+mosip.inji.qr.code.height=650
+mosip.inji.qr.code.width=650
+
+#OVP Config
+mosip.inji.ovp.qrdata.pattern=INJI_OVP://https://injiweb.collab.mosip.net/authorize?response_type=vp_token&resource=%s&presentation_definition=%s
+mosip.inji.ovp.redirect.url.pattern=%s#vp_token=%s&presentation_submission=%s
+mosip.inji.ovp.error.redirect.url.pattern=%s?error=%s&error_description=%s
+
+#DataShare Config
+mosip.data.share.url=https://datashare-inji.collab.mosip.net
+mosip.data.share.create.url=https://datashare-inji.collab.mosip.net/v1/datashare/create/static-policyid/static-subscriberid
+mosip.data.share.create.retry.count=3
+mosip.data.share.get.url.pattern=https://datashare-inji.collab.mosip.net/v1/datashare/get/static-policyid/static-subscriberid/*
+
+#OpenId4VP related Configuration END

--- a/docker-compose/docker-compose-injistack/config/mimoto-issuers-config.json
+++ b/docker-compose/docker-compose-injistack/config/mimoto-issuers-config.json
@@ -1,0 +1,29 @@
+{
+  "issuers": [
+    {
+      "credential_issuer": "Mock",
+      "protocol": "OpenId4VCI",
+      "display": [
+        {
+          "name": "Farmers Credentials",
+          "logo": {
+            "url": "https://api.collab.mosip.net/inji/mosip-logo.png",
+            "alt_text": "mosip-logo"
+          },
+          "title": "Mock Identity",
+          "description": "Download Mock Identity Credential",
+          "language": "en"
+        }
+      ],
+      "client_id": "mpartner-mock-testing",
+      "redirect_uri": "io.mosip.residentapp.inji://oauthredirect",
+      "token_endpoint": "http://localhost:8099/v1/mimoto/get-token/Mock",
+      "authorization_audience": "https://esignet-mock.dev1.mosip.net/v1/esignet/oauth/v2/token",
+      "proxy_token_endpoint": "https://esignet-mock.dev1.mosip.net/v1/esignet/oauth/v2/token",
+      "client_alias": "mpartner-mock-testing",
+      "qr_code_type": "EmbeddedVC",
+      "enabled": "true",
+      "wellknown_endpoint": "http://certify:8090/v1/certify/issuance/.well-known/openid-credential-issuer"
+    }
+  ]
+}

--- a/docker-compose/docker-compose-injistack/config/mimoto-trusted-verifiers.json
+++ b/docker-compose/docker-compose-injistack/config/mimoto-trusted-verifiers.json
@@ -1,0 +1,10 @@
+{
+  "verifiers": [
+    {
+      "client_id": "https://injiverify.collab.mosip.net",
+      "redirect_uri": [
+        "https://injiverify.collab.mosip.net/redirect"
+      ]
+    }
+  ]
+}

--- a/docker-compose/docker-compose-injistack/docker-compose.yaml
+++ b/docker-compose/docker-compose-injistack/docker-compose.yaml
@@ -1,0 +1,105 @@
+version: '3.8'
+
+services:
+  database:
+    image: 'postgres:latest'
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    volumes:
+      - ./certify_init.sql:/docker-entrypoint-initdb.d/certify_init.sql
+    networks:
+      - network
+    ports:
+      - "5433:5432"
+
+  certify:
+    image: mosipdev/inji-certify:develop
+    user: root
+    ports:
+      - 8090:8090
+    environment:
+      - container_user=mosip
+      - active_profile_env=default, mock-identity
+      - SPRING_CONFIG_NAME=certify
+      - SPRING_CONFIG_LOCATION=/home/mosip/config/
+      - enable_certify_artifactory=false
+      - download_hsm_client=false
+    volumes:
+      - ./config/certify-default.properties:/home/mosip/config/certify-default.properties
+      - ./config/certify-mock-identity.properties:/home/mosip/config/certify-mock-identity.properties
+      - ./data/CERTIFY_PKCS12:/home/mosip/CERTIFY_PKCS12
+      - ./loader_path/certify/:/home/mosip/additional_jars/
+    networks:
+      - network
+    depends_on:
+      - database
+
+  nginx:
+    container_name: nginx
+    image: nginx:alpine
+    ports:
+      - '80:80'
+    volumes:
+      - ./config/mimoto-issuers-config.json:/config/server/mimoto-issuers-config.json
+      - ./config/mimoto-trusted-verifiers.json:/config/server/mimoto-trusted-verifiers.json
+      - ./config/credential-template.html:/config/server/credential-template.html
+      - ./nginx.conf:/etc/nginx/nginx.conf
+    networks:
+      - network
+  mimoto-service:
+    container_name: 'Mimoto-Service'
+    image: 'mosipid/mimoto:0.14.0'
+    user: root
+    ports:
+      - '8099:8099'
+    environment:
+      - container_user=mosip
+      - active_profile_env=default
+      - SPRING_CONFIG_NAME=mimoto
+      - SPRING_CONFIG_LOCATION=/home/mosip/
+    networks:
+      - network
+    volumes:
+      - ./config/mimoto-default.properties:/home/mosip/mimoto-default.properties
+      - ./config/mimoto-issuers-config.json:/home/mosip/mimoto-issuers-config.json
+      - ./config/mimoto-trusted-verifiers.json:/home/mosip/mimoto-trusted-verifiers.json
+      - ./certs/oidckeystore.p12:/home/mosip/certs/oidckeystore.p12
+    depends_on:
+      - nginx
+
+  inji-web-proxy:
+    container_name: 'inji-web-proxy'
+    image: inji-web-proxy:local
+    ports:
+      - '3010:3010'
+    environment:
+      - MIMOTO_HOST=http://mimoto-service:8099
+      - PORT=3010
+    depends_on:
+      - mimoto-service
+    networks:
+      - network
+
+  inji-web:
+    container_name: 'inji-web'
+    image: mosipdev/inji-web:develop
+    ports:
+      - '3001:3004'
+    environment:
+      - MIMOTO_HOST=http://localhost:3010/v1/mimoto
+      - DEFAULT_LANG=en
+    depends_on:
+      - inji-web-proxy
+    networks:
+      - network
+
+
+networks:
+  network:
+    name: mosip_network
+    external: true
+
+volumes:
+  cache:
+    driver: local

--- a/docker-compose/docker-compose-injistack/docker-compose.yaml
+++ b/docker-compose/docker-compose-injistack/docker-compose.yaml
@@ -74,7 +74,7 @@ services:
     ports:
       - '3010:3010'
     environment:
-      - MIMOTO_HOST=http://mimoto-service:8099
+      - MIMOTO_HOST=http://mimoto-service:8099/v1/mimoto
       - PORT=3010
     depends_on:
       - mimoto-service
@@ -87,7 +87,7 @@ services:
     ports:
       - '3001:3004'
     environment:
-      - MIMOTO_HOST=http://localhost:3010/v1/mimoto
+      - MIMOTO_HOST=http://localhost:3010
       - DEFAULT_LANG=en
     depends_on:
       - inji-web-proxy

--- a/docker-compose/docker-compose-injistack/nginx.conf
+++ b/docker-compose/docker-compose-injistack/nginx.conf
@@ -1,0 +1,12 @@
+events { }
+
+http {
+    server {
+        listen 80;
+
+        location / {
+            root /config/server;
+            autoindex on;
+        }
+    }
+}


### PR DESCRIPTION
[INJICERT-456]: Add complete Inji Stack docker setup

This commit includes the complete setup for running InjiStack setup:

- Add docker-compose configuration for all required services:
  * PostgreSQL database
  * Certify service
  * Nginx
  * Mimoto service
  * inji-web-proxy
  * inji-web

- Include comprehensive README with:
  * Prerequisites and build instructions
  * Directory structure setup
  * Mock certify plugin configuration (v0.3.0+)
  * Step-by-step deployment guide
  * Troubleshooting instructions

- Configure necessary networking and volume mounts
- Add support for custom certify plugins
- Setup credential download functionality at localhost:3001

Dependencies:
- Requires inji-web-proxy:local image build
- Requires mock-certify-plugin v0.3.0 or above
- Requires valid PKCS12 certificate from esignet onboarding

[INJICERT-456]: https://mosip.atlassian.net/browse/INJICERT-567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ