### PR TITLE
[INJICERT-657] Added a fix to keep issuer metedata value fixed

### DIFF
--- a/certify-service/src/main/java/io/mosip/certify/services/CertifyIssuanceServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/CertifyIssuanceServiceImpl.java
@@ -142,10 +142,14 @@ public class CertifyIssuanceServiceImpl implements VCIssuanceService {
        if(issuerMetadata.containsKey(version)) {
            return issuerMetadata.get(version);
        } else if(version != null && version.equals("vd12")) {
-           Map<String, Object> vd12IssuerMetadata = convertLatestToVd12(issuerMetadata.get("latest"));
+           LinkedHashMap<String, Object> originalIssuerMetadata = new LinkedHashMap<>(issuerMetadata.get("latest"));
+           Map<String, Object> vd12IssuerMetadata = convertLatestToVd12(originalIssuerMetadata);
+           issuerMetadata.put("vd12", (LinkedHashMap<String, Object>) vd12IssuerMetadata);
            return vd12IssuerMetadata;
        } else if(version != null && version.equals("vd11")) {
-           Map<String, Object> vd11IssuerMetadata = convertLatestToVd11(issuerMetadata.get("latest"));
+           LinkedHashMap<String, Object> originalIssuerMetadata = new LinkedHashMap<>(issuerMetadata.get("latest"));
+           Map<String, Object> vd11IssuerMetadata = convertLatestToVd11(originalIssuerMetadata);
+           issuerMetadata.put("vd11", (LinkedHashMap<String, Object>) vd11IssuerMetadata);
            return vd11IssuerMetadata;
        }
        throw new InvalidRequestException(ErrorConstants.UNSUPPORTED_OPENID_VERSION);

--- a/certify-service/src/main/java/io/mosip/certify/services/VCIssuanceServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/VCIssuanceServiceImpl.java
@@ -117,10 +117,14 @@ public class VCIssuanceServiceImpl implements VCIssuanceService {
         if(issuerMetadata.containsKey(version)) {
             return issuerMetadata.get(version);
         } else if(version != null && version.equals("vd12")) {
-            Map<String, Object> vd12IssuerMetadata = convertLatestToVd12(issuerMetadata.get(version));
+            LinkedHashMap<String, Object> originalIssuerMetadata = new LinkedHashMap<>(issuerMetadata.get("latest"));
+            Map<String, Object> vd12IssuerMetadata = convertLatestToVd12(originalIssuerMetadata);
+            issuerMetadata.put("vd12", (LinkedHashMap<String, Object>) vd12IssuerMetadata);
             return vd12IssuerMetadata;
         } else if(version != null && version.equals("vd11")) {
-            Map<String, Object> vd11IssuerMetadata = convertLatestToVd11(issuerMetadata.get(version));
+            LinkedHashMap<String, Object> originalIssuerMetadata = new LinkedHashMap<>(issuerMetadata.get("latest"));
+            Map<String, Object> vd11IssuerMetadata = convertLatestToVd11(originalIssuerMetadata);
+            issuerMetadata.put("vd11", (LinkedHashMap<String, Object>) vd11IssuerMetadata);
             return vd11IssuerMetadata;
         }
         throw new InvalidRequestException(ErrorConstants.UNSUPPORTED_OPENID_VERSION);


### PR DESCRIPTION
To restrict original metadata to be changed on conversion of latest to vd11 and vd12