### PR TITLE
INJICERT-681 - moving the testcases to known issues as these are fixed in next release

### DIFF
--- a/api-test/pom.xml
+++ b/api-test/pom.xml
@@ -58,7 +58,7 @@
 		<dependency>
 			<groupId>io.mosip.testrig.apitest.commons</groupId>
 			<artifactId>apitest-commons</artifactId>
-			<version>1.3.1-SNAPSHOT</version>
+			<version>1.3.1</version>
 		</dependency>
 	</dependencies>
 		

--- a/api-test/src/main/resources/testCaseSkippedList.txt
+++ b/api-test/src/main/resources/testCaseSkippedList.txt
@@ -1,2 +1,11 @@
 ##### JIRA number;testcase 
-#MOSIP-12456------Mimoto_AddIdentity_Binding_smoke_Pos
+#MOSIP-12456------Mimoto_AddIdentity_Binding_smoke_PosINJICERT-681
+INJICERT-681------InjiCertify_GetCredentialForMockIDA_IdpAccessToken_Invalid_Format_Neg
+INJICERT-681------InjiCertify_GetCredentialForMockIDA_IdpAccessToken_MoreThanOne_Format_Neg
+INJICERT-681------InjiCertify_GetCredentialForMockIDA_IdpAccessToken_UnImplementedJWTVCJsonld_Format_Neg
+INJICERT-681------InjiCertify_GetCredentialForMockIDA_IdpAccessToken_UnImplementedJWT_Format_Neg
+INJICERT-681------InjiCertify_GetCredentialSunBirdC_IdpAccessToken_Context_empty_Neg
+INJICERT-681------InjiCertify_GetCredentialSunBirdC_IdpAccessToken_context_Emptyarray_Neg
+INJICERT-681------InjiCertify_GetCredentialSunBirdC_IdpAccessToken_invalid_format_Neg
+INJICERT-681------InjiCertify_GetCredentialSunBirdC_IdpAccessToken_multiple_format_value_Neg
+INJICERT-681------InjiCertify_GetCredentialSunBirdC_IdpAccessToken_unsupported_format_value_Neg


### PR DESCRIPTION
INJICERT-681 - moving the testcases to known issues as these are fixed in next release

MockUse case 

InjiCertify_GetCredentialForMockIDA_IdpAccessToken_Invalid_Format_Neg
InjiCertify_GetCredentialForMockIDA_IdpAccessToken_MoreThanOne_Format_Neg
InjiCertify_GetCredentialForMockIDA_IdpAccessToken_UnImplementedJWTVCJsonld_Format_Neg
InjiCertify_GetCredentialForMockIDA_IdpAccessToken_UnImplementedJWT_Format_Neg

Sunbird Use case

InjiCertify_GetCredentialSunBirdC_IdpAccessToken_Context_empty_Neg
InjiCertify_GetCredentialSunBirdC_IdpAccessToken_context_Emptyarray_Neg
InjiCertify_GetCredentialSunBirdC_IdpAccessToken_invalid_format_Neg
InjiCertify_GetCredentialSunBirdC_IdpAccessToken_multiple_format_value_Neg
InjiCertify_GetCredentialSunBirdC_IdpAccessToken_unsupported_format_value_Neg