### PR TITLE
fix: docker image tags for mimoto and inji-web

### DIFF
--- a/docker-compose/docker-compose-injistack/docker-compose.yaml
+++ b/docker-compose/docker-compose-injistack/docker-compose.yaml
@@ -41,7 +41,7 @@ services:
 
   mimoto-service:
     container_name: 'Mimoto-Service'
-    image: mosipid/mimoto:release-0.15.0
+    image: mosipid/mimoto:0.15.0
     user: root
     ports:
       - '8099:8099'
@@ -60,7 +60,7 @@ services:
 
   inji-web:
     container_name: 'inji-web'
-    image: mosipid/inji-web:release-0.11.0
+    image: mosipid/inji-web:0.11.0
     ports:
       - '3001:3004'
     environment:


### PR DESCRIPTION
closes #221 