### PR TITLE
MOSIP-39719 - Added a log level for the commons classes

### DIFF
--- a/api-test/pom.xml
+++ b/api-test/pom.xml
@@ -58,7 +58,7 @@
 		<dependency>
 			<groupId>io.mosip.testrig.apitest.commons</groupId>
 			<artifactId>apitest-commons</artifactId>
-			<version>1.3.1-SNAPSHOT</version>
+			<version>1.3.2-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 		

--- a/api-test/src/main/java/io/mosip/testrig/apirig/injicertify/testrunner/MosipTestRunner.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/injicertify/testrunner/MosipTestRunner.java
@@ -36,6 +36,7 @@ import io.mosip.testrig.apirig.utils.CertsUtil;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.GlobalMethods;
 import io.mosip.testrig.apirig.utils.JWKKeyUtil;
+import io.mosip.testrig.apirig.utils.KernelAuthentication;
 import io.mosip.testrig.apirig.utils.KeyCloakUserAndAPIKeyGeneration;
 import io.mosip.testrig.apirig.utils.KeycloakUserManager;
 import io.mosip.testrig.apirig.utils.MispPartnerAndLicenseKeyGeneration;
@@ -65,12 +66,7 @@ public class MosipTestRunner {
 	public static void main(String[] arg) {
 
 		try {
-
-			Map<String, String> envMap = System.getenv();
-			LOGGER.info("** ------------- Get ALL ENV varibales --------------------------------------------- **");
-			for (String envName : envMap.keySet()) {
-				LOGGER.info(String.format("ENV %s = %s%n", envName, envMap.get(envName)));
-			}
+			LOGGER.info("** ------------- API Test Rig Run Started --------------------------------------------- **");
 			
 			BaseTestCase.setRunContext(getRunType(), jarUrl);
 			ExtractResource.removeOldMosipTestTestResource();
@@ -158,6 +154,9 @@ public class MosipTestRunner {
 		MispPartnerAndLicenseKeyGeneration.setLogLevel();
 		JWKKeyUtil.setLogLevel();
 		CertsUtil.setLogLevel();
+		KernelAuthentication.setLogLevel();
+		BaseTestCase.setLogLevel();
+		InjiCertifyUtil.setLogLevel();
 	}
 
 	/**

--- a/api-test/src/main/java/io/mosip/testrig/apirig/injicertify/utils/InjiCertifyConfigManager.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/injicertify/utils/InjiCertifyConfigManager.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 
 import io.mosip.testrig.apirig.injicertify.testrunner.MosipTestRunner;
@@ -13,6 +14,9 @@ public class InjiCertifyConfigManager extends ConfigManager{
 	private static final Logger LOGGER = Logger.getLogger(InjiCertifyConfigManager.class);
 
 	public static void init() {
+		Logger configManagerLogger = Logger.getLogger(ConfigManager.class);
+		configManagerLogger.setLevel(Level.WARN);
+		
 		Map<String, Object> moduleSpecificPropertiesMap = new HashMap<>();
 		// Load scope specific properties
 		try {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/injicertify/utils/InjiCertifyUtil.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/injicertify/utils/InjiCertifyUtil.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 
 import javax.ws.rs.core.MediaType;
 
+import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -41,6 +42,13 @@ public class InjiCertifyUtil extends AdminTestUtil {
 
 	private static final Logger logger = Logger.getLogger(InjiCertifyUtil.class);
 	public static String currentUseCase = "";
+	
+	public static void setLogLevel() {
+		if (InjiCertifyConfigManager.IsDebugEnabled())
+			logger.setLevel(Level.ALL);
+		else
+			logger.setLevel(Level.ERROR);
+	}
 
 	public static String smtpOtpHandler(String inputJson, TestCaseDTO testCaseDTO) {
 		JSONObject request = new JSONObject(inputJson);
@@ -421,9 +429,6 @@ public class InjiCertifyUtil extends AdminTestUtil {
 	
 	public static String signJWKKeyForMock(String clientId, RSAKey jwkKey) {
 		String tempUrl = getValueFromEsignetWellKnownEndPoint("token_endpoint", InjiCertifyConfigManager.getEsignetBaseUrl());
-		if (tempUrl.contains("esignet.")) {
-			tempUrl = tempUrl.replace("esignet.", InjiCertifyConfigManager.getproperty("esignetMockBaseURL"));
-		}
 		int idTokenExpirySecs = Integer
 				.parseInt(getValueFromEsignetActuator(InjiCertifyConfigManager.getEsignetActuatorPropertySection(),
 						GlobalConstants.MOSIP_ESIGNET_ID_TOKEN_EXPIRE_SECONDS));

--- a/api-test/src/main/resources/config/injiCertify.properties
+++ b/api-test/src/main/resources/config/injiCertify.properties
@@ -16,4 +16,5 @@ injiCertifyWellKnownEndPoint=/v1/certify/issuance/.well-known/openid-credential-
 sunBirdBaseURL=https://registry.released.mosip.net
 # allowed useCaseToExecute values are sunbird,mosipid,mock.
 useCaseToExecute=sunbird,mosipid,mock
-#moduleNamePattern=(mimoto|certify|signup|partnermanager|preregistration|resident|residentmobileapp|masterdata|esignet|idgenerator|policymanager|idauthentication|idrepository|auditmanager|authmanager|keymanager|mock-identity-system)
+#example of the value will be --> moduleNamePattern=(mimoto|certify|signup|partnermanager|preregistration|resident|residentmobileapp|masterdata|esignet|idgenerator|policymanager|idauthentication|idrepository|auditmanager|authmanager|keymanager|mock-identity-system)
+moduleNamePattern=

--- a/api-test/src/main/resources/config/injiCertify.properties
+++ b/api-test/src/main/resources/config/injiCertify.properties
@@ -16,5 +16,3 @@ injiCertifyWellKnownEndPoint=/v1/certify/issuance/.well-known/openid-credential-
 sunBirdBaseURL=https://registry.released.mosip.net
 # allowed useCaseToExecute values are sunbird,mosipid,mock.
 useCaseToExecute=sunbird,mosipid,mock
-#example of the value will be --> moduleNamePattern=(mimoto|certify|signup|partnermanager|preregistration|resident|residentmobileapp|masterdata|esignet|idgenerator|policymanager|idauthentication|idrepository|auditmanager|authmanager|keymanager|mock-identity-system)
-moduleNamePattern=


### PR DESCRIPTION
The setLogLevel method was added to the commons classes to prevent sensitive information, like secrets, from being printed in the console logs.