### PR TITLE
MOSIP-40516 - Fix the automation failures while running only the smoke test

### DIFF
--- a/api-test/src/main/java/io/mosip/testrig/apirig/injicertify/testscripts/PostWithAutogenIdWithOtpGenerate.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/injicertify/testscripts/PostWithAutogenIdWithOtpGenerate.java
@@ -243,17 +243,5 @@ public class PostWithAutogenIdWithOtpGenerate extends InjiCertifyUtil implements
 	}
 
 	@AfterClass(alwaysRun = true)
-	public void waittime() {
-		try {
-			if (!testCaseName.contains(GlobalConstants.ESIGNET_)) {
-				long delayTime = Long.parseLong(properties.getProperty("Delaytime"));
-				logger.info("waiting for " + delayTime + " mili secs after VID Generation In RESIDENT SERVICES");
-				Thread.sleep(delayTime);
-			}
-		} catch (Exception e) {
-			logger.error("Exception : " + e.getMessage());
-			Thread.currentThread().interrupt();
-		}
-
-	}
+	public void waittime() {}
 }

--- a/api-test/src/main/resources/config/injiCertify.properties
+++ b/api-test/src/main/resources/config/injiCertify.properties
@@ -3,16 +3,13 @@ actuatorEndpoint=/resident/v1/actuator/env
 actuatorAdminEndpoint=/v1/admin/actuator/env
 actuatorMasterDataEndpoint=/v1/masterdata/actuator/env
 actuatorIDAEndpoint=/idauthentication/v1/actuator/env
-#actuatorRegprocEndpoint=/registrationprocessor/v1/registrationtransaction/actuator/env
 actuatorEsignetEndpoint=/v1/esignet/actuator/env
 tokenEndpoint=/v1/esignet/oauth/token
-#auditActuatorEndpoint=/v1/auditmanager/actuator/info
-#validateBindingEndpoint=ida-binding
 esignetWellKnownEndPoint=/v1/esignet/oidc/.well-known/openid-configuration
 signupSettingsEndPoint=/v1/signup/settings
 actuatorMimotoEndpoint=/residentmobileapp/actuator/env
-esignetActuatorPropertySection=esignet-default.properties
+esignetActuatorPropertySection=esignet-mosipid.properties
 injiCertifyWellKnownEndPoint=/v1/certify/issuance/.well-known/openid-credential-issuer
 sunBirdBaseURL=https://registry.released.mosip.net
-# allowed useCaseToExecute values are sunbird,mosipid,mock.
-useCaseToExecute=sunbird,mosipid,mock
+# allowed useCaseToExecute values are (sunbird/mosipid/mock)
+useCaseToExecute=mosipid

--- a/api-test/src/main/resources/injicertify/SunBirdCNegative/AuthenticateUserSunBirdCNeg/AuthenticateUserSunBirdCNeg.yml
+++ b/api-test/src/main/resources/injicertify/SunBirdCNegative/AuthenticateUserSunBirdCNeg/AuthenticateUserSunBirdCNeg.yml
@@ -1,5 +1,5 @@
 AuthenticateUserSunBirdCNeg:
-   InjiCertify_ESignet_AuthenticateUserSunBirdC_Valid_Smoke_Neg:
+   InjiCertify_ESignet_AuthenticateUserSunBirdC_Valid_Neg:
       endPoint: $ESIGNETMOCKBASEURL$/v1/esignet/authorization/authenticate
       uniqueIdentifier: TC_esignetDependent_AuthenticateUserNeg      
       description: Authenticate User      
@@ -10,9 +10,9 @@ AuthenticateUserSunBirdCNeg:
       inputTemplate: injicertify/SunBirdCNegative/AuthenticateUserSunBirdCNeg/AuthenticateUserSunBirdCNeg
       outputTemplate: injicertify/SunBirdCNegative/AuthenticateUserSunBirdCNeg/AuthenticateUserSunBirdCResultNeg
       input: '{
-        "encodedHash": "$ID:ESignet_OAuthDetailsRequest_SunBirdC_all_Valid_Smoke_sid_Neg_encodedResp$",
+        "encodedHash": "$ID:ESignet_OAuthDetailsRequest_SunBirdC_all_Valid_sid_Neg_encodedResp$",
       	"requestTime": "$TIMESTAMP$",
-      	"transactionId": "$ID:ESignet_OAuthDetailsRequest_SunBirdC_all_Valid_Smoke_sid_Neg_transactionId$",
+      	"transactionId": "$ID:ESignet_OAuthDetailsRequest_SunBirdC_all_Valid_sid_Neg_transactionId$",
       	"individualId": "$POLICYNUMBERFORSUNBIRDRC$",
       	"authFactorType" : "KBA",
       	"challenge" : "$CHALLENGEVALUEFORSUNBIRDC$",

--- a/api-test/src/main/resources/injicertify/SunBirdCNegative/AuthorizationCodeSunBirdCNeg/AuthorizationCodeSunBirdCNeg.yml
+++ b/api-test/src/main/resources/injicertify/SunBirdCNegative/AuthorizationCodeSunBirdCNeg/AuthorizationCodeSunBirdCNeg.yml
@@ -1,5 +1,5 @@
 AuthorizationCodeSunBirdCNeg:
-   InjiCertify_ESignet_AuthorizationCode_SunBirdC_All_Valid_Smoke_sid_Neg:
+   InjiCertify_ESignet_AuthorizationCode_SunBirdC_All_Valid_sid_Neg:
       endPoint: $ESIGNETMOCKBASEURL$/v1/esignet/authorization/auth-code
       uniqueIdentifier: TC_esignetDependent_AuthorizationCodeNeg      
       description: Authorization Code      
@@ -10,9 +10,9 @@ AuthorizationCodeSunBirdCNeg:
       inputTemplate: injicertify/SunBirdCNegative/AuthorizationCodeSunBirdCNeg/AuthorizationCodeSunBirdCNeg
       outputTemplate: injicertify/SunBirdCNegative/AuthorizationCodeSunBirdCNeg/AuthorizationCodeSunBirdCResultNeg
       input: '{
-        "encodedHash": "$ID:ESignet_OAuthDetailsRequest_SunBirdC_all_Valid_Smoke_sid_Neg_encodedResp$",
+        "encodedHash": "$ID:ESignet_OAuthDetailsRequest_SunBirdC_all_Valid_sid_Neg_encodedResp$",
       	"requestTime": "$TIMESTAMP$",
-      	"transactionId": "$ID:ESignet_OAuthDetailsRequest_SunBirdC_all_Valid_Smoke_sid_Neg_transactionId$",
+      	"transactionId": "$ID:ESignet_OAuthDetailsRequest_SunBirdC_all_Valid_sid_Neg_transactionId$",
       	"permittedAuthorizeScopes": [{scope: "sunbird_rc_insurance_vc_ldp"}]
 }'
       output: '{

--- a/api-test/src/main/resources/injicertify/SunBirdCNegative/GenerateTokenSunBirdCNeg/GenerateTokenSunBirdCNeg.yml
+++ b/api-test/src/main/resources/injicertify/SunBirdCNegative/GenerateTokenSunBirdCNeg/GenerateTokenSunBirdCNeg.yml
@@ -1,5 +1,5 @@
 GenerateTokenSunBirdCNeg:
-   InjiCertify_ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg:
+   InjiCertify_ESignet_GenerateTokenSunBirdC_Valid_sid_Neg:
       endPoint: $ESIGNETMOCKBASEURL$/v1/esignet/oauth/v2/token
       uniqueIdentifier: TC_esignetDependent_GenerateTokenNeg      
       description: Generate Token      
@@ -10,7 +10,7 @@ GenerateTokenSunBirdCNeg:
       outputTemplate: injicertify/SunBirdCNegative/GenerateTokenSunBirdCNeg/GenerateTokenSunBirdCResultNeg
       input: '{
 		  "grant_type": "authorization_code",
-		  "code": "$ID:ESignet_AuthorizationCode_SunBirdC_All_Valid_Smoke_sid_Neg_code$",
+		  "code": "$ID:ESignet_AuthorizationCode_SunBirdC_All_Valid_sid_Neg_code$",
 		  "client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
 		  "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
 		  "client_assertion": "$CLIENT_ASSERTION_USER4_JWK$",

--- a/api-test/src/main/resources/injicertify/SunBirdCNegative/GetCredentialSunBirdCNeg/GetCredentialSunBirdCNeg.yml
+++ b/api-test/src/main/resources/injicertify/SunBirdCNegative/GetCredentialSunBirdCNeg/GetCredentialSunBirdCNeg.yml
@@ -11,7 +11,7 @@ GetCredentialSunBirdCNeg:
       outputTemplate: injicertify/error2
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
         "format": "abcdef",
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
@@ -33,7 +33,7 @@ GetCredentialSunBirdCNeg:
       outputTemplate: injicertify/error2
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
       	"proof_type": "jwt",
@@ -54,7 +54,7 @@ GetCredentialSunBirdCNeg:
       outputTemplate: injicertify/error2
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
         "format": "jwt_vc_json",
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
@@ -76,7 +76,7 @@ GetCredentialSunBirdCNeg:
       outputTemplate: injicertify/error2
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
         "format": "ldp_vc, jwt_vc_json-ld",
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
@@ -98,7 +98,7 @@ GetCredentialSunBirdCNeg:
       outputTemplate: injicertify/error2
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
         "format": "ldp_vc",
       	"type": [{types: "VerifiableCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
@@ -120,7 +120,7 @@ GetCredentialSunBirdCNeg:
       outputTemplate: injicertify/error2
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
         "format": "ldp_vc",
       	"type": [{types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
@@ -142,7 +142,7 @@ GetCredentialSunBirdCNeg:
       outputTemplate: injicertify/error2
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
         "format": "ldp_vc",
       	"type": [{types: "abcdefghij"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
@@ -164,7 +164,7 @@ GetCredentialSunBirdCNeg:
       outputTemplate: injicertify/error2
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
         "format": "ldp_vc",
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
@@ -186,7 +186,7 @@ GetCredentialSunBirdCNeg:
       outputTemplate: injicertify/error2
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
         "format": "ldp_vc",
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
@@ -208,7 +208,7 @@ GetCredentialSunBirdCNeg:
       outputTemplate: injicertify/error2
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
         "format": "ldp_vc",
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
@@ -230,7 +230,7 @@ GetCredentialSunBirdCNeg:
       outputTemplate: injicertify/error2
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
         "format": "ldp_vc",
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
@@ -252,7 +252,7 @@ GetCredentialSunBirdCNeg:
       outputTemplate: injicertify/error2
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
         "format": "ldp_vc",
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
@@ -274,7 +274,7 @@ GetCredentialSunBirdCNeg:
       outputTemplate: injicertify/error2
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
         "format": "",
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
@@ -296,7 +296,7 @@ GetCredentialSunBirdCNeg:
       outputTemplate: injicertify/error2
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
         "format": "ldp_vc",
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
@@ -317,7 +317,7 @@ GetCredentialSunBirdCNeg:
       outputTemplate: injicertify/error2
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
         "format": "ldp_vc",
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
@@ -339,7 +339,7 @@ GetCredentialSunBirdCNeg:
       outputTemplate: injicertify/error2
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
         "format": "ldp_vc",
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
@@ -361,7 +361,7 @@ GetCredentialSunBirdCNeg:
       outputTemplate: injicertify/error2
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
         "format": "ldp_vc",
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
@@ -383,7 +383,7 @@ GetCredentialSunBirdCNeg:
       outputTemplate: injicertify/error2
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
         "format": "ldp_vc",
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
@@ -405,7 +405,7 @@ GetCredentialSunBirdCNeg:
       outputTemplate: injicertify/error2
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
         "format": "ldp_vc",
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
@@ -427,7 +427,7 @@ GetCredentialSunBirdCNeg:
       outputTemplate: injicertify/error2
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
         "format": "ldp_vc",
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
@@ -449,7 +449,7 @@ GetCredentialSunBirdCNeg:
       outputTemplate: injicertify/error2
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
         "format": "ldp_vc",
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
@@ -471,7 +471,7 @@ GetCredentialSunBirdCNeg:
       outputTemplate: injicertify/error2
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
         "format": "ldp_vc",
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
@@ -493,7 +493,7 @@ GetCredentialSunBirdCNeg:
       outputTemplate: injicertify/error2
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
         "format": "ldp_vc",
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
@@ -515,7 +515,7 @@ GetCredentialSunBirdCNeg:
       outputTemplate: injicertify/error2
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
         "format": "ldp_vc",
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
@@ -537,7 +537,7 @@ GetCredentialSunBirdCNeg:
       outputTemplate: injicertify/error2
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
         "format": "ldp_vc",
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
@@ -559,7 +559,7 @@ GetCredentialSunBirdCNeg:
       outputTemplate: injicertify/error2
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
         "format": "ldp_vc",
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
@@ -581,7 +581,7 @@ GetCredentialSunBirdCNeg:
       outputTemplate: injicertify/error2
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
         "format": "ldp_vc",
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
@@ -603,7 +603,7 @@ GetCredentialSunBirdCNeg:
       outputTemplate: injicertify/error2
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
         "format": "ldp_vc",
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
@@ -625,7 +625,7 @@ GetCredentialSunBirdCNeg:
       outputTemplate: injicertify/error2
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
         "format": "ldp_vc",
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
@@ -647,7 +647,7 @@ GetCredentialSunBirdCNeg:
       outputTemplate: injicertify/error2
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
         "format": "ldp_vc",
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"},{types: "abcdef"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
@@ -669,7 +669,7 @@ GetCredentialSunBirdCNeg:
       outputTemplate: injicertify/error2
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
         "format": "ldp_vc",
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": "",
@@ -691,7 +691,7 @@ GetCredentialSunBirdCNeg:
       outputTemplate: injicertify/error2
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
         "format": "ldp_vc",
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"proof_type": "jwt",
@@ -712,7 +712,7 @@ GetCredentialSunBirdCNeg:
       outputTemplate: injicertify/error2
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
         "format": "ldp_vc",
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [],
@@ -734,7 +734,7 @@ GetCredentialSunBirdCNeg:
       outputTemplate: injicertify/error2
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_Neg_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
         "format": "ldp_vc",
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "dfshgshssg"}],

--- a/api-test/src/main/resources/injicertify/SunBirdCNegative/OAuthDetailsRequestSunBirdCNeg/OAuthDetailsRequestSunBirdCNeg.yml
+++ b/api-test/src/main/resources/injicertify/SunBirdCNegative/OAuthDetailsRequestSunBirdCNeg/OAuthDetailsRequestSunBirdCNeg.yml
@@ -1,5 +1,5 @@
 OAuthDetailsRequestSunBirdCNeg:
-   InjiCertify_ESignet_OAuthDetailsRequest_SunBirdC_all_Valid_Smoke_sid_Neg:
+   InjiCertify_ESignet_OAuthDetailsRequest_SunBirdC_all_Valid_sid_Neg:
       endPoint: $ESIGNETMOCKBASEURL$/v1/esignet/authorization/v2/oauth-details
       uniqueIdentifier: TC_esignetDependent_OAuthdetailsRequestNeg
       description: OAuth details request

--- a/api-test/src/main/resources/injicertify/VCIMockIDANegTC/AuthenticateUserForMockIDANegTC/AuthenticateUserForMockIDANegTC.yml
+++ b/api-test/src/main/resources/injicertify/VCIMockIDANegTC/AuthenticateUserForMockIDANegTC/AuthenticateUserForMockIDANegTC.yml
@@ -1,5 +1,5 @@
 AuthenticateUserForMockIDANegTC:
-   InjiCertify_ESignet_AuthenticateUserVCI_ForMockIDA_uin_Otp_Valid_Smoke_For_Neg_Flow:
+   InjiCertify_ESignet_AuthenticateUserVCI_ForMockIDA_uin_Otp_Valid_For_Neg_Flow:
       endPoint: $ESIGNETMOCKIDABASEURL$/v1/esignet/authorization/authenticate
       role: resident
       restMethod: post
@@ -8,17 +8,17 @@ AuthenticateUserForMockIDANegTC:
       inputTemplate: injicertify/VCIMockIDANegTC/AuthenticateUserForMockIDANegTC/AuthenticateUserForMockIDANegTC
       outputTemplate: injicertify/VCIMockIDANegTC/AuthenticateUserForMockIDANegTC/AuthenticateUserForMockIDANegTCResult
       input: '{
-        "encodedHash": "$ID:ESignet_OAuthDetailsRequest_ForMockIDA_uin_all_Valid_Smoke_sid_For_Neg_Flow_encodedResp$",
+        "encodedHash": "$ID:ESignet_OAuthDetailsRequest_ForMockIDA_uin_all_Valid_sid_For_Neg_Flow_encodedResp$",
         "requestTime": "$TIMESTAMP$",
-        "transactionId": "$ID:ESignet_OAuthDetailsRequest_ForMockIDA_uin_all_Valid_Smoke_sid_For_Neg_Flow_transactionId$",
+        "transactionId": "$ID:ESignet_OAuthDetailsRequest_ForMockIDA_uin_all_Valid_sid_For_Neg_Flow_transactionId$",
         "individualId": "$ID:AddIdentity_For_Mock_Valid_smoke_Pos_UIN$",
         "authFactorType" : "OTP",
         "challenge" : "111111",
         "format": "alpha-numeric",
         "sendOtp":{
-            "encodedHash": "$ID:ESignet_OAuthDetailsRequest_ForMockIDA_uin_all_Valid_Smoke_sid_For_Neg_Flow_encodedResp$",
+            "encodedHash": "$ID:ESignet_OAuthDetailsRequest_ForMockIDA_uin_all_Valid_sid_For_Neg_Flow_encodedResp$",
             "requestTime": "$TIMESTAMP$",
-            "transactionId": "$ID:ESignet_OAuthDetailsRequest_ForMockIDA_uin_all_Valid_Smoke_sid_For_Neg_Flow_transactionId$",
+            "transactionId": "$ID:ESignet_OAuthDetailsRequest_ForMockIDA_uin_all_Valid_sid_For_Neg_Flow_transactionId$",
             "individualId": "$ID:AddIdentity_For_Mock_Valid_smoke_Pos_UIN$",
             "otpChannels": [{channel: "email"},{channel: "phone"}],
             "sendOtpReqTemplate": "injicertify/SendOtp/SendOtp",

--- a/api-test/src/main/resources/injicertify/VCIMockIDANegTC/AuthorizationCodeForMockIDANegTC/AuthorizationCodeForMockIDANegTC.yml
+++ b/api-test/src/main/resources/injicertify/VCIMockIDANegTC/AuthorizationCodeForMockIDANegTC/AuthorizationCodeForMockIDANegTC.yml
@@ -1,5 +1,5 @@
 AuthorizationCodeForMockIDANegTC:
-   InjiCertify_ESignet_AuthorizationCode_ForMockIDA_All_Valid_Smoke_sid_For_Neg_Flow:
+   InjiCertify_ESignet_AuthorizationCode_ForMockIDA_All_Valid_sid_For_Neg_Flow:
       endPoint: $ESIGNETMOCKIDABASEURL$/v1/esignet/authorization/auth-code
       role: resident
       restMethod: post
@@ -8,9 +8,9 @@ AuthorizationCodeForMockIDANegTC:
       inputTemplate: injicertify/VCIMockIDANegTC/AuthorizationCodeForMockIDANegTC/AuthorizationCodeForMockIDANegTC
       outputTemplate: injicertify/VCIMockIDANegTC/AuthorizationCodeForMockIDANegTC/AuthorizationCodeForMockIDANegTCResult
       input: '{
-        "encodedHash": "$ID:ESignet_OAuthDetailsRequest_ForMockIDA_uin_all_Valid_Smoke_sid_For_Neg_Flow_encodedResp$",
+        "encodedHash": "$ID:ESignet_OAuthDetailsRequest_ForMockIDA_uin_all_Valid_sid_For_Neg_Flow_encodedResp$",
         "requestTime": "$TIMESTAMP$",
-        "transactionId": "$ID:ESignet_OAuthDetailsRequest_ForMockIDA_uin_all_Valid_Smoke_sid_For_Neg_Flow_transactionId$"
+        "transactionId": "$ID:ESignet_OAuthDetailsRequest_ForMockIDA_uin_all_Valid_sid_For_Neg_Flow_transactionId$"
 }'
       output: '{
 }'

--- a/api-test/src/main/resources/injicertify/VCIMockIDANegTC/GenerateTokenForMockIDANegTC/GenerateTokenForMockIDANegTC.yml
+++ b/api-test/src/main/resources/injicertify/VCIMockIDANegTC/GenerateTokenForMockIDANegTC/GenerateTokenForMockIDANegTC.yml
@@ -1,5 +1,5 @@
 GenerateTokenForMockIDANegTC:
-   InjiCertify_ESignet_GenerateToken_ForMockIDA_Valid_Smoke_sid_For_Neg_Flow:
+   InjiCertify_ESignet_GenerateToken_ForMockIDA_Valid_sid_For_Neg_Flow:
       endPoint: $ESIGNETMOCKIDABASEURL$/v1/esignet/oauth/v2/token
       role: resident
       restMethod: post
@@ -8,7 +8,7 @@ GenerateTokenForMockIDANegTC:
       outputTemplate: injicertify/VCIMockIDANegTC/GenerateTokenForMockIDANegTC/GenerateTokenForMockIDANegTCResult
       input: '{
           "grant_type": "authorization_code",
-          "code": "$ID:ESignet_AuthorizationCode_ForMockIDA_All_Valid_Smoke_sid_For_Neg_Flow_code$",
+          "code": "$ID:ESignet_AuthorizationCode_ForMockIDA_All_Valid_sid_For_Neg_Flow_code$",
           "client_id": "$ID:ESignet_CreateOIDCClientV2_ForMockIDA_all_Valid_Smoke_sid_clientId$",
           "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
           "client_assertion": "$CLIENT_ASSERTION_USER4_JWT$",

--- a/api-test/src/main/resources/injicertify/VCIMockIDANegTC/GetCredentialForMockIDANegTC/GetCredentialForMockIDANegTC.yml
+++ b/api-test/src/main/resources/injicertify/VCIMockIDANegTC/GetCredentialForMockIDANegTC/GetCredentialForMockIDANegTC.yml
@@ -11,7 +11,7 @@ GetCredentialForMockIDANegTC:
       outputTemplate: injicertify/error2
       input: '{
         "client_id": "$ID:ESignet_CreateOIDCClientV2_ForMockIDA_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_Smoke_sid_For_Neg_Flow_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_sid_For_Neg_Flow_access_token$",
         "format": "invalid",
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
@@ -34,7 +34,7 @@ GetCredentialForMockIDANegTC:
       outputTemplate: injicertify/error2
       input: '{
         "client_id": "$ID:ESignet_CreateOIDCClientV2_ForMockIDA_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_Smoke_sid_For_Neg_Flow_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_sid_For_Neg_Flow_access_token$",
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
         "proof_type": "jwt",
@@ -56,7 +56,7 @@ GetCredentialForMockIDANegTC:
       outputTemplate: injicertify/error2
       input: '{
         "client_id": "$ID:ESignet_CreateOIDCClientV2_ForMockIDA_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_Smoke_sid_For_Neg_Flow_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_sid_For_Neg_Flow_access_token$",
         "format": "",
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
@@ -79,7 +79,7 @@ GetCredentialForMockIDANegTC:
       outputTemplate: injicertify/error2
       input: '{
         "client_id": "$ID:ESignet_CreateOIDCClientV2_ForMockIDA_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_Smoke_sid_For_Neg_Flow_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_sid_For_Neg_Flow_access_token$",
         "format": " ",
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
@@ -102,7 +102,7 @@ GetCredentialForMockIDANegTC:
       outputTemplate: injicertify/error2
       input: '{
         "client_id": "$ID:ESignet_CreateOIDCClientV2_ForMockIDA_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_Smoke_sid_For_Neg_Flow_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_sid_For_Neg_Flow_access_token$",
         "format": "jwt_vc_json",
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
@@ -125,7 +125,7 @@ GetCredentialForMockIDANegTC:
       outputTemplate: injicertify/error2
       input: '{
         "client_id": "$ID:ESignet_CreateOIDCClientV2_ForMockIDA_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_Smoke_sid_For_Neg_Flow_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_sid_For_Neg_Flow_access_token$",
         "format": "jwt_vc_json-ld",
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
@@ -149,7 +149,7 @@ GetCredentialForMockIDANegTC:
       outputTemplate: injicertify/error2
       input: '{
         "client_id": "$ID:ESignet_CreateOIDCClientV2_ForMockIDA_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_Smoke_sid_For_Neg_Flow_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_sid_For_Neg_Flow_access_token$",
         "format": "jwt_vc_json-ld,jwt_vc_json-ld",
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
@@ -172,7 +172,7 @@ GetCredentialForMockIDANegTC:
       outputTemplate: injicertify/error2
       input: '{
         "client_id": "$ID:ESignet_CreateOIDCClientV2_ForMockIDA_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_Smoke_sid_For_Neg_Flow_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_sid_For_Neg_Flow_access_token$",
         "format": "ldp_vc",
         "type": [],
         "@context": [{context: "$VCICONTEXTURL$"}],
@@ -196,7 +196,7 @@ GetCredentialForMockIDANegTC:
       outputTemplate: injicertify/error2
       input: '{
         "client_id": "$ID:ESignet_CreateOIDCClientV2_ForMockIDA_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_Smoke_sid_For_Neg_Flow_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_sid_For_Neg_Flow_access_token$",
         "format": "ldp_vc",
         "type": [{types: "VerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
@@ -220,7 +220,7 @@ GetCredentialForMockIDANegTC:
       outputTemplate: injicertify/error2
       input: '{
         "client_id": "$ID:ESignet_CreateOIDCClientV2_ForMockIDA_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_Smoke_sid_For_Neg_Flow_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_sid_For_Neg_Flow_access_token$",
         "format": "ldp_vc",
         "type": [{types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
@@ -243,7 +243,7 @@ GetCredentialForMockIDANegTC:
       outputTemplate: injicertify/error2
       input: '{
         "client_id": "$ID:ESignet_CreateOIDCClientV2_ForMockIDA_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_Smoke_sid_For_Neg_Flow_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_sid_For_Neg_Flow_access_token$",
         "format": "ldp_vc",
         "type": [{types: "randomvalue"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
@@ -267,7 +267,7 @@ GetCredentialForMockIDANegTC:
       outputTemplate: injicertify/error2
       input: '{
         "client_id": "$ID:ESignet_CreateOIDCClientV2_ForMockIDA_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_Smoke_sid_For_Neg_Flow_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_sid_For_Neg_Flow_access_token$",
         "format": "ldp_vc",
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}]
@@ -289,7 +289,7 @@ GetCredentialForMockIDANegTC:
       outputTemplate: injicertify/error2
       input: '{
         "client_id": "$ID:ESignet_CreateOIDCClientV2_ForMockIDA_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_Smoke_sid_For_Neg_Flow_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_sid_For_Neg_Flow_access_token$",
         "format": "ldp_vc",
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
@@ -313,7 +313,7 @@ GetCredentialForMockIDANegTC:
       outputTemplate: injicertify/error2
       input: '{
         "client_id": "$ID:ESignet_CreateOIDCClientV2_ForMockIDA_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_Smoke_sid_For_Neg_Flow_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_sid_For_Neg_Flow_access_token$",
         "format": "ldp_vc",
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
@@ -336,7 +336,7 @@ GetCredentialForMockIDANegTC:
       outputTemplate: injicertify/error2
       input: '{
         "client_id": "$ID:ESignet_CreateOIDCClientV2_ForMockIDA_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_Smoke_sid_For_Neg_Flow_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_sid_For_Neg_Flow_access_token$",
         "format": "ldp_vc",
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
@@ -360,7 +360,7 @@ GetCredentialForMockIDANegTC:
       outputTemplate: injicertify/error2
       input: '{
         "client_id": "$ID:ESignet_CreateOIDCClientV2_ForMockIDA_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_Smoke_sid_For_Neg_Flow_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_sid_For_Neg_Flow_access_token$",
         "format": "ldp_vc",
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
@@ -383,7 +383,7 @@ GetCredentialForMockIDANegTC:
       outputTemplate: injicertify/error2
       input: '{
         "client_id": "$ID:ESignet_CreateOIDCClientV2_ForMockIDA_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_Smoke_sid_For_Neg_Flow_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_sid_For_Neg_Flow_access_token$",
         "format": "ldp_vc",
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
@@ -405,7 +405,7 @@ GetCredentialForMockIDANegTC:
       outputTemplate: injicertify/error2
       input: '{
         "client_id": "$ID:ESignet_CreateOIDCClientV2_ForMockIDA_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_Smoke_sid_For_Neg_Flow_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_sid_For_Neg_Flow_access_token$",
         "format": "ldp_vc",
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
@@ -428,7 +428,7 @@ GetCredentialForMockIDANegTC:
       outputTemplate: injicertify/error2
       input: '{
         "client_id": "$ID:ESignet_CreateOIDCClientV2_ForMockIDA_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_Smoke_sid_For_Neg_Flow_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_sid_For_Neg_Flow_access_token$",
         "format": "ldp_vc",
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
@@ -451,7 +451,7 @@ GetCredentialForMockIDANegTC:
       outputTemplate: injicertify/error2
       input: '{
         "client_id": "$ID:ESignet_CreateOIDCClientV2_ForMockIDA_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_Smoke_sid_For_Neg_Flow_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_sid_For_Neg_Flow_access_token$",
         "format": "ldp_vc",
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
@@ -474,7 +474,7 @@ GetCredentialForMockIDANegTC:
       outputTemplate: injicertify/error2
       input: '{
         "client_id": "$ID:ESignet_CreateOIDCClientV2_ForMockIDA_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_Smoke_sid_For_Neg_Flow_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_sid_For_Neg_Flow_access_token$",
         "format": "ldp_vc",
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
@@ -498,7 +498,7 @@ GetCredentialForMockIDANegTC:
       outputTemplate: injicertify/error2
       input: '{
         "client_id": "$ID:ESignet_CreateOIDCClientV2_ForMockIDA_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_Smoke_sid_For_Neg_Flow_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_sid_For_Neg_Flow_access_token$",
         "format": "ldp_vc",
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
@@ -523,7 +523,7 @@ GetCredentialForMockIDANegTC:
       outputTemplate: injicertify/error2
       input: '{
         "client_id": "$ID:ESignet_CreateOIDCClientV2_ForMockIDA_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_Smoke_sid_For_Neg_Flow_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_sid_For_Neg_Flow_access_token$",
         "format": "ldp_vc",
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
@@ -546,7 +546,7 @@ GetCredentialForMockIDANegTC:
       outputTemplate: injicertify/error2
       input: '{
         "client_id": "$ID:ESignet_CreateOIDCClientV2_ForMockIDA_all_Valid_Smoke_sid_clientId$",
-        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_Smoke_sid_For_Neg_Flow_access_token$",
+        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_sid_For_Neg_Flow_access_token$",
         "format": "ldp_vc",
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],

--- a/api-test/src/main/resources/injicertify/VCIMockIDANegTC/OAuthDetailsRequestForMockIDANegTC/OAuthDetailsRequestForMockIDANegTC.yml
+++ b/api-test/src/main/resources/injicertify/VCIMockIDANegTC/OAuthDetailsRequestForMockIDANegTC/OAuthDetailsRequestForMockIDANegTC.yml
@@ -1,5 +1,5 @@
 OAuthDetailsRequestForMockIDANegTC:
-   InjiCertify_ESignet_OAuthDetailsRequest_ForMockIDA_uin_all_Valid_Smoke_sid_For_Neg_Flow:
+   InjiCertify_ESignet_OAuthDetailsRequest_ForMockIDA_uin_all_Valid_sid_For_Neg_Flow:
       endPoint: $ESIGNETMOCKIDABASEURL$/v1/esignet/authorization/v2/oauth-details
       role: resident
       restMethod: post


### PR DESCRIPTION
Mosiptestrunner Class:
- Added a condition for the mosipid use case to generate certificates.
- Cleaned up the use case looping condition as it is no longer used.

PostWithAutogenIdWithOtpGenerate:
- Removed the afterMethod wait time, as it is not required for inji-certify.

YAMLs:
- Removed smoke from test case names, except for positive flows.