### PR TITLE
INJICERT-973 - Added ED25519 testcases for mock and sunbird use case

### DIFF
--- a/api-test/src/main/resources/injicertify/SunBirdC/GetCredentialSunBirdC/GetCredentialSunBirdC.yml
+++ b/api-test/src/main/resources/injicertify/SunBirdC/GetCredentialSunBirdC/GetCredentialSunBirdC.yml
@@ -16,7 +16,33 @@ GetCredentialSunBirdC:
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
       	"proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_2$"
+        "proof_jwt": "$PROOF_JWT_2$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
+}'
+      output: '{
+}'
+
+   InjiCertify_GetCredentialSunBirdC_IdpAccessToken_ED25519_Sign_all_Valid_Smoke:
+      endPoint: $INJICERTIFYINSURANCEBASEURL$/v1/certify/issuance/credential
+      uniqueIdentifier: TC_injicertify_credentialissuance      
+      description: Get sunbird VC with valid details     
+      role: resident
+      checkErrorsOnlyInResponse: true
+      restMethod: post
+      validityCheckRequired: true
+      inputTemplate: injicertify/SunBirdC/GetCredentialSunBirdC/GetCredentialSunBirdC
+      outputTemplate: injicertify/SunBirdC/GetCredentialSunBirdC/GetCredentialSunBirdCResult
+      input: '{
+      	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_Smoke_sid_access_token$",
+        "format": "ldp_vc",
+      	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
+      	"@context": [{context: "$VCICONTEXTURL$"}],
+      	"proof_type": "jwt",
+        "proof_jwt": "$PROOF_JWT_ED25519$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "Ed25519"
 }'
       output: '{
 }'

--- a/api-test/src/main/resources/injicertify/SunBirdCForVd11/GetCredentialSunBirdCForVd11/GetCredentialSunBirdCForVd11.yml
+++ b/api-test/src/main/resources/injicertify/SunBirdCForVd11/GetCredentialSunBirdCForVd11/GetCredentialSunBirdCForVd11.yml
@@ -16,7 +16,33 @@ GetCredentialSunBirdCForVd11:
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
       	"proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_2$"
+        "proof_jwt": "$PROOF_JWT_2$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
+}'
+      output: '{
+}'
+
+   InjiCertify_GetCredentialSunBirdCForVd11_IdpAccessToken_ED25519_Sign_all_Valid_Smoke:
+      endPoint: $INJICERTIFYINSURANCEBASEURL$/v1/certify/issuance/vd11/credential
+      uniqueIdentifier: TC_injicertify_credentialissuance_Vd11     
+      description: Get sunbird VC with valid details      
+      role: resident
+      checkErrorsOnlyInResponse: true
+      restMethod: post
+      validityCheckRequired: true
+      inputTemplate: injicertify/SunBirdCForVd11/GetCredentialSunBirdCForVd11/GetCredentialSunBirdCForVd11
+      outputTemplate: injicertify/SunBirdCForVd11/GetCredentialSunBirdCForVd11/GetCredentialSunBirdCForVd11Result
+      input: '{
+      	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdCForVd11_Valid_Smoke_sid_access_token$",
+        "format": "ldp_vc",
+      	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
+      	"@context": [{context: "$VCICONTEXTURL$"}],
+      	"proof_type": "jwt",
+        "proof_jwt": "$PROOF_JWT_ED25519$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "Ed25519"
 }'
       output: '{
 }'

--- a/api-test/src/main/resources/injicertify/SunBirdCForVd12/GetCredentialSunBirdCForVd12/GetCredentialSunBirdCForVd12.yml
+++ b/api-test/src/main/resources/injicertify/SunBirdCForVd12/GetCredentialSunBirdCForVd12/GetCredentialSunBirdCForVd12.yml
@@ -16,7 +16,33 @@ GetCredentialSunBirdCForVd12:
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
       	"proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_2$"
+        "proof_jwt": "$PROOF_JWT_2$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
+}'
+      output: '{
+}'
+
+   InjiCertify_GetCredentialSunBirdCForVd12_IdpAccessToken_ED25519_Sign_all_Valid_Smoke:
+      endPoint: $INJICERTIFYINSURANCEBASEURL$/v1/certify/issuance/vd12/credential
+      uniqueIdentifier: TC_injicertify_credentialissuance_Vd12      
+      description: Get sunbird VC with valid details      
+      role: resident
+      checkErrorsOnlyInResponse: true
+      restMethod: post
+      validityCheckRequired: true
+      inputTemplate: injicertify/SunBirdCForVd12/GetCredentialSunBirdCForVd12/GetCredentialSunBirdCForVd12
+      outputTemplate: injicertify/SunBirdCForVd12/GetCredentialSunBirdCForVd12/GetCredentialSunBirdCForVd12Result
+      input: '{
+      	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdCForVd12_Valid_Smoke_sid_access_token$",
+        "format": "ldp_vc",
+      	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
+      	"@context": [{context: "$VCICONTEXTURL$"}],
+      	"proof_type": "jwt",
+        "proof_jwt": "$PROOF_JWT_ED25519$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "Ed25519"
 }'
       output: '{
 }'

--- a/api-test/src/main/resources/injicertify/SunBirdCNegative/GetCredentialSunBirdCNeg/GetCredentialSunBirdCNeg.yml
+++ b/api-test/src/main/resources/injicertify/SunBirdCNegative/GetCredentialSunBirdCNeg/GetCredentialSunBirdCNeg.yml
@@ -16,7 +16,9 @@ GetCredentialSunBirdCNeg:
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
       	"proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_2$"
+        "proof_jwt": "$PROOF_JWT_2$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
       "error": "unsupported_credential_format"
@@ -37,7 +39,9 @@ GetCredentialSunBirdCNeg:
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
       	"proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_2$"
+        "proof_jwt": "$PROOF_JWT_2$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
       "error": "invalid_vc_format"
@@ -59,7 +63,9 @@ GetCredentialSunBirdCNeg:
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
       	"proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_2$"
+        "proof_jwt": "$PROOF_JWT_2$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
       "error": "not_implemented"
@@ -81,7 +87,9 @@ GetCredentialSunBirdCNeg:
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
       	"proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_2$"
+        "proof_jwt": "$PROOF_JWT_2$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
       "error": "unsupported_credential_format"
@@ -103,7 +111,9 @@ GetCredentialSunBirdCNeg:
       	"type": [{types: "VerifiableCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
       	"proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_2$"
+        "proof_jwt": "$PROOF_JWT_2$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
       "error": "unsupported_credential_type"
@@ -125,7 +135,9 @@ GetCredentialSunBirdCNeg:
       	"type": [{types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
       	"proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_2$"
+        "proof_jwt": "$PROOF_JWT_2$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
       "error": "unsupported_credential_type"
@@ -147,7 +159,9 @@ GetCredentialSunBirdCNeg:
       	"type": [{types: "abcdefghij"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
       	"proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_2$"
+        "proof_jwt": "$PROOF_JWT_2$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
       "error": "unsupported_credential_type"
@@ -169,7 +183,9 @@ GetCredentialSunBirdCNeg:
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
         "proof_type": "$REMOVE$",
-        "proof_jwt": "$REMOVE$"
+        "proof_jwt": "$REMOVE$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
       "error": "unsupported_proof_type"
@@ -191,7 +207,9 @@ GetCredentialSunBirdCNeg:
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
       	"proof_type": "jwt",
-        "proof_jwt": "$REMOVE$"
+        "proof_jwt": "$REMOVE$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
       "error": "invalid_proof"
@@ -213,7 +231,9 @@ GetCredentialSunBirdCNeg:
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
       	"proof_type": "",
-        "proof_jwt": "$PROOF_JWT_2$"
+        "proof_jwt": "$PROOF_JWT_2$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
       "error": "unsupported_proof_type"
@@ -235,7 +255,9 @@ GetCredentialSunBirdCNeg:
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
       	"proof_type": "   ",
-        "proof_jwt": "$PROOF_JWT_2$"
+        "proof_jwt": "$PROOF_JWT_2$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
       "error": "unsupported_proof_type"
@@ -257,7 +279,9 @@ GetCredentialSunBirdCNeg:
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
         "proof_type": "jwt",
-        "proof_jwt": "asdaffdsa"
+        "proof_jwt": "asdaffdsa",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
       "error": "invalid_proof"
@@ -279,7 +303,9 @@ GetCredentialSunBirdCNeg:
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
       	"proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_2$"
+        "proof_jwt": "$PROOF_JWT_2$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
       "error": "invalid_vc_format"
@@ -300,7 +326,9 @@ GetCredentialSunBirdCNeg:
         "format": "ldp_vc",
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
-        "proof_jwt": "$PROOF_JWT_2$"
+        "proof_jwt": "$PROOF_JWT_2$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
       "error": "unsupported_proof_type"
@@ -322,7 +350,9 @@ GetCredentialSunBirdCNeg:
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
       	"proof_type": "jwt",
-        "proof_jwt": "  "
+        "proof_jwt": "  ",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
       "error": "invalid_proof"
@@ -344,7 +374,9 @@ GetCredentialSunBirdCNeg:
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
       	"proof_type": "jwt",
-        "proof_jwt": "PROOF_cwt"
+        "proof_jwt": "PROOF_cwt",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
       "error": "invalid_proof"
@@ -366,7 +398,9 @@ GetCredentialSunBirdCNeg:
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
       	"proof_type": "jwt123",
-        "proof_jwt": "$PROOF_JWT_2$"
+        "proof_jwt": "$PROOF_JWT_2$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
       "error": "unsupported_proof_type"
@@ -388,7 +422,9 @@ GetCredentialSunBirdCNeg:
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
       	"proof_type": "cwt",
-        "proof_jwt": "$PROOF_JWT_2$"
+        "proof_jwt": "$PROOF_JWT_2$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
       "error": "unsupported_proof_type"
@@ -410,7 +446,9 @@ GetCredentialSunBirdCNeg:
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
       	"proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_2$"
+        "proof_jwt": "$PROOF_JWT_2$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
       "error": "invalid_proof"
@@ -432,7 +470,9 @@ GetCredentialSunBirdCNeg:
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
       	"proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_2$"
+        "proof_jwt": "$PROOF_JWT_2$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
       "error": "invalid_proof"
@@ -454,7 +494,9 @@ GetCredentialSunBirdCNeg:
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
       	"proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_2$"
+        "proof_jwt": "$PROOF_JWT_2$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
       "error": "invalid_proof"
@@ -476,7 +518,9 @@ GetCredentialSunBirdCNeg:
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
       	"proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_2$"
+        "proof_jwt": "$PROOF_JWT_2$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
       "error": "invalid_proof"
@@ -498,7 +542,9 @@ GetCredentialSunBirdCNeg:
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
       	"proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_2$"
+        "proof_jwt": "$PROOF_JWT_2$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
       "error": "invalid_proof"
@@ -520,7 +566,9 @@ GetCredentialSunBirdCNeg:
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
       	"proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_2$"
+        "proof_jwt": "$PROOF_JWT_2$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
       "error": "invalid_proof"
@@ -542,7 +590,9 @@ GetCredentialSunBirdCNeg:
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
       	"proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_2$"
+        "proof_jwt": "$PROOF_JWT_2$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
       "error": "invalid_proof"
@@ -564,7 +614,9 @@ GetCredentialSunBirdCNeg:
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
       	"proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_2$"
+        "proof_jwt": "$PROOF_JWT_2$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
       "error": "invalid_proof"
@@ -586,7 +638,9 @@ GetCredentialSunBirdCNeg:
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
       	"proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_2$"
+        "proof_jwt": "$PROOF_JWT_2$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
       "error": "invalid_proof"
@@ -608,7 +662,9 @@ GetCredentialSunBirdCNeg:
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
       	"proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_2$"
+        "proof_jwt": "$PROOF_JWT_2$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
       "error": "invalid_proof"
@@ -630,7 +686,9 @@ GetCredentialSunBirdCNeg:
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
       	"proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_2$"
+        "proof_jwt": "$PROOF_JWT_2$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
       "error": "invalid_proof"
@@ -652,7 +710,9 @@ GetCredentialSunBirdCNeg:
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"},{types: "abcdef"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
       	"proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_2$"
+        "proof_jwt": "$PROOF_JWT_2$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
       "error": "vci_exchange_failed"
@@ -674,7 +734,9 @@ GetCredentialSunBirdCNeg:
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": "",
       	"proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_2$"
+        "proof_jwt": "$PROOF_JWT_2$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
       "error": "invalid request"
@@ -695,7 +757,9 @@ GetCredentialSunBirdCNeg:
         "format": "ldp_vc",
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_2$"
+        "proof_jwt": "$PROOF_JWT_2$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
       "error": "unknown_error"
@@ -717,7 +781,9 @@ GetCredentialSunBirdCNeg:
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [],
       	"proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_2$"
+        "proof_jwt": "$PROOF_JWT_2$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
 	   "error": "vci_exchange_failed"
@@ -739,8 +805,58 @@ GetCredentialSunBirdCNeg:
       	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
       	"@context": [{context: "dfshgshssg"}],
       	"proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_2$"
+        "proof_jwt": "$PROOF_JWT_2$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
       "error": "vci_exchange_failed"
+}'
+
+   InjiCertify_GetCredentialSunBirdC_IdpAccessToken_ED25519_Sign_Missing_Proof_Jwt_Neg:
+      endPoint: $INJICERTIFYBASEURL$/v1/certify/issuance/credential
+      uniqueIdentifier: TC_injicertify_credentialissuance_38
+      description: Get sunbird VC when invalid value is given as context value and expected VC download should get failed with proper error
+      role: resident
+      restMethod: post
+      validityCheckRequired: true
+      inputTemplate: injicertify/SunBirdCNegative/GetCredentialSunBirdCNeg/GetCredentialSunBirdCNeg
+      outputTemplate: injicertify/error2
+      input: '{
+      	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
+        "format": "ldp_vc",
+      	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
+      	"@context": [{context: "$VCICONTEXTURL$"}],
+      	"proof_type": "jwt",
+        "proof_jwt": "$REMOVE$",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "Ed25519"
+}'
+      output: '{
+		"error": "invalid_proof"
+}'
+
+   InjiCertify_GetCredentialSunBirdC_IdpAccessToken_ED25519_Sign_Invalid_Proof_Jwt_Neg:
+      endPoint: $INJICERTIFYBASEURL$/v1/certify/issuance/credential
+      uniqueIdentifier: TC_injicertify_credentialissuance_39
+      description: Get sunbird VC when invalid value is given as context value and expected VC download should get failed with proper error
+      role: resident
+      restMethod: post
+      validityCheckRequired: true
+      inputTemplate: injicertify/SunBirdCNegative/GetCredentialSunBirdCNeg/GetCredentialSunBirdCNeg
+      outputTemplate: injicertify/error2
+      input: '{
+      	"client_id": "$ID:ESignet_CreateOIDCClientV2SunBirdC_all_Valid_Smoke_sid_clientId$",
+        "idpAccessToken": "$ID:ESignet_GenerateTokenSunBirdC_Valid_sid_Neg_access_token$",
+        "format": "ldp_vc",
+      	"type": [{types: "VerifiableCredential"}, {types: "InsuranceCredential"}],
+      	"@context": [{context: "$VCICONTEXTURL$"}],
+      	"proof_type": "jwt",
+        "proof_jwt": "sjkdbfjksd",
+        "credentialType": "InsuranceCredential",
+        "signatureSupported": "Ed25519"
+}'
+      output: '{
+		"error": "invalid_proof"
 }'

--- a/api-test/src/main/resources/injicertify/VCILandRegistry/GetCredentialForLandRegistry/GetCredentialForLandRegistry.yml
+++ b/api-test/src/main/resources/injicertify/VCILandRegistry/GetCredentialForLandRegistry/GetCredentialForLandRegistry.yml
@@ -18,7 +18,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_3$",
         "credentialType": "LandStatementCredential",
-        "signatureSupported": "RsaSignature2018"
+        "signatureSupported": "RS256"
 }'
       output: '{
 }'
@@ -42,7 +42,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_3$",
         "credentialType": "LandStatementCredential",
-        "signatureSupported": "RsaSignature2018"
+        "signatureSupported": "PS256"
 }'
       output: '{
 }'
@@ -66,7 +66,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_3$",
         "credentialType": "LandStatementCredential",
-        "signatureSupported": "RsaSignature2018"
+        "signatureSupported": "RS256"
 }'
       output: '{
 }'
@@ -90,7 +90,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_3$",
         "credentialType": "LandStatementCredential",
-        "signatureSupported": "RsaSignature2018"
+        "signatureSupported": "PS256"
 }'
       output: '{
 }'
@@ -114,7 +114,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_3$",
         "credentialType": "RegistrationReceiptCredential",
-        "signatureSupported": "RsaSignature2018"
+        "signatureSupported": "RS256"
 }'
       output: '{
 }'
@@ -138,7 +138,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_3$",
         "credentialType": "RegistrationReceiptCredential",
-        "signatureSupported": "RsaSignature2018"
+        "signatureSupported": "PS256"
 }'
       output: '{
 }'
@@ -162,7 +162,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_3$",
         "credentialType": "RegistrationReceiptCredential",
-        "signatureSupported": "RsaSignature2018"
+        "signatureSupported": "RS256"
 }'
       output: '{
 }'
@@ -186,7 +186,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_3$",
         "credentialType": "RegistrationReceiptCredential",
-        "signatureSupported": "RsaSignature2018"
+        "signatureSupported": "PS256"
 }'
       output: '{
 }'
@@ -210,7 +210,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",
         "credentialType": "LandStatementCredential",
-        "signatureSupported": "Ed25519Signature2020"
+        "signatureSupported": "Ed25519"
 }'
       output: '{
 }'
@@ -234,7 +234,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",
         "credentialType": "LandStatementCredential",
-        "signatureSupported": "Ed25519Signature2020"
+        "signatureSupported": "Ed25519"
 }'
       output: '{
 }'
@@ -258,7 +258,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",
         "credentialType": "RegistrationReceiptCredential",
-        "signatureSupported": "Ed25519Signature2020"
+        "signatureSupported": "Ed25519"
 }'
       output: '{
 }'
@@ -282,7 +282,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",
         "credentialType": "RegistrationReceiptCredential",
-        "signatureSupported": "Ed25519Signature2020"
+        "signatureSupported": "Ed25519"
 }'
       output: '{
 }'

--- a/api-test/src/main/resources/injicertify/VCILandRegistryNeg/GetCredentialForLandRegistry/GetCredentialForLandRegistry.yml
+++ b/api-test/src/main/resources/injicertify/VCILandRegistryNeg/GetCredentialForLandRegistry/GetCredentialForLandRegistry.yml
@@ -18,7 +18,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_3$",
         "credentialType": "LandStatementCredential",
-        "signatureSupported": "RsaSignature2018"
+        "signatureSupported": "RS256"
 }'
       output: '{
 		"error": "unsupported_credential_type"
@@ -43,7 +43,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_3$",
         "credentialType": "LandStatementCredential",
-        "signatureSupported": "RsaSignature2018"
+        "signatureSupported": "RS256"
 }'
       output: '{
 		"error": "expected_template_not_found"
@@ -68,7 +68,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_3$",
         "credentialType": "RegistrationReceiptCredential",
-        "signatureSupported": "RsaSignature2018"
+        "signatureSupported": "RS256"
 }'
       output: '{
 		"error": "unsupported_credential_type"
@@ -93,7 +93,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_3$",
         "credentialType": "RegistrationReceiptCredential",
-        "signatureSupported": "RsaSignature2018"
+        "signatureSupported": "RS256"
 }'
       output: '{
 		"error": "expected_template_not_found"
@@ -118,7 +118,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",
         "credentialType": "LandStatementCredential",
-        "signatureSupported": "Ed25519Signature2020"
+        "signatureSupported": "Ed25519"
 }'
       output: '{
 		"error": "unsupported_credential_type"
@@ -143,7 +143,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",
         "credentialType": "LandStatementCredential",
-        "signatureSupported": "Ed25519Signature2020"
+        "signatureSupported": "Ed25519"
 }'
       output: '{
 		"error": "expected_template_not_found"
@@ -168,7 +168,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",
         "credentialType": "RegistrationReceiptCredential",
-        "signatureSupported": "Ed25519Signature2020"
+        "signatureSupported": "Ed25519"
 }'
       output: '{
 		"error": "unsupported_credential_type"
@@ -193,7 +193,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",
         "credentialType": "RegistrationReceiptCredential",
-        "signatureSupported": "Ed25519Signature2020"
+        "signatureSupported": "Ed25519"
 }'
       output: '{
 		"error": "expected_template_not_found"
@@ -218,7 +218,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$REMOVE$",
         "credentialType": "LandStatementCredential",
-        "signatureSupported": "Ed25519Signature2020"
+        "signatureSupported": "Ed25519"
 }'
       output: '{
 		"error": "invalid_proof"
@@ -243,7 +243,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$REMOVE$",
         "credentialType": "LandStatementCredential",
-        "signatureSupported": "Ed25519Signature2020"
+        "signatureSupported": "Ed25519"
 }'
       output: '{
 		"error": "invalid_proof"
@@ -268,7 +268,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "sjkdbfjksd",
         "credentialType": "LandStatementCredential",
-        "signatureSupported": "Ed25519Signature2020"
+        "signatureSupported": "Ed25519"
 }'
       output: '{
 		"error": "invalid_proof"
@@ -293,7 +293,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "sjkdbfjksd",
         "credentialType": "LandStatementCredential",
-        "signatureSupported": "Ed25519Signature2020"
+        "signatureSupported": "Ed25519"
 }'
       output: '{
 		"error": "invalid_proof"

--- a/api-test/src/main/resources/injicertify/VCILandRegistryVD11/GetCredentialForLandRegistry/GetCredentialForLandRegistry.yml
+++ b/api-test/src/main/resources/injicertify/VCILandRegistryVD11/GetCredentialForLandRegistry/GetCredentialForLandRegistry.yml
@@ -18,7 +18,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_3$",
         "credentialType": "LandStatementCredential",
-        "signatureSupported": "RsaSignature2018"
+        "signatureSupported": "RS256"
 }'
       output: '{
 }'
@@ -42,7 +42,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_3$",
         "credentialType": "LandStatementCredential",
-        "signatureSupported": "RsaSignature2018"
+        "signatureSupported": "RS256"
 }'
       output: '{
 }'
@@ -66,7 +66,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_3$",
         "credentialType": "RegistrationReceiptCredential",
-        "signatureSupported": "RsaSignature2018"
+        "signatureSupported": "RS256"
 }'
       output: '{
 }'
@@ -90,7 +90,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_3$",
         "credentialType": "RegistrationReceiptCredential",
-        "signatureSupported": "RsaSignature2018"
+        "signatureSupported": "RS256"
 }'
       output: '{
 }'
@@ -114,7 +114,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",
         "credentialType": "LandStatementCredential",
-        "signatureSupported": "Ed25519Signature2020"
+        "signatureSupported": "Ed25519"
 }'
       output: '{
 }'
@@ -138,7 +138,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",
         "credentialType": "LandStatementCredential",
-        "signatureSupported": "Ed25519Signature2020"
+        "signatureSupported": "Ed25519"
 }'
       output: '{
 }'
@@ -162,7 +162,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",
         "credentialType": "RegistrationReceiptCredential",
-        "signatureSupported": "Ed25519Signature2020"
+        "signatureSupported": "Ed25519"
 }'
       output: '{
 }'
@@ -186,7 +186,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",
         "credentialType": "RegistrationReceiptCredential",
-        "signatureSupported": "Ed25519Signature2020"
+        "signatureSupported": "Ed25519"
 }'
       output: '{
 }'

--- a/api-test/src/main/resources/injicertify/VCILandRegistryVD12/GetCredentialForLandRegistry/GetCredentialForLandRegistry.yml
+++ b/api-test/src/main/resources/injicertify/VCILandRegistryVD12/GetCredentialForLandRegistry/GetCredentialForLandRegistry.yml
@@ -18,7 +18,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_3$",
         "credentialType": "LandStatementCredential",
-        "signatureSupported": "RsaSignature2018"
+        "signatureSupported": "RS256"
 }'
       output: '{
 }'
@@ -42,7 +42,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_3$",
         "credentialType": "LandStatementCredential",
-        "signatureSupported": "RsaSignature2018"
+        "signatureSupported": "RS256"
 }'
       output: '{
 }'
@@ -66,7 +66,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_3$",
         "credentialType": "RegistrationReceiptCredential",
-        "signatureSupported": "RsaSignature2018"
+        "signatureSupported": "RS256"
 }'
       output: '{
 }'
@@ -90,7 +90,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_3$",
         "credentialType": "RegistrationReceiptCredential",
-        "signatureSupported": "RsaSignature2018"
+        "signatureSupported": "RS256"
 }'
       output: '{
 }'
@@ -114,7 +114,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",
         "credentialType": "LandStatementCredential",
-        "signatureSupported": "Ed25519Signature2020"
+        "signatureSupported": "Ed25519"
 }'
       output: '{
 }'
@@ -138,7 +138,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",
         "credentialType": "LandStatementCredential",
-        "signatureSupported": "Ed25519Signature2020"
+        "signatureSupported": "Ed25519"
 }'
       output: '{
 }'
@@ -162,7 +162,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",
         "credentialType": "RegistrationReceiptCredential",
-        "signatureSupported": "Ed25519Signature2020"
+        "signatureSupported": "Ed25519"
 }'
       output: '{
 }'
@@ -186,7 +186,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",
         "credentialType": "RegistrationReceiptCredential",
-        "signatureSupported": "Ed25519Signature2020"
+        "signatureSupported": "Ed25519"
 }'
       output: '{
 }'

--- a/api-test/src/main/resources/injicertify/VCIMockIDA/GetCredentialForMockIDA/GetCredentialForMockIDA.yml
+++ b/api-test/src/main/resources/injicertify/VCIMockIDA/GetCredentialForMockIDA/GetCredentialForMockIDA.yml
@@ -16,7 +16,33 @@ GetCredentialForMockIDA:
       	"type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
       	"proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_3$"
+        "proof_jwt": "$PROOF_JWT_3$",
+        "credentialType": "MockVerifiableCredential",
+        "signatureSupported": "RS256"
+}'
+      output: '{
+}'
+
+   InjiCertify_GetCredentialForMockIDA_IdpAccessToken_ED25519_Sign_all_Valid_Smoke:
+      endPoint: $INJICERTIFYMOCKIDABASEURL$/v1/certify/issuance/credential
+      uniqueIdentifier: TC_InjiCertify_GetCredentialForMockIDA_01
+      description: Get credentials for Mock with all valid data
+      role: resident
+      checkErrorsOnlyInResponse: true
+      restMethod: post
+      validityCheckRequired: true
+      inputTemplate: injicertify/VCIMockIDA/GetCredentialForMockIDA/GetCredentialForMockIDA
+      outputTemplate: injicertify/VCIMockIDA/GetCredentialForMockIDA/GetCredentialForMockIDAResult
+      input: '{
+      	"client_id": "$ID:ESignet_CreateOIDCClientV2_ForMockIDA_all_Valid_Smoke_sid_clientId$",
+        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_Smoke_sid_access_token$",
+        "format": "ldp_vc",
+      	"type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
+      	"@context": [{context: "$VCICONTEXTURL$"}],
+      	"proof_type": "jwt",
+        "proof_jwt": "$PROOF_JWT_ED25519$",
+        "credentialType": "MockVerifiableCredential",
+        "signatureSupported": "Ed25519"
 }'
       output: '{
 }'

--- a/api-test/src/main/resources/injicertify/VCIMockIDAForVd11/GetCredentialForMockIDA/GetCredentialForMockIDA.yml
+++ b/api-test/src/main/resources/injicertify/VCIMockIDAForVd11/GetCredentialForMockIDA/GetCredentialForMockIDA.yml
@@ -14,7 +14,31 @@ GetCredentialForMockIDA:
       	"type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
       	"proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_3$"
+        "proof_jwt": "$PROOF_JWT_3$",
+        "credentialType": "MockVerifiableCredential",
+        "signatureSupported": "RS256"
+}'
+      output: '{
+}'
+
+   InjiCertify_GetCredentialForMockIDA_Vd11_IdpAccessToken_ED25519_Sign_all_Valid_Smoke:
+      endPoint: $INJICERTIFYMOCKIDABASEURL$/v1/certify/issuance/vd11/credential
+      role: resident
+      checkErrorsOnlyInResponse: true
+      restMethod: post
+      validityCheckRequired: true
+      inputTemplate: injicertify/VCIMockIDAForVd11/GetCredentialForMockIDA/GetCredentialForMockIDA
+      outputTemplate: injicertify/VCIMockIDAForVd11/GetCredentialForMockIDA/GetCredentialForMockIDAResult
+      input: '{
+      	"client_id": "$ID:ESignet_CreateOIDCClientV2_ForMockIDA_all_Valid_Smoke_sid_clientId$",
+        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Vd11_Valid_Smoke_sid_access_token$",
+        "format": "ldp_vc",
+      	"type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
+      	"@context": [{context: "$VCICONTEXTURL$"}],
+      	"proof_type": "jwt",
+        "proof_jwt": "$PROOF_JWT_ED25519$",
+        "credentialType": "MockVerifiableCredential",
+        "signatureSupported": "Ed25519"
 }'
       output: '{
 }'

--- a/api-test/src/main/resources/injicertify/VCIMockIDAForVd12/GetCredentialForMockIDA/GetCredentialForMockIDA.yml
+++ b/api-test/src/main/resources/injicertify/VCIMockIDAForVd12/GetCredentialForMockIDA/GetCredentialForMockIDA.yml
@@ -14,7 +14,31 @@ GetCredentialForMockIDA:
       	"type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
       	"@context": [{context: "$VCICONTEXTURL$"}],
       	"proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_3$"
+        "proof_jwt": "$PROOF_JWT_3$",
+        "credentialType": "MockVerifiableCredential",
+        "signatureSupported": "RS256"
+}'
+      output: '{
+}'
+
+   InjiCertify_GetCredentialForMockIDA_Vd12_IdpAccessToken_ED25519_Sign_all_Valid_Smoke:
+      endPoint: $INJICERTIFYMOCKIDABASEURL$/v1/certify/issuance/vd12/credential
+      role: resident
+      checkErrorsOnlyInResponse: true
+      restMethod: post
+      validityCheckRequired: true
+      inputTemplate: injicertify/VCIMockIDAForVd12/GetCredentialForMockIDA/GetCredentialForMockIDA
+      outputTemplate: injicertify/VCIMockIDAForVd12/GetCredentialForMockIDA/GetCredentialForMockIDAResult
+      input: '{
+      	"client_id": "$ID:ESignet_CreateOIDCClientV2_ForMockIDA_all_Valid_Smoke_sid_clientId$",
+        "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Vd12_Valid_Smoke_sid_access_token$",
+        "format": "ldp_vc",
+      	"type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
+      	"@context": [{context: "$VCICONTEXTURL$"}],
+      	"proof_type": "jwt",
+        "proof_jwt": "$PROOF_JWT_ED25519$",
+        "credentialType": "MockVerifiableCredential",
+        "signatureSupported": "Ed25519"
 }'
       output: '{
 }'

--- a/api-test/src/main/resources/injicertify/VCIMockIDANegTC/GetCredentialForMockIDANegTC/GetCredentialForMockIDANegTC.yml
+++ b/api-test/src/main/resources/injicertify/VCIMockIDANegTC/GetCredentialForMockIDANegTC/GetCredentialForMockIDANegTC.yml
@@ -573,7 +573,7 @@ GetCredentialForMockIDANegTC:
         "@context": [{context: "$VCICONTEXTURL$"}],
         "proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_3$",
-		"credentialType": "MockVerifiableCredential",
+        "credentialType": "MockVerifiableCredential",
         "signatureSupported": "RS256"
 }'
       output: '{

--- a/api-test/src/main/resources/injicertify/VCIMockIDANegTC/GetCredentialForMockIDANegTC/GetCredentialForMockIDANegTC.yml
+++ b/api-test/src/main/resources/injicertify/VCIMockIDANegTC/GetCredentialForMockIDANegTC/GetCredentialForMockIDANegTC.yml
@@ -16,7 +16,9 @@ GetCredentialForMockIDANegTC:
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
         "proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_3$"
+        "proof_jwt": "$PROOF_JWT_3$",
+        "credentialType": "MockVerifiableCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
         "error": "unsupported_credential_format"
@@ -38,7 +40,9 @@ GetCredentialForMockIDANegTC:
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
         "proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_3$"
+        "proof_jwt": "$PROOF_JWT_3$",
+        "credentialType": "MockVerifiableCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
         "error": "invalid_vc_format"
@@ -61,7 +65,9 @@ GetCredentialForMockIDANegTC:
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
         "proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_3$"
+        "proof_jwt": "$PROOF_JWT_3$",
+        "credentialType": "MockVerifiableCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
         "error": "invalid_vc_format"
@@ -84,7 +90,9 @@ GetCredentialForMockIDANegTC:
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
         "proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_3$"
+        "proof_jwt": "$PROOF_JWT_3$",
+        "credentialType": "MockVerifiableCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
         "error": "invalid_vc_format"
@@ -107,7 +115,9 @@ GetCredentialForMockIDANegTC:
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
         "proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_3$"
+        "proof_jwt": "$PROOF_JWT_3$",
+        "credentialType": "MockVerifiableCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
         "error": "not_implemented"
@@ -130,7 +140,9 @@ GetCredentialForMockIDANegTC:
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
         "proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_3$"
+        "proof_jwt": "$PROOF_JWT_3$",
+        "credentialType": "MockVerifiableCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
         "error": "not_implemented"
@@ -154,7 +166,9 @@ GetCredentialForMockIDANegTC:
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
         "proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_3$"
+        "proof_jwt": "$PROOF_JWT_3$",
+        "credentialType": "MockVerifiableCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
         "error": "unsupported_credential_format"
@@ -177,7 +191,9 @@ GetCredentialForMockIDANegTC:
         "type": [],
         "@context": [{context: "$VCICONTEXTURL$"}],
         "proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_3$"
+        "proof_jwt": "$PROOF_JWT_3$",
+        "credentialType": "MockVerifiableCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
         "error": "invalid_request"
@@ -201,7 +217,9 @@ GetCredentialForMockIDANegTC:
         "type": [{types: "VerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
         "proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_3$"
+        "proof_jwt": "$PROOF_JWT_3$",
+        "credentialType": "MockVerifiableCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
         "error": "unsupported_credential_type"
@@ -225,7 +243,9 @@ GetCredentialForMockIDANegTC:
         "type": [{types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
         "proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_3$"
+        "proof_jwt": "$PROOF_JWT_3$",
+        "credentialType": "MockVerifiableCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
         "error": "unsupported_credential_type"
@@ -248,7 +268,9 @@ GetCredentialForMockIDANegTC:
         "type": [{types: "randomvalue"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
         "proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_3$"
+        "proof_jwt": "$PROOF_JWT_3$",
+        "credentialType": "MockVerifiableCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
         "error": "unsupported_credential_type"
@@ -270,7 +292,9 @@ GetCredentialForMockIDANegTC:
         "idpAccessToken": "$ID:ESignet_GenerateToken_ForMockIDA_Valid_sid_For_Neg_Flow_access_token$",
         "format": "ldp_vc",
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
-        "@context": [{context: "$VCICONTEXTURL$"}]
+        "@context": [{context: "$VCICONTEXTURL$"}],
+        "credentialType": "MockVerifiableCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
         "error": "invalid_proof"
@@ -294,7 +318,9 @@ GetCredentialForMockIDANegTC:
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
         "proof_type": "",
-        "proof_jwt": ""
+        "proof_jwt": "",
+        "credentialType": "MockVerifiableCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
         "error": "unsupported_proof_type"
@@ -317,7 +343,9 @@ GetCredentialForMockIDANegTC:
         "format": "ldp_vc",
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
-        "proof_type": "jwt"
+        "proof_type": "jwt",
+        "credentialType": "MockVerifiableCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
         "error": "invalid_proof"
@@ -341,7 +369,9 @@ GetCredentialForMockIDANegTC:
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
         "proof_type": "",
-        "proof_jwt": "$PROOF_JWT_3$"
+        "proof_jwt": "$PROOF_JWT_3$",
+        "credentialType": "MockVerifiableCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
         "error": "unsupported_proof_type"
@@ -365,7 +395,9 @@ GetCredentialForMockIDANegTC:
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
         "proof_type": " ",
-        "proof_jwt": "$PROOF_JWT_3$"
+        "proof_jwt": "$PROOF_JWT_3$",
+        "credentialType": "MockVerifiableCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
         "error": "unsupported_proof_type"
@@ -387,7 +419,9 @@ GetCredentialForMockIDANegTC:
         "format": "ldp_vc",
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
-        "proof_jwt": "$PROOF_JWT_3"
+        "proof_jwt": "$PROOF_JWT_3",
+        "credentialType": "MockVerifiableCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
         "error": "unsupported_proof_type"
@@ -409,8 +443,10 @@ GetCredentialForMockIDANegTC:
         "format": "ldp_vc",
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
-        "proof_type": "jwt",		
-        "proof_jwt": ""
+        "proof_type": "jwt",
+        "proof_jwt": "",
+        "credentialType": "MockVerifiableCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
         "error": "invalid_proof"
@@ -433,7 +469,9 @@ GetCredentialForMockIDANegTC:
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
         "proof_type": "jwt",		
-        "proof_jwt": " "
+        "proof_jwt": " ",
+        "credentialType": "MockVerifiableCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
         "error": "invalid_proof"
@@ -456,7 +494,9 @@ GetCredentialForMockIDANegTC:
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
         "proof_type": "jwt",		
-        "proof_jwt": "invalid"
+        "proof_jwt": "invalid",
+        "credentialType": "MockVerifiableCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
         "error": "invalid_proof"
@@ -479,7 +519,9 @@ GetCredentialForMockIDANegTC:
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
         "proof_type": "cwt",		
-        "proof_jwt": "$PROOF_JWT_3$"
+        "proof_jwt": "$PROOF_JWT_3$",
+        "credentialType": "MockVerifiableCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
         "error": "unsupported_proof_type"
@@ -503,7 +545,9 @@ GetCredentialForMockIDANegTC:
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
         "proof_type": "jwt123",		
-        "proof_jwt": "$PROOF_JWT_3$"
+        "proof_jwt": "$PROOF_JWT_3$",
+        "credentialType": "MockVerifiableCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
         "error": "unsupported_proof_type"
@@ -528,7 +572,9 @@ GetCredentialForMockIDANegTC:
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
         "proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_3$"
+        "proof_jwt": "$PROOF_JWT_3$",
+		"credentialType": "MockVerifiableCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
         "error": "invalid_proof"
@@ -551,7 +597,9 @@ GetCredentialForMockIDANegTC:
         "type": [{types: "VerifiableCredential"}, {types: "MockVerifiableCredential"}],
         "@context": [{context: "$VCICONTEXTURL$"}],
         "proof_type": "jwt",
-        "proof_jwt": "$PROOF_JWT_3$"
+        "proof_jwt": "$PROOF_JWT_3$",
+        "credentialType": "MockVerifiableCredential",
+        "signatureSupported": "RS256"
 }'
       output: '{
         "error": "invalid_proof"


### PR DESCRIPTION
- Added ED25519 testcases for mock and sunbird use case.
- Modified logic of getting proof alg supported values from well-known endpoint and storing it in Map in common for all use cases.