### PR TITLE
INJICERT-973 - Enabled the property for auth factor type if esignet version is older than 1.5.1

### DIFF
--- a/api-test/src/main/resources/config/injiCertify.properties
+++ b/api-test/src/main/resources/config/injiCertify.properties
@@ -16,5 +16,5 @@ sunBirdBaseURL=https://registry.released.mosip.net
 # allowed useCaseToExecute values are (sunbird/mosipid/mock/landregistry)
 useCaseToExecute=mosipid
 
-# Uncomment the line below if the eSignet version is older than 1.5.1 for compatibility
-#sunbirdInsuranceAuthFactorType=KBA
+# if the eSignet version is older than 1.5.1 for compatibility add the value as KBA for below property
+sunbirdInsuranceAuthFactorType=


### PR DESCRIPTION
INJICERT-973 - Enabled the property for auth factor type if esignet version is older than 1.5.1