### PR TITLE
[INJICERT-1028] Implement Periodic Status List Update Job

### DIFF
--- a/certify-service/src/main/java/io/mosip/certify/config/SchedulerConfig.java
+++ b/certify-service/src/main/java/io/mosip/certify/config/SchedulerConfig.java
@@ -1,0 +1,13 @@
+package io.mosip.certify.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+/**
+ * Configuration class to enable scheduling
+ */
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+    // Configuration is handled via properties
+}

--- a/certify-service/src/main/java/io/mosip/certify/entity/CredentialStatus.java
+++ b/certify-service/src/main/java/io/mosip/certify/entity/CredentialStatus.java
@@ -1,0 +1,41 @@
+package io.mosip.certify.entity;
+
+import lombok.Data;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+/**
+ * Entity class for credential_status table
+ */
+@Data
+@Entity
+@Table(name = "credential_status")
+public class CredentialStatus {
+
+    @Id
+    @Column(name = "status_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long statusId;
+
+    @Column(name = "ledger_id")
+    private String ledgerId;
+
+    @Column(name = "status_purpose")
+    private String statusPurpose;
+
+    @Column(name = "status_list_credential_id")
+    private String statusListCredentialId;
+
+    @Column(name = "status_list_index")
+    private Long statusListIndex;
+
+    @Column(name = "status_value")
+    private String statusValue;
+
+    @Column(name = "cr_dtimes")
+    private LocalDateTime createdDtimes;
+
+    @Column(name = "upd_dtimes")
+    private LocalDateTime updatedDtimes;
+}

--- a/certify-service/src/main/java/io/mosip/certify/entity/CredentialStatusTransaction.java
+++ b/certify-service/src/main/java/io/mosip/certify/entity/CredentialStatusTransaction.java
@@ -1,0 +1,46 @@
+package io.mosip.certify.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+/**
+ * Entity class for credential_status_transaction table
+ * Represents a transaction to update the status of a credential
+ */
+@Data
+@Entity
+@Table(name = "credential_status_transaction")
+@NoArgsConstructor
+@AllArgsConstructor
+public class CredentialStatusTransaction {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "transaction_log_id")
+    private Long transactionLogId;
+
+    @Column(name = "credential_id", nullable = false)
+    private String credentialId;
+
+    @Column(name = "status_purpose")
+    private String statusPurpose;
+
+    @Column(name = "status_value")
+    private Boolean statusValue;
+
+    @Column(name = "status_list_credential_id")
+    private String statusListCredentialId;
+
+    @Column(name = "status_list_index")
+    private Long statusListIndex;
+
+    @Column(name = "cr_dtimes", nullable = false)
+    private LocalDateTime createdDtimes;
+
+    @Column(name = "upd_dtimes")
+    private LocalDateTime updatedDtimes;
+}

--- a/certify-service/src/main/java/io/mosip/certify/entity/StatusListCredential.java
+++ b/certify-service/src/main/java/io/mosip/certify/entity/StatusListCredential.java
@@ -1,0 +1,57 @@
+// StatusListCredential.java
+package io.mosip.certify.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "status_list_credential")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class StatusListCredential {
+
+    @Id
+    private String id;
+
+    @Column(name = "vc_document", nullable = false)
+    @Lob
+    private byte[] vcDocument;
+
+    @Column(name = "credential_type", nullable = false)
+    private String credentialType;
+
+    @Column(name = "status_purpose")
+    private String statusPurpose;
+
+    @Column(name = "capacity")
+    private Long capacity;
+
+    @Column(name = "credential_status")
+    @Enumerated(EnumType.STRING)
+    private CredentialStatus credentialStatus;
+
+    @Column(name = "cr_dtimes", nullable = false, updatable = false)
+    private LocalDateTime createdDtimes;
+
+    @Column(name = "upd_dtimes")
+    private LocalDateTime updatedDtimes;
+
+    @PrePersist
+    protected void onCreate() {
+        createdDtimes = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedDtimes = LocalDateTime.now();
+    }
+
+    public enum CredentialStatus {
+        AVAILABLE, FULL
+    }
+}

--- a/certify-service/src/main/java/io/mosip/certify/exception/BitstringStatusListException.java
+++ b/certify-service/src/main/java/io/mosip/certify/exception/BitstringStatusListException.java
@@ -1,0 +1,26 @@
+package io.mosip.certify.exception;
+
+/**
+ * Exception class for Bitstring Status List operations
+ */
+public class BitstringStatusListException extends Exception {
+
+    private final String errorCode;
+
+    public BitstringStatusListException(String errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    /**
+     * Gets the error URL as per W3C Problem Details format
+     * As defined in section 3.5 of the specification
+     */
+    public String getErrorUrl() {
+        return "https://www.w3.org/ns/credentials/status-list#" + errorCode;
+    }
+}

--- a/certify-service/src/main/java/io/mosip/certify/repository/CredentialStatusRepository.java
+++ b/certify-service/src/main/java/io/mosip/certify/repository/CredentialStatusRepository.java
@@ -1,0 +1,36 @@
+package io.mosip.certify.repository;
+
+import io.mosip.certify.entity.CredentialStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.LockModeType;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Repository for CredentialStatus entity
+ */
+@Repository
+public interface CredentialStatusRepository extends JpaRepository<CredentialStatus, Long> {
+
+    /**
+     * Find credential status by credential ID with pessimistic lock for update
+     *
+     * @param credentialId the credential ID
+     * @return optional credential status
+     */
+    @Query("SELECT cs FROM CredentialStatus cs WHERE cs.ledgerId = :credentialId")
+    Optional<CredentialStatus> findByCredentialIdForUpdate(@Param("credentialId") String credentialId);
+
+    /**
+     * Find all credential status entries for a specific status list credential ID
+     *
+     * @param statusListCredentialId the status list credential ID
+     * @return list of credential status entries
+     */
+    List<CredentialStatus> findByStatusListCredentialId(String statusListCredentialId);
+}

--- a/certify-service/src/main/java/io/mosip/certify/repository/CredentialStatusTransactionRepository.java
+++ b/certify-service/src/main/java/io/mosip/certify/repository/CredentialStatusTransactionRepository.java
@@ -1,0 +1,50 @@
+package io.mosip.certify.repository;
+
+import io.mosip.certify.entity.CredentialStatusTransaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Repository for the credential_status_transaction table
+ */
+@Repository
+public interface CredentialStatusTransactionRepository extends JpaRepository<CredentialStatusTransaction, Long> {
+
+    /**
+     * Find all transactions that occurred after a specified timestamp
+     *
+     * @param timestamp the timestamp to filter transactions
+     * @return list of transactions created after the specified timestamp
+     */
+    @Query("SELECT cst FROM CredentialStatusTransaction cst WHERE cst.createdDtimes > :timestamp ORDER BY cst.createdDtimes ASC")
+    List<CredentialStatusTransaction> findTransactionsSince(@Param("timestamp") LocalDateTime timestamp);
+
+    /**
+     * Find all transactions for a specific credential
+     *
+     * @param credentialId the ID of the credential
+     * @return list of transactions for the specified credential
+     */
+    List<CredentialStatusTransaction> findByCredentialId(String credentialId);
+
+    /**
+     * Find all transactions for a specific status list credential
+     *
+     * @param statusListCredentialId the ID of the status list credential
+     * @return list of transactions for the specified status list credential
+     */
+    List<CredentialStatusTransaction> findByStatusListCredentialId(String statusListCredentialId);
+
+    /**
+     * Find transactions created after the specified timestamp
+     *
+     * @param timestamp the timestamp to compare against
+     * @return list of transactions created after the specified timestamp
+     */
+    List<CredentialStatusTransaction> findByCreatedDtimesAfterOrderByCreatedDtimes(LocalDateTime timestamp);
+}

--- a/certify-service/src/main/java/io/mosip/certify/repository/StatusListCredentialRepository.java
+++ b/certify-service/src/main/java/io/mosip/certify/repository/StatusListCredentialRepository.java
@@ -1,0 +1,41 @@
+package io.mosip.certify.repository;
+
+import io.mosip.certify.entity.StatusListCredential;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface StatusListCredentialRepository extends JpaRepository<StatusListCredential, String> {
+
+    /**
+     * Find a suitable status list credential that is available (not full) and matches the given purpose
+     *
+     * @param statusPurpose The purpose of the status list (e.g., "revocation", "suspension")
+     * @return An optional containing the first available status list credential, or empty if none found
+     */
+    @Query("SELECT s FROM StatusListCredential s WHERE s.statusPurpose = :statusPurpose " +
+            "AND s.credentialStatus = io.mosip.certify.entities.StatusListCredential.CredentialStatusEnum.AVAILABLE " +
+            "ORDER BY s.createdDtimes DESC")
+    Optional<StatusListCredential> findSuitableStatusList(@Param("statusPurpose") String statusPurpose);
+
+    /**
+     * Find all status list credentials for a specific purpose
+     *
+     * @param statusPurpose The purpose of the status list
+     * @return List of status list credentials
+     */
+    List<StatusListCredential> findByStatusPurpose(String statusPurpose);
+
+    /**
+     * Find all status list credentials with a specific credential status
+     *
+     * @param credentialStatus The status of the credential (AVAILABLE or FULL)
+     * @return List of status list credentials
+     */
+    List<StatusListCredential> findByCredentialStatus(StatusListCredential.CredentialStatus credentialStatus);
+}

--- a/certify-service/src/main/java/io/mosip/certify/services/BitStringStatusListService.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/BitStringStatusListService.java
@@ -1,0 +1,149 @@
+package io.mosip.certify.services;
+
+import io.mosip.certify.core.constants.ErrorConstants;
+import io.mosip.certify.core.exception.CertifyException;
+import io.mosip.certify.utils.BitStringUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Base64;
+
+/**
+ * Service to handle bit string operations for status lists
+ * This service is responsible for manipulating the encoded status list
+ */
+@Slf4j
+@Service
+public class BitStringStatusListService {
+
+    /**
+     * Creates an empty encoded list (all bits set to 0)
+     *
+     * @param capacity the number of bits in the list
+     * @return Base64-encoded string representing the bit array
+     */
+    public String createEmptyEncodedList(long capacity) {
+        log.debug("Creating empty encoded list with capacity {}", capacity);
+
+        // Calculate number of bytes needed
+        int numBytes = (int) Math.ceil(capacity / 8.0);
+        byte[] emptyList = new byte[numBytes];
+
+        // All bytes initialized to 0 by default in Java
+        return Base64.getEncoder().encodeToString(emptyList);
+    }
+
+    /**
+     * Find the next available index (bit set to 0) in the encoded list
+     *
+     * @param encodedList Base64-encoded string representing the bit array
+     * @return next available index, or -1 if no available index found
+     */
+    public long findNextAvailableIndex(String encodedList) {
+        log.debug("Finding next available index in encoded list");
+
+        try {
+            byte[] decodedList = Base64.getDecoder().decode(encodedList);
+
+            // Find first bit that is 0
+            for (int byteIndex = 0; byteIndex < decodedList.length; byteIndex++) {
+                byte currentByte = decodedList[byteIndex];
+
+                // Skip if byte is full (all bits set to 1)
+                if (currentByte == (byte) 0xFF) {
+                    continue;
+                }
+
+                // Check each bit in the byte
+                for (int bitIndex = 0; bitIndex < 8; bitIndex++) {
+                    // Calculate mask for current bit
+                    byte mask = (byte) (1 << bitIndex);
+
+                    // If bit is 0, we found an available index
+                    if ((currentByte & mask) == 0) {
+                        return (byteIndex * 8) + bitIndex;
+                    }
+                }
+            }
+
+            // No available index found
+            return -1;
+
+        } catch (IllegalArgumentException e) {
+            log.error("Invalid Base64 encoded list", e);
+            throw new CertifyException("INVALID_ENCODED_LIST");
+        }
+    }
+
+    /**
+     * Update the status bit at the specified index
+     *
+     * @param encodedList Base64-encoded string representing the bit array
+     * @param index the index to update
+     * @param setValue true to set bit to 1, false to set to 0
+     * @return updated Base64-encoded string
+     */
+    public String updateStatusAtIndex(String encodedList, long index, boolean setValue) {
+        log.debug("Updating status at index {} to {}", index, setValue);
+
+        try {
+            byte[] decodedList = Base64.getDecoder().decode(encodedList);
+
+            int byteIndex = (int) (index / 8);
+            int bitIndex = (int) (index % 8);
+
+            if (byteIndex >= decodedList.length) {
+                log.error("Index out of bounds: {} (max bytes: {})", byteIndex, decodedList.length);
+                throw new CertifyException("INDEX_OUT_OF_BOUNDS");
+            }
+
+            byte mask = (byte) (1 << bitIndex);
+
+            if (setValue) {
+                // Set bit to 1
+                decodedList[byteIndex] |= mask;
+            } else {
+                // Set bit to 0
+                decodedList[byteIndex] &= ~mask;
+            }
+
+            return Base64.getEncoder().encodeToString(decodedList);
+
+        } catch (IllegalArgumentException e) {
+            log.error("Invalid Base64 encoded list", e);
+            throw new CertifyException("INVALID_ENCODED_LIST");
+        }
+    }
+
+    /**
+     * Check if a bit is set at the specified index
+     *
+     * @param encodedList Base64-encoded string representing the bit array
+     * @param index the index to check
+     * @return true if bit is 1, false if bit is 0
+     */
+    public boolean isStatusSetAtIndex(String encodedList, long index) {
+        log.debug("Checking status at index {}", index);
+
+        try {
+            byte[] decodedList = Base64.getDecoder().decode(encodedList);
+
+            int byteIndex = (int) (index / 8);
+            int bitIndex = (int) (index % 8);
+
+            if (byteIndex >= decodedList.length) {
+                log.error("Index out of bounds: {} (max bytes: {})", byteIndex, decodedList.length);
+                throw new CertifyException("INDEX_OUT_OF_BOUNDS");
+            }
+
+            byte mask = (byte) (1 << bitIndex);
+
+            // Return true if bit is 1, false if bit is 0
+            return (decodedList[byteIndex] & mask) != 0;
+
+        } catch (IllegalArgumentException e) {
+            log.error("Invalid Base64 encoded list", e);
+            throw new CertifyException("INVALID_ENCODED_LIST");
+        }
+    }
+}

--- a/certify-service/src/main/java/io/mosip/certify/services/StatusListCredentialService.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/StatusListCredentialService.java
@@ -1,0 +1,302 @@
+package io.mosip.certify.services;
+
+import foundation.identity.jsonld.JsonLDObject;
+import io.mosip.certify.api.dto.VCResult;
+import io.mosip.certify.core.constants.Constants;
+import io.mosip.certify.core.constants.ErrorConstants;
+import io.mosip.certify.core.exception.CertifyException;
+import io.mosip.certify.entity.StatusListCredential;
+import io.mosip.certify.repository.StatusListCredentialRepository;
+import io.mosip.certify.utils.BitStringUtils;
+import io.mosip.certify.vcformatters.VCFormatter;
+import io.mosip.certify.vcsigners.VCSigner;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Service class for managing Status List Credentials
+ * Responsible for generating, retrieving, and managing status list VCs
+ */
+@Slf4j
+@Service
+public class StatusListCredentialService {
+
+    @Autowired
+    private StatusListCredentialRepository statusListCredentialRepository;
+
+    @Autowired
+    private VCFormatter vcFormatter;
+
+    @Autowired
+    private VCSigner vcSigner;
+
+    @Autowired
+    private BitStringStatusListService bitStringStatusListService;
+
+    @Value("${mosip.certify.data-provider-plugin.issuer.vc-sign-algo:Ed25519Signature2020}")
+    private String vcSignAlgorithm;
+
+    @Value("${mosip.certify.data-provider-plugin.issuer-uri}")
+    private String issuerId;
+
+    @Value("${mosip.certify.domain.url}")
+    private String domainUrl;
+
+    @Value("${mosip.certify.statuslist.default-capacity:131072}")
+    private long defaultCapacity;
+
+    @Value("${mosip.certify.statuslist.template-name:StatusList2021Credential}")
+    private String statusListTemplateName;
+
+    /**
+     * Find a suitable status list for the given purpose
+     *
+     * @param statusPurpose the purpose of the status list (e.g., "revocation", "suspension")
+     * @return Optional containing StatusListCredential if found
+     */
+    public Optional<StatusListCredential> findSuitableStatusList(String statusPurpose) {
+        return statusListCredentialRepository.findSuitableStatusList(statusPurpose);
+    }
+
+    /**
+     * Generate a new status list credential for the specified purpose
+     *
+     * @param statusPurpose the purpose of the status list (e.g., "revocation", "suspension")
+     * @return the generated StatusListCredential
+     */
+    @Transactional
+    public StatusListCredential generateStatusListCredential(String statusPurpose) {
+        log.info("Generating new status list credential with purpose: {}", statusPurpose);
+
+        try {
+            // Generate unique ID for status list
+            String statusListId = domainUrl + "/status-list-credentials/" + UUID.randomUUID().toString();
+
+            // Create the template data for the status list VC
+            JSONObject statusListData = new JSONObject();
+            statusListData.put("statusPurpose", statusPurpose);
+            statusListData.put("statusListId", statusListId);
+            statusListData.put("issuer", issuerId);
+
+            // Create empty encoded list (all 0s)
+            String encodedList = bitStringStatusListService.createEmptyEncodedList(defaultCapacity);
+            statusListData.put("encodedList", encodedList);
+
+            // Format the status list credential using VCFormatter
+            Map<String, Object> templateParams = new HashMap<>();
+            templateParams.put(Constants.TEMPLATE_NAME, statusListTemplateName);
+            templateParams.put(Constants.ISSUER_URI, issuerId);
+
+            String unsignedVC = vcFormatter.format(statusListData, templateParams);
+
+            // Sign the status list credential
+            Map<String, String> signerSettings = new HashMap<>();
+            signerSettings.put(Constants.APPLICATION_ID, CertifyIssuanceServiceImpl.keyChooser.get(vcSignAlgorithm).getFirst());
+            signerSettings.put(Constants.REFERENCE_ID, CertifyIssuanceServiceImpl.keyChooser.get(vcSignAlgorithm).getLast());
+
+            // Attach signature to the VC
+            VCResult<?> vcResult = vcSigner.attachSignature(unsignedVC, signerSettings);
+
+            if (vcResult.getCredential() == null) {
+                log.error("Failed to generate status list VC");
+                throw new CertifyException("VC_ISSUANCE_FAILED");
+            }
+
+            // Convert to byte array for storage
+            byte[] vcDocument = vcResult.getCredential().toString().getBytes();
+
+            // Create and save the status list credential entity
+            StatusListCredential statusListCredential = new StatusListCredential();
+            statusListCredential.setId(statusListId);
+            statusListCredential.setVcDocument(vcDocument);
+            statusListCredential.setCredentialType("BitstringStatusListCredential");
+            statusListCredential.setStatusPurpose(statusPurpose);
+            statusListCredential.setCapacity(defaultCapacity);
+            statusListCredential.setCredentialStatus(StatusListCredential.CredentialStatus.AVAILABLE);
+            statusListCredential.setCreatedDtimes(LocalDateTime.now());
+
+            // Save to database
+            return statusListCredentialRepository.save(statusListCredential);
+
+        } catch (Exception e) {
+            log.error("Error generating status list credential", e);
+            throw new CertifyException("STATUS_LIST_GENERATION_FAILED");
+        }
+    }
+
+    /**
+     * Find or create a suitable status list for the given purpose
+     * If no suitable status list exists, a new one will be created
+     *
+     * @param statusPurpose the purpose of the status list
+     * @return StatusListCredential that can be used for the given purpose
+     */
+    @Transactional
+    public StatusListCredential findOrCreateStatusList(String statusPurpose) {
+        log.info("Finding or creating status list for purpose: {}", statusPurpose);
+
+        // Try to find an existing suitable status list
+        Optional<StatusListCredential> existingStatusList = findSuitableStatusList(statusPurpose);
+
+        if (existingStatusList.isPresent()) {
+            return existingStatusList.get();
+        }
+
+        // No suitable status list found, generate a new one
+        log.info("No suitable status list found, generating a new one");
+        return generateStatusListCredential(statusPurpose);
+    }
+
+    /**
+     * Find next available index in the status list
+     *
+     * @param statusListId the ID of the status list
+     * @return the next available index, or -1 if the list is full
+     */
+    public long findNextAvailableIndex(String statusListId) {
+        Optional<StatusListCredential> statusListOpt = statusListCredentialRepository.findById(statusListId);
+
+        if (statusListOpt.isEmpty()) {
+            log.error("Status list not found with ID: {}", statusListId);
+            throw new CertifyException("STATUS_LIST_NOT_FOUND");
+        }
+
+        StatusListCredential statusList = statusListOpt.get();
+        if (statusList.getCredentialStatus() == StatusListCredential.CredentialStatus.FULL) {
+            log.info("Status list is full: {}", statusListId);
+            return -1;
+        }
+
+        // Get the status list data and find next available index
+        JsonLDObject statusListVC = deserializeVC(statusList.getVcDocument());
+        String encodedList = getEncodedListFromVC(statusListVC);
+
+        long nextIndex = bitStringStatusListService.findNextAvailableIndex(encodedList);
+
+        // Check if the list is now full after this allocation
+        if (nextIndex == -1 || nextIndex >= statusList.getCapacity() - 1) {
+            statusList.setCredentialStatus(StatusListCredential.CredentialStatus.FULL);
+            statusListCredentialRepository.save(statusList);
+
+            if (nextIndex == -1) {
+                return -1; // No available index found
+            }
+        }
+
+        return nextIndex;
+    }
+
+    /**
+     * Update the status at a specific index in the status list
+     *
+     * @param statusListId the ID of the status list
+     * @param index the index to update
+     * @param isRevoked true if the credential is revoked, false otherwise
+     * @return updated StatusListCredential
+     */
+    @Transactional
+    public StatusListCredential updateStatusAtIndex(String statusListId, long index, boolean isRevoked) {
+        Optional<StatusListCredential> statusListOpt = statusListCredentialRepository.findById(statusListId);
+
+        if (statusListOpt.isEmpty()) {
+            log.error("Status list not found with ID: {}", statusListId);
+            throw new CertifyException("STATUS_LIST_NOT_FOUND");
+        }
+
+        StatusListCredential statusList = statusListOpt.get();
+
+        // Get the status list data
+        JsonLDObject statusListVC = deserializeVC(statusList.getVcDocument());
+        String encodedList = getEncodedListFromVC(statusListVC);
+
+        // Update the bit at the specified index
+        String updatedEncodedList = bitStringStatusListService.updateStatusAtIndex(encodedList, index, isRevoked);
+
+        // Create updated VC with new encodedList
+        JSONObject statusListData = new JSONObject();
+        statusListData.put("statusPurpose", statusList.getStatusPurpose());
+        statusListData.put("statusListId", statusListId);
+        statusListData.put("issuer", issuerId);
+        statusListData.put("encodedList", updatedEncodedList);
+
+        Map<String, Object> templateParams = new HashMap<>();
+        templateParams.put(Constants.TEMPLATE_NAME, statusListTemplateName);
+        templateParams.put(Constants.ISSUER_URI, issuerId);
+
+        String unsignedVC = vcFormatter.format(statusListData, templateParams);
+
+        // Sign the updated VC
+        Map<String, String> signerSettings = new HashMap<>();
+        signerSettings.put(Constants.APPLICATION_ID, CertifyIssuanceServiceImpl.keyChooser.get("Ed25519Signature2020").getFirst());
+        signerSettings.put(Constants.REFERENCE_ID, CertifyIssuanceServiceImpl.keyChooser.get("Ed25519Signature2020").getLast());
+
+        VCResult<?> vcResult = vcSigner.attachSignature(unsignedVC, signerSettings);
+
+        if (vcResult.getCredential() == null) {
+            log.error("Failed to update status list VC");
+            throw new CertifyException("VC_ISSUANCE_FAILED");
+        }
+
+        // Update the entity with new VC document
+        statusList.setVcDocument(vcResult.getCredential().toString().getBytes());
+        statusList.setUpdatedDtimes(LocalDateTime.now());
+
+        return statusListCredentialRepository.save(statusList);
+    }
+
+    /**
+     * Get the status list credential by ID
+     *
+     * @param statusListId the ID of the status list
+     * @return StatusListCredential
+     */
+    public StatusListCredential getStatusListCredential(String statusListId) {
+        return statusListCredentialRepository.findById(statusListId)
+                .orElseThrow(() -> new CertifyException("STATUS_LIST_NOT_FOUND"));
+    }
+
+    // Helper methods
+
+    /**
+     * Deserialize VC document from byte array
+     *
+     * @param vcDocument byte array of VC document
+     * @return JsonLDObject representation of the VC
+     */
+    private JsonLDObject deserializeVC(byte[] vcDocument) {
+        try {
+            String vcString = new String(vcDocument);
+            return JsonLDObject.fromJson(vcString);
+        } catch (Exception e) {
+            log.error("Error deserializing VC document", e);
+            throw new CertifyException("INVALID_VC_DOCUMENT");
+        }
+    }
+
+    /**
+     * Extract encodedList from VC
+     *
+     * @param statusListVC the status list VC
+     * @return encodedList string
+     */
+    private String getEncodedListFromVC(JsonLDObject statusListVC) {
+        try {
+            Map<String, Object> credentialSubject = (Map<String, Object>) statusListVC.getJsonObject().get("credentialSubject");
+            Map<String, Object> statusList = (Map<String, Object>) credentialSubject.get("statusList");
+            return (String) statusList.get("encodedList");
+        } catch (Exception e) {
+            log.error("Error extracting encodedList from VC", e);
+            throw new CertifyException("INVALID_VC_DOCUMENT");
+        }
+    }
+}

--- a/certify-service/src/main/java/io/mosip/certify/utils/BitStringUtils.java
+++ b/certify-service/src/main/java/io/mosip/certify/utils/BitStringUtils.java
@@ -1,0 +1,176 @@
+package io.mosip.certify.utils;
+
+import io.mosip.certify.exception.BitstringStatusListException;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.*;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+public class BitStringUtils {
+    private static final int DEFAULT_LIST_SIZE = 131_072; // 16 KB
+    private static final int DEFAULT_STATUS_SIZE = 1;
+    public static final int MINIMUM_BITSTRING_SIZE = 131072;
+
+    /**
+     * Set a specific bit in a byte array
+     * @param bitstring The byte array containing the bitstring
+     * @param index The index of the bit to set
+     * @param value The value to set (0 or 1)
+     */
+    public static void setBitAtIndex(byte[] bitstring, long index, byte value) {
+        int byteIndex = (int) (index / 8);
+        int bitPosition = (int) (index % 8);
+
+        if (byteIndex >= bitstring.length) {
+            throw new IndexOutOfBoundsException("Index out of bounds for bitstring");
+        }
+
+        if (value == 1) {
+            // Set the bit to 1
+            bitstring[byteIndex] |= (1 << (7 - bitPosition));
+        } else {
+            // Set the bit to 0
+            bitstring[byteIndex] &= ~(1 << (7 - bitPosition));
+        }
+    }
+
+    /**
+     * Check the value of a bit at a specific index
+     * @param bitstring The byte array containing the bitstring
+     * @param index The index of the bit to check
+     * @return true if the bit is 1, false if the bit is 0
+     */
+    public static boolean checkBitAtIndex(byte[] bitstring, long index) {
+        int byteIndex = (int) (index / 8);
+        int bitPosition = (int) (index % 8);
+
+        if (byteIndex >= bitstring.length) {
+            throw new IndexOutOfBoundsException("Index out of bounds for bitstring");
+        }
+
+        return ((bitstring[byteIndex] & (1 << (7 - bitPosition))) != 0);
+    }
+
+    /**
+     * Decompress GZIP compressed byte array
+     */
+    public static byte[] decompressGzip(byte[] compressedBytes) throws IOException {
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(compressedBytes);
+             GZIPInputStream gzipIs = new GZIPInputStream(bais);
+             ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+
+            byte[] buffer = new byte[1024];
+            int len;
+            while ((len = gzipIs.read(buffer)) > 0) {
+                baos.write(buffer, 0, len);
+            }
+            return baos.toByteArray();
+        }
+    }
+
+    /**
+     * Compress a bitstring using GZIP and encode it with Base64url
+     *
+     * @param bitstring The bitstring to compress
+     * @param bitstringSize The size of the bitstring in bits
+     * @return Base64url encoded compressed bitstring
+     * @throws IOException if compression fails
+     */
+    private static String compressBitstring(BitSet bitstring, int bitstringSize) throws IOException {
+        // Convert BitSet to byte array
+        byte[] bitsetBytes = toByteArray(bitstring, bitstringSize);
+
+        // Compress using GZIP
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (GZIPOutputStream gzipOutputStream = new GZIPOutputStream(baos)) {
+            gzipOutputStream.write(bitsetBytes);
+        }
+
+        // Base64url encode (with no padding)
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(baos.toByteArray());
+    }
+
+    /**
+     * Convert BitSet to byte array ensuring proper ordering
+     *
+     * @param bitset The BitSet to convert
+     * @param bitstringSize The size of the bitstring in bits
+     * @return Byte array representation of the bitstring
+     */
+    public static byte[] toByteArray(BitSet bitset, int bitstringSize) {
+        // Calculate bytes needed (bitstringSize / 8, rounded up)
+        int byteSize = (bitstringSize + 7) / 8;
+        byte[] bytes = new byte[byteSize];
+
+        // Convert BitSet to byte array with proper bit ordering
+        for (int i = 0; i < bitstringSize; i++) {
+            if (bitset.get(i)) {
+                // Calculate byte index and bit position within byte
+                int byteIndex = i / 8;
+                int bitPosition = 7 - (i % 8); // MSB ordering within each byte
+                bytes[byteIndex] |= (1 << bitPosition);
+            }
+        }
+
+        return bytes;
+    }
+
+    /**
+     * Expand a compressed bitstring
+     * Implements Section 3.4 of the W3C Bitstring Status List specification
+     *
+     * @param compressedBitstring Base64url encoded compressed bitstring
+     * @return Expanded BitSet
+     * @throws BitstringStatusListException if expansion fails
+     */
+    public static BitSet expandCompressedList(String compressedBitstring) throws BitstringStatusListException {
+        try {
+            // Decode Base64url
+            byte[] compressedBytes = Base64.getUrlDecoder().decode(compressedBitstring);
+
+            // Decompress using GZIP
+            ByteArrayInputStream bais = new ByteArrayInputStream(compressedBytes);
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+            try (GZIPInputStream gzipInputStream = new GZIPInputStream(bais)) {
+                byte[] buffer = new byte[1024];
+                int len;
+                while ((len = gzipInputStream.read(buffer)) != -1) {
+                    baos.write(buffer, 0, len);
+                }
+            }
+
+            byte[] expandedBytes = baos.toByteArray();
+
+            // Convert to BitSet
+            return fromByteArray(expandedBytes);
+        } catch (IOException | IllegalArgumentException e) {
+            throw new BitstringStatusListException("EXPANSION_ERROR",
+                    "Error expanding bitstring: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Convert byte array to BitSet ensuring proper ordering
+     *
+     * @param bytes The byte array to convert
+     * @return BitSet representation
+     */
+    public static BitSet fromByteArray(byte[] bytes) {
+        BitSet bitset = new BitSet(bytes.length * 8);
+
+        // Convert byte array to BitSet with proper bit ordering
+        for (int i = 0; i < bytes.length; i++) {
+            for (int j = 0; j < 8; j++) {
+                if ((bytes[i] & (1 << (7 - j))) != 0) {
+                    bitset.set((i * 8) + j);
+                }
+            }
+        }
+
+        return bitset;
+    }
+}

--- a/certify-service/src/main/java/io/mosip/certify/utils/StatusListUpdaterJob.java
+++ b/certify-service/src/main/java/io/mosip/certify/utils/StatusListUpdaterJob.java
@@ -1,0 +1,237 @@
+package io.mosip.certify.utils;
+
+import io.mosip.certify.entity.CredentialStatus;
+import io.mosip.certify.entity.CredentialStatusTransaction;
+import io.mosip.certify.entity.StatusListCredential;
+import io.mosip.certify.repository.CredentialStatusRepository;
+import io.mosip.certify.repository.CredentialStatusTransactionRepository;
+import io.mosip.certify.repository.StatusListCredentialRepository;
+import io.mosip.certify.services.StatusListCredentialService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Job to update the status list credentials based on credential status transactions
+ * This job runs at configurable intervals to process new status transactions and
+ * regenerate the relevant status list credentials
+ */
+@Slf4j
+@Component
+public class StatusListUpdaterJob {
+
+    @Autowired
+    private CredentialStatusTransactionRepository transactionRepository;
+
+    @Autowired
+    private CredentialStatusRepository credentialStatusRepository;
+
+    @Autowired
+    private StatusListCredentialRepository statusListCredentialRepository;
+
+    @Autowired
+    private StatusListCredentialService statusListCredentialService;
+
+    @Value("${mosip.certify.status-list-update.job.lock-timeout-seconds:300}")
+    private int lockTimeoutSeconds;
+
+    @Value("${mosip.certify.status-list-update.job.batch-size:100}")
+    private int batchSize;
+
+    private LocalDateTime lastProcessedTimestamp = LocalDateTime.now().minusYears(10); // Default to a past date
+
+    /**
+     * Scheduled method that runs at a configurable interval to process credential status transactions
+     * and update status list credentials accordingly
+     */
+    @Scheduled(fixedDelayString = "${mosip.certify.status-list-update.job.interval-ms:3600000}")
+    public void processStatusUpdates() {
+        log.info("Starting status list update job at {}", LocalDateTime.now());
+
+        try {
+            List<CredentialStatusTransaction> newTransactions = fetchNewTransactions();
+
+            if (newTransactions.isEmpty()) {
+                log.info("No new transactions found. Exiting job.");
+                return;
+            }
+
+            log.info("Found {} new transactions to process", newTransactions.size());
+
+            // Process transactions in batches to avoid memory issues with large datasets
+            List<List<CredentialStatusTransaction>> batches = getBatches(newTransactions, batchSize);
+
+            for (List<CredentialStatusTransaction> batch : batches) {
+                processTransactionBatch(batch);
+            }
+
+            updateLastProcessedTimestamp(newTransactions);
+
+            log.info("Status list update job completed successfully at {}", LocalDateTime.now());
+        } catch (Exception e) {
+            log.error("Error occurred while processing status updates", e);
+        }
+    }
+
+    /**
+     * Fetch new transactions that haven't been processed yet
+     *
+     * @return List of new CredentialStatusTransaction objects
+     */
+    private List<CredentialStatusTransaction> fetchNewTransactions() {
+        log.debug("Fetching transactions created after {}", lastProcessedTimestamp);
+        return transactionRepository.findByCreatedDtimesAfterOrderByCreatedDtimes(lastProcessedTimestamp);
+    }
+
+    /**
+     * Process a batch of transactions
+     *
+     * @param transactions List of transactions to process
+     */
+    @Transactional
+    public void processTransactionBatch(List<CredentialStatusTransaction> transactions) {
+        Set<String> affectedStatusListIds = new HashSet<>();
+
+        for (CredentialStatusTransaction transaction : transactions) {
+            try {
+                updateCredentialStatus(transaction);
+
+                if (transaction.getStatusListCredentialId() != null) {
+                    affectedStatusListIds.add(transaction.getStatusListCredentialId());
+                }
+            } catch (Exception e) {
+                log.error("Error processing transaction for credential ID: {}", transaction.getCredentialId(), e);
+            }
+        }
+
+        regenerateAffectedStatusLists(affectedStatusListIds);
+    }
+
+    /**
+     * Update the credential status with transaction data using pessimistic locking
+     *
+     * @param transaction The transaction data to apply
+     */
+    private void updateCredentialStatus(CredentialStatusTransaction transaction) {
+        // Find credential status record with lock for update
+        Optional<CredentialStatus> statusOpt = credentialStatusRepository.findByCredentialIdForUpdate(transaction.getCredentialId());
+
+        if (statusOpt.isPresent()) {
+            CredentialStatus status = statusOpt.get();
+
+            // Update status with transaction data
+            if (transaction.getStatusPurpose() != null) {
+                status.setStatusPurpose(transaction.getStatusPurpose());
+            }
+
+            // Update status value if provided
+            if (transaction.getStatusValue() != null) {
+                status.setStatusValue(transaction.getStatusValue() ? "revoked" : "valid");
+            }
+
+            // Update status list credential ID and index if provided
+            if (transaction.getStatusListCredentialId() != null) {
+                status.setStatusListCredentialId(transaction.getStatusListCredentialId());
+            }
+
+            if (transaction.getStatusListIndex() != null) {
+                status.setStatusListIndex(transaction.getStatusListIndex());
+            }
+
+            // Update timestamp
+            status.setUpdatedDtimes(LocalDateTime.now());
+
+            // Save updated status
+            credentialStatusRepository.save(status);
+            log.debug("Updated credential status for credential ID: {}", transaction.getCredentialId());
+        } else {
+            log.warn("No credential status found for credential ID: {}", transaction.getCredentialId());
+        }
+    }
+
+    /**
+     * Regenerate affected status lists
+     *
+     * @param affectedStatusListIds Set of status list IDs that need to be regenerated
+     */
+    private void regenerateAffectedStatusLists(Set<String> affectedStatusListIds) {
+        log.info("Regenerating {} affected status lists", affectedStatusListIds.size());
+
+        for (String statusListId : affectedStatusListIds) {
+            try {
+                Optional<StatusListCredential> statusListOpt = statusListCredentialRepository.findById(statusListId);
+
+                if (statusListOpt.isPresent()) {
+                    StatusListCredential statusList = statusListOpt.get();
+
+                    List<CredentialStatus> statusEntries = credentialStatusRepository.findByStatusListCredentialId(statusListId);
+
+                    Map<Long, Boolean> statusMap = statusEntries.stream()
+                            .filter(entry -> entry.getStatusListIndex() != null)
+                            .collect(Collectors.toMap(
+                                    CredentialStatus::getStatusListIndex,
+                                    entry -> "revoked".equals(entry.getStatusValue())
+                            ));
+
+                    regenerateStatusListCredential(statusList, statusMap);
+
+                    log.info("Successfully regenerated status list credential: {}", statusListId);
+                } else {
+                    log.warn("Status list credential not found with ID: {}", statusListId);
+                }
+            } catch (Exception e) {
+                log.error("Error regenerating status list credential: {}", statusListId, e);
+            }
+        }
+    }
+
+    /**
+     * Regenerate a status list credential with updated bitstring
+     *
+     * @param statusList The status list credential to update
+     * @param statusMap Map of index to status value (true for revoked, false for valid)
+     */
+    private void regenerateStatusListCredential(StatusListCredential statusList, Map<Long, Boolean> statusMap) {
+        for (Map.Entry<Long, Boolean> entry : statusMap.entrySet()) {
+            statusListCredentialService.updateStatusAtIndex(statusList.getId(), entry.getKey(), entry.getValue());
+        }
+    }
+
+    /**
+     * Split a list into batches of specified size
+     *
+     * @param list The list to split
+     * @param batchSize The maximum size of each batch
+     * @return List of batches
+     */
+    private <T> List<List<T>> getBatches(List<T> list, int batchSize) {
+        List<List<T>> batches = new ArrayList<>();
+        for (int i = 0; i < list.size(); i += batchSize) {
+            batches.add(list.subList(i, Math.min(i + batchSize, list.size())));
+        }
+        return batches;
+    }
+
+    /**
+     * Update the last processed timestamp based on the transactions processed
+     *
+     * @param transactions The transactions that were processed
+     */
+    private void updateLastProcessedTimestamp(List<CredentialStatusTransaction> transactions) {
+        Optional<LocalDateTime> latestTimestamp = transactions.stream()
+                .map(CredentialStatusTransaction::getCreatedDtimes)
+                .max(LocalDateTime::compareTo);
+
+        latestTimestamp.ifPresent(timestamp -> {
+            lastProcessedTimestamp = timestamp;
+            log.debug("Updated last processed timestamp to {}", lastProcessedTimestamp);
+        });
+    }
+}


### PR DESCRIPTION

## Description
This PR implements a scheduled job that runs at configurable intervals to check for credential status changes in the `credential_status_transaction` table and updates the corresponding status list credentials as needed. 

When credentials are revoked or have their status changed, entries are made in the transaction table. This job processes those transactions, updating the relevant status list credentials by regenerating the bitstring with the updated status values, re-signing the VC, and saving it back to the database.

## Changes Made
- Created `StatusListUpdateJob` class that runs on a configurable schedule
- Added repository interface for querying the `credential_status_transaction` table
- Defined `CredentialStatusTransaction` entity class
- Added configuration class to enable scheduled jobs
- Added configuration properties for the job interval and last processed time

## Configuration
The job interval can be configured via the following property in `application-local.properties`:
```
mosip.certify.status-list-update.job.lock-timeout-seconds:300
mosip.certify.status-list-update.job.batch-size:100
mosip.certify.status-list-update.job.interval-ms:3600000
```
The default interval is 1 hour (3600000 ms).