### PR TITLE
INJICERT-1045 - Added did:key support for proof-jwt in API test rig

### DIFF
--- a/api-test/pom.xml
+++ b/api-test/pom.xml
@@ -75,6 +75,12 @@
 		    <artifactId>tink</artifactId>
 		    <version>1.13.0</version>
 		</dependency>
+		<dependency>
+		    <groupId>org.bitcoinj</groupId>
+		    <artifactId>bitcoinj-core</artifactId>
+		    <version>0.15.10</version>
+		</dependency>
+
 	</dependencies>
 		
 	<build>

--- a/api-test/src/main/java/io/mosip/testrig/apirig/injicertify/utils/InjiCertifyUtil.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/injicertify/utils/InjiCertifyUtil.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.PublicKey;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.ECGenParameterSpec;
@@ -23,6 +24,7 @@ import javax.ws.rs.core.MediaType;
 
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
+import org.bitcoinj.core.Base58;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.testng.SkipException;
@@ -1075,6 +1077,23 @@ public class InjiCertifyUtil extends AdminTestUtil {
 
 	    return proofJWT;
 	}
+	
+	public static String generateEd25519DidKey(byte[] rawEd25519PublicKey) {
+	    // Ed25519 public keys are 32 bytes
+	    if (rawEd25519PublicKey == null || rawEd25519PublicKey.length != 32) {
+	        throw new IllegalArgumentException("Invalid Ed25519 public key: must be 32 bytes");
+	    }
+
+	    // Multicodec prefix for Ed25519 (0xED01)
+	    byte[] prefix = new byte[]{(byte) 0xED, 0x01};
+
+	    byte[] combined = new byte[prefix.length + rawEd25519PublicKey.length];
+	    System.arraycopy(prefix, 0, combined, 0, prefix.length);
+	    System.arraycopy(rawEd25519PublicKey, 0, combined, prefix.length, rawEd25519PublicKey.length);
+
+	    return "did:key:z" + Base58.encode(combined);
+	}
+
 
 	
 	public static String signED25519JWT(String clientId, String accessToken, String testCaseName, String tempUrl) {
@@ -1085,12 +1104,25 @@ public class InjiCertifyUtil extends AdminTestUtil {
 		String proofJWT = "";
 //		String typ = "openid4vci-proof+jwt";
 		SignedJWT signedJWT = null;
+		JWSHeader header = null;
 
 		try {
 			OctetKeyPair edJWK = new OctetKeyPairGenerator(Curve.Ed25519).generate();
+			
+			if(testCaseName.contains("_Did_Key_Sign_")) {
+				
+				byte[] rawPublicKey = edJWK.getX().decode();
 
-			JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.Ed25519)
-					.type(new JOSEObjectType("openid4vci-proof+jwt")).jwk(edJWK.toPublicJWK()).build();
+				String didKey = generateEd25519DidKey(rawPublicKey);
+				
+				header = new JWSHeader.Builder(JWSAlgorithm.Ed25519)
+						.type(new JOSEObjectType("openid4vci-proof+jwt")).keyID(didKey).build();
+			}else {
+				header = new JWSHeader.Builder(JWSAlgorithm.Ed25519)
+						.type(new JOSEObjectType("openid4vci-proof+jwt")).jwk(edJWK.toPublicJWK()).build();
+			}
+
+			
 
 			Date currentTime = new Date();
 

--- a/api-test/src/main/resources/injicertify/VCILandRegistry/GetCredentialForLandRegistry/GetCredentialForLandRegistry.yml
+++ b/api-test/src/main/resources/injicertify/VCILandRegistry/GetCredentialForLandRegistry/GetCredentialForLandRegistry.yml
@@ -310,3 +310,27 @@ GetCredentialForLandRegistry:
 }'
       output: '{
 }'
+
+   InjiCertify_GetCredentialForLandRegistry_IdpAccessToken_ED25519_Did_Key_Sign_all_Valid_Smoke:
+      endPoint: $INJICERTIFYBASEURL$/v1/certify/issuance/credential
+      uniqueIdentifier: TC_InjiCertify_GetCredentialForLandRegistry_21
+      description: Get credentials for Land Registry with LandStatementCredential all valid data
+      role: resident
+      checkErrorsOnlyInResponse: true
+      restMethod: post
+      validityCheckRequired: true
+      inputTemplate: injicertify/VCILandRegistry/GetCredentialForLandRegistry/GetCredentialForLandRegistry
+      outputTemplate: injicertify/VCILandRegistry/GetCredentialForLandRegistry/GetCredentialForLandRegistryResult
+      input: '{
+      	"client_id": "$ID:ESignet_CreateOIDCClientV2_ForLandRegistry_all_Valid_Smoke_sid_clientId$",
+        "idpAccessToken": "$ID:ESignet_GenerateToken_ForLandRegistry_Valid_Smoke_sid_access_token$",
+        "format": "ldp_vc",
+      	"type": [{types: "VerifiableCredential"}, {types: "LandStatementCredential"}],
+      	"@context": [{context: "$VCICONTEXTURL$"}],
+      	"proof_type": "jwt",
+        "proof_jwt": "$PROOF_JWT_ED25519$",
+        "credentialType": "LandStatementCredential",
+        "signatureSupported": "Ed25519"
+}'
+      output: '{
+}'


### PR DESCRIPTION
- Added dependency for base58 encoding.
- Added positive testcase for did:key support.
- Modified signED25519JWT method to support did key signing.