### PR TITLE
[INJICERT-1145] Changes to singatureCryptoSuite validation and well-know derivation of credential_signing_alg_values_supported field

### DIFF
--- a/certify-core/src/main/java/io/mosip/certify/core/dto/CredentialConfigurationDTO.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/dto/CredentialConfigurationDTO.java
@@ -33,7 +33,6 @@ public class CredentialConfigurationDTO {
 
     private String signatureAlgo; //Can be called as Proof algorithm
 
-    @NotNull(message = ErrorConstants.INVALID_REQUEST)
     private String signatureCryptoSuite;
 
     private String sdClaim;

--- a/certify-service/src/main/java/io/mosip/certify/validators/credentialconfigvalidators/LdpVcCredentialConfigValidator.java
+++ b/certify-service/src/main/java/io/mosip/certify/validators/credentialconfigvalidators/LdpVcCredentialConfigValidator.java
@@ -9,6 +9,7 @@ public class LdpVcCredentialConfigValidator {
     public static boolean isValidCheck(CredentialConfig credentialConfig) {
         return credentialConfig.getContext() != null && !credentialConfig.getContext().isEmpty()
                 && credentialConfig.getCredentialType() != null && !credentialConfig.getCredentialType().isEmpty()
+                && credentialConfig.getSignatureCryptoSuite() != null && !credentialConfig.getSignatureCryptoSuite().isEmpty()
                 && credentialConfig.getDocType() == null && credentialConfig.getSdJwtVct() == null
                 && credentialConfig.getMsoMdocClaims() == null && credentialConfig.getSdJwtClaims() == null;
     }

--- a/certify-service/src/main/java/io/mosip/certify/validators/credentialconfigvalidators/MsoMdocCredentialConfigValidator.java
+++ b/certify-service/src/main/java/io/mosip/certify/validators/credentialconfigvalidators/MsoMdocCredentialConfigValidator.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 public class MsoMdocCredentialConfigValidator {
     public static boolean isValidCheck(CredentialConfig credentialConfig) {
         return credentialConfig.getDocType() != null && !credentialConfig.getDocType().isEmpty()
+                && credentialConfig.getSignatureCryptoSuite() != null && !credentialConfig.getSignatureCryptoSuite().isEmpty()
                 && credentialConfig.getCredentialType() == null && credentialConfig.getContext() == null
                 && credentialConfig.getSdJwtVct() == null && credentialConfig.getCredentialSubject() == null
                 && credentialConfig.getSdJwtClaims() == null;

--- a/certify-service/src/main/java/io/mosip/certify/validators/credentialconfigvalidators/SdJwtCredentialConfigValidator.java
+++ b/certify-service/src/main/java/io/mosip/certify/validators/credentialconfigvalidators/SdJwtCredentialConfigValidator.java
@@ -11,7 +11,7 @@ public class SdJwtCredentialConfigValidator {
                 && credentialConfig.getSignatureAlgo() != null && !credentialConfig.getSignatureAlgo().isEmpty()
                 && credentialConfig.getCredentialType() == null && credentialConfig.getContext() == null
                 && credentialConfig.getDocType() == null && credentialConfig.getCredentialSubject() == null &&
-                credentialConfig.getMsoMdocClaims() == null;
+                credentialConfig.getMsoMdocClaims() == null && credentialConfig.getSignatureCryptoSuite() == null;
     }
 
     public static boolean isConfigAlreadyPresent(CredentialConfig credentialConfig,

--- a/certify-service/src/test/java/io/mosip/certify/services/CredentialConfigurationServiceImplTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/CredentialConfigurationServiceImplTest.java
@@ -262,6 +262,55 @@ public class CredentialConfigurationServiceImplTest {
     }
 
     @Test
+    public void fetchCredentialIssuerMetadata_SigningAlgValuesSupported_UsesSignatureAlgo_WhenCryptoSuiteIsNull() {
+        CredentialConfig config = new CredentialConfig();
+        config.setConfigId(UUID.randomUUID().toString());
+        config.setCredentialConfigKeyId("test-credential");
+        config.setStatus("active");
+        config.setCredentialFormat("ldp_vc");
+        config.setSignatureCryptoSuite(null); // triggers else branch
+        config.setSignatureAlgo("ES256");
+        config.setCredentialSubject(null);
+
+        when(credentialConfigRepository.findAll()).thenReturn(List.of(config));
+        CredentialConfigurationDTO dto = new CredentialConfigurationDTO();
+        dto.setCredentialFormat("ldp_vc");
+        when(credentialConfigMapper.toDto(config)).thenReturn(dto);
+
+
+        CredentialIssuerMetadataDTO result = credentialConfigurationService.fetchCredentialIssuerMetadata("latest");
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.getCredentialConfigurationSupportedDTO().containsKey("test-credential"));
+        CredentialConfigurationSupportedDTO supportedDTO = result.getCredentialConfigurationSupportedDTO().get("test-credential");
+        Assert.assertEquals(List.of("ES256"), supportedDTO.getCredentialSigningAlgValuesSupported());
+    }
+
+    @Test
+    public void fetchCredentialIssuerMetadata_SigningAlgValuesSupported_UsesSignatureAlgo_WhenCryptoSuiteIsNull_SdJwtFormat() {
+        CredentialConfig config = new CredentialConfig();
+        config.setConfigId(UUID.randomUUID().toString());
+        config.setCredentialConfigKeyId("sdjwt-credential");
+        config.setStatus("active");
+        config.setCredentialFormat("vc+sd-jwt");
+        config.setSignatureCryptoSuite(null); // triggers else branch
+        config.setSignatureAlgo("ES256");
+        config.setSdJwtVct("test-vct");
+
+        when(credentialConfigRepository.findAll()).thenReturn(List.of(config));
+        CredentialConfigurationDTO dto = new CredentialConfigurationDTO();
+        dto.setCredentialFormat("vc+sd-jwt");
+        when(credentialConfigMapper.toDto(config)).thenReturn(dto);
+
+        CredentialIssuerMetadataDTO result = credentialConfigurationService.fetchCredentialIssuerMetadata("latest");
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.getCredentialConfigurationSupportedDTO().containsKey("sdjwt-credential"));
+        CredentialConfigurationSupportedDTO supportedDTO = result.getCredentialConfigurationSupportedDTO().get("sdjwt-credential");
+        Assert.assertEquals(List.of("ES256"), supportedDTO.getCredentialSigningAlgValuesSupported());
+    }
+
+    @Test
     public void fetchCredentialIssuerMetadata_vd11Version() {
         // Setup minimal test data
         List<CredentialConfig> credentialConfigList = List.of(credentialConfig);
@@ -435,7 +484,7 @@ public class CredentialConfigurationServiceImplTest {
             CertifyException ex = assertThrows(CertifyException.class, () ->
                     ReflectionTestUtils.invokeMethod(credentialConfigurationService, "validateCredentialConfiguration", config, true)
             );
-            assertEquals("Context and credentialType are mandatory for ldp_vc format", ex.getMessage());
+            assertEquals("Context, credentialType and signatureCryptoSuite are mandatory for ldp_vc format", ex.getMessage());
         }
     }
 
@@ -464,7 +513,7 @@ public class CredentialConfigurationServiceImplTest {
             CertifyException ex = assertThrows(CertifyException.class, () ->
                     ReflectionTestUtils.invokeMethod(credentialConfigurationService, "validateCredentialConfiguration", config, true)
             );
-            assertEquals("Doctype field is mandatory for mso_mdoc format", ex.getMessage());
+            assertEquals("Doctype and signatureCryptoSuite fields are mandatory for mso_mdoc format", ex.getMessage());
         }
     }
 

--- a/certify-service/src/test/java/io/mosip/certify/validators/credentialconfigvalidators/LdpVcCredentialConfigValidatorTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/validators/credentialconfigvalidators/LdpVcCredentialConfigValidatorTest.java
@@ -22,6 +22,15 @@ class LdpVcCredentialConfigValidatorTest {
     }
 
     @Test
+    void testIsValidCheck_missingSignatureCryptoSuite_returnsFalse() {
+        CredentialConfig config = new CredentialConfig();
+        config.setContext("https://example.org/context");
+        config.setCredentialType("VerifiableCredential,TestVerifiableCredential");
+        config.setSignatureCryptoSuite(null);
+        assertFalse(LdpVcCredentialConfigValidator.isValidCheck(config));
+    }
+
+    @Test
     void testIsValidCheck_allValidFields_returnsTrue() {
         CredentialConfig config = new CredentialConfig();
         config.setContext("https://example.org/context");

--- a/certify-service/src/test/java/io/mosip/certify/validators/credentialconfigvalidators/MsoMdocCredentialConfigValidatorTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/validators/credentialconfigvalidators/MsoMdocCredentialConfigValidatorTest.java
@@ -55,6 +55,22 @@ class MsoMdocCredentialConfigValidatorTest {
     }
 
     @Test
+    void testIsValidCheck_missingSignatureCryptoSuite_returnsFalse() {
+        CredentialConfig config = new CredentialConfig();
+        config.setDocType("docType");
+        config.setSignatureCryptoSuite(null);
+        assertFalse(MsoMdocCredentialConfigValidator.isValidCheck(config));
+    }
+
+    @Test
+    void testIsValidCheck_emptySignatureCryptoSuite_returnsFalse() {
+        CredentialConfig config = new CredentialConfig();
+        config.setDocType("docType");
+        config.setSignatureCryptoSuite("");
+        assertFalse(MsoMdocCredentialConfigValidator.isValidCheck(config));
+    }
+
+    @Test
     void testIsValidCheck_credentialTypeNotNull_returnsFalse() {
         CredentialConfig config = new CredentialConfig();
         config.setDocType("docType");

--- a/certify-service/src/test/java/io/mosip/certify/validators/credentialconfigvalidators/SdJwtCredentialConfigValidatorTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/validators/credentialconfigvalidators/SdJwtCredentialConfigValidatorTest.java
@@ -127,5 +127,23 @@ class SdJwtCredentialConfigValidatorTest {
                 .thenReturn(Optional.empty());
         assertFalse(SdJwtCredentialConfigValidator.isConfigAlreadyPresent(config, repo));
     }
+
+    @Test
+    void testIsValidCheck_msoMdocClaimsNotNull_returnsFalse() {
+        CredentialConfig config = new CredentialConfig();
+        config.setSdJwtVct("vctValue");
+        config.setSignatureAlgo("algoValue");
+        config.setMsoMdocClaims(new HashMap<>());
+        assertFalse(SdJwtCredentialConfigValidator.isValidCheck(config));
+    }
+
+    @Test
+    void testIsValidCheck_signatureCryptoSuiteNotNull_returnsFalse() {
+        CredentialConfig config = new CredentialConfig();
+        config.setSdJwtVct("vctValue");
+        config.setSignatureAlgo("algoValue");
+        config.setSignatureCryptoSuite("suiteValue");
+        assertFalse(SdJwtCredentialConfigValidator.isValidCheck(config));
+    }
 }
 


### PR DESCRIPTION
Made singatureCryptoSuite non-mandatory for sdJwt format and fixed derivation of credential_signing_alg_values_supported when singatureCryptoSuite field is missing incase of sdJWT