### PR TITLE
[INJICERT-1153] Add docs for newly added features, update docker-compose setup ReadMe and update postman collections 

### DIFF
--- a/docker-compose/docker-compose-injistack/README.md
+++ b/docker-compose/docker-compose-injistack/README.md
@@ -84,7 +84,7 @@ public interface VCIssuancePlugin {
 
 ## Certificate Setup
 
-**Note**: This step is required only if you are using the Inji Web application or Mimoto as a BFF for your usecase.
+**Note**: This step is required only if you are using the Inji Web application for your usecase.
 
 - Create a `certs/` directory inside the docker-compose-injistack directory.
 - Place your PKCS12 keystore file in the `certs` directory as `oidckeystore.p12`. This is required for the Inji Web application and other applications which rely on Mimoto as a BFF and it can be configured as per these [docs](https://docs.inji.io/inji-wallet/inji-mobile/technical-overview/customization-overview/credential_providers#onboarding-mimoto-as-oidc-client-for-a-new-issuer) after the file is downloaded in the `certs` directory as shown in the directory tree.
@@ -126,7 +126,7 @@ Ensure all configuration files are properly updated in the config directory if y
 - certify-default.properties
 - certify-csvdp-farmer.properties
 
-Following files are optional and can be used to configure the Mimoto service for your usecase, if you are not using Mimoto, you can skip these files:
+Following files are optional and can be used to configure the Inji Web application for your usecase, if you are not using web application, you can skip these files:
 
 - mimoto-default.properties
 - mimoto-issuers-config.json

--- a/docker-compose/docker-compose-injistack/README.md
+++ b/docker-compose/docker-compose-injistack/README.md
@@ -26,7 +26,7 @@ You have two options for the certify plugin which gives Verifiable Credentials o
 
 ## Directory Structure Setup
 
-Create the following directory structure before proceeding:
+Create the following directory structure in your local codebase before proceeding inside the `docker-compose` directory:
 
 ```
 docker-compose-injistack/
@@ -84,6 +84,8 @@ public interface VCIssuancePlugin {
 
 ## Certificate Setup
 
+**Note**: This step is required only if you are using the Inji Web application or Mimoto as a BFF for your usecase.
+
 - Create a `certs/` directory inside the docker-compose-injistack directory.
 - Place your PKCS12 keystore file in the `certs` directory as `oidckeystore.p12`. This is required for the Inji Web application and other applications which rely on Mimoto as a BFF and it can be configured as per these [docs](https://docs.inji.io/inji-wallet/inji-mobile/technical-overview/customization-overview/credential_providers#onboarding-mimoto-as-oidc-client-for-a-new-issuer) after the file is downloaded in the `certs` directory as shown in the directory tree.
 - Update `mosip.oidc.p12.password` to the password of the `oidckeystore.p12` file in the Mimoto [Config file](./config/mimoto-default.properties).
@@ -123,6 +125,9 @@ Ensure all configuration files are properly updated in the config directory if y
 
 - certify-default.properties
 - certify-csvdp-farmer.properties
+
+Following files are optional and can be used to configure the Mimoto service for your usecase, if you are not using Mimoto, you can skip these files:
+
 - mimoto-default.properties
 - mimoto-issuers-config.json
 - mimoto-trusted-verifiers.json
@@ -133,6 +138,8 @@ Ensure all configuration files are properly updated in the config directory if y
 ## Running the Application
 
 ### Start the Services
+
+**Note** : In case you want to access only certify service, you can modify the docker-compose.yaml to remove the other services and run only the `certify` service.
 
 ```bash
 docker-compose up -d
@@ -164,7 +171,7 @@ The following services will be available:
     - View credential status at a Standards Compliant VC Verfier such as [Inji Verify](https://injiverify.collab.mosip.net).
 3. As a sample, you can try downloading VC with the UIN `5860356276` or `2154189532`. The OTP for this purpose can be given as `111111` which is the Mock OTP for eSignet Collab Environment. The above sample identities should be present at both the Identity Provider(here, National ID) and at the Local Issuer(here, Agriculture Department or Transport Department).
 
-### Advanced Users: Accessing the Credentials via the Postman Interface
+### Running only certify service - Accessing the Credentials via the Postman Interface
 
 1. Open Postman
 2. Import the [Mock Collections & Environments](../../docs/postman-collections/) from here, make appropriate changes to the Credential Type and contexts as per your VerifiableCredential and the configured WellKnown.
@@ -172,6 +179,8 @@ The following services will be available:
     - Download credentials
     - View credential status
     - Manage your digital identity
+
+Refer to [API documentation](https://mosip.stoplight.io/docs/inji-certify) for detailed usage instructions and examples.
 
 
 ## Advanced Configurations

--- a/docs/Credential-Issuer-Configuration.md
+++ b/docs/Credential-Issuer-Configuration.md
@@ -1,0 +1,71 @@
+# Credential Configuration
+
+This guide explains how to manage (add, update, view, and delete) credential configurations in the Inji Certify service. These configurations tell Inji Certify how to issue different types of Verifiable Credentials using various formats and settings.
+
+## What is a Credential Configuration?
+
+A credential configuration defines the rules and details for issuing a specific type of digital credential. For example, it specifies the format, signing method, and any templates or types needed for the credential.
+
+## Why is this important?
+
+Before Inji Certify can issue a new type of credential, you need to define its configuration using the API endpoints described below. Additionally, this configuration will be used in openid-credential-issuer metadata to help clients understand how to interact with the credential issuer. This is crucial for ensuring that the credentials are issued correctly and can be verified by other systems.
+
+---
+
+## Available API Endpoints
+
+You can use these endpoints to manage your credential configurations:
+
+1. **Add a New Configuration**
+    - **POST** `/credential-configurations`
+    - Use this to create a new credential configuration.
+    - You must provide all required details in the request body.
+
+2. **Get a Configuration by ID**
+    - **GET** `/credential-configurations/{credentialConfigKeyId}`
+    - Use this to view the details of a specific configuration.
+
+3. **Update an Existing Configuration**
+    - **PUT** `/credential-configurations/{credentialConfigKeyId}`
+    - Use this to change the details of an existing configuration.
+
+4. **Delete a Configuration**
+    - **DELETE** `/credential-configurations/{credentialConfigKeyId}`
+    - Use this to remove a configuration you no longer need.
+
+---
+
+## What Information Do You Need to Provide?
+
+When adding or updating a configuration, you need to send a JSON object with details related to the credential format you are configuring. The required fields depend on the credential format (e.g., `ldp_vc`, `mso_mdoc`, `vc+sd-jwt`). For more details regarding the API fields and examples, refer to the [Inji Certify API docs](https://mosip.stoplight.io/docs/inji-certify).
+
+---
+
+## Configuration Properties
+
+The Inji Certify uses several configuration properties to control how credential configurations work. These are typically set in your `application.properties` or `application.yml` file.
+
+| Property Name                                                          | Description                                                                              | Example Value                                                                                                                                                                                                                                                                                     |
+|------------------------------------------------------------------------|------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `mosip.certify.data-provider-plugin.credential-status.supported-purposes` | List of supported credential status purposes. Default value 'revocation'.                | `["suspension", "revocation"]`                                                                                                                                                                                                                                                                    |
+| `mosip.certify.credential-config.cryptographic-binding-methods-supported` | Supported cryptographic binding methods per credential format.                           | `{ 'ldp_vc': {'did:jwk','did:key'}, 'mso_mdoc': {'cose_key'},'vc+sd-jwt': {'did:jwk','did:key'} }`                                                                                                                                                                                                |
+| `mosip.certify.credential-config.credential-signing-alg-values-supported` | Supported signing algorithms per crypto suite.                                           | `{ 'RsaSignature2018': {'RS256'}, 'Ed25519Signature2018': {'EdDSA'}, 'Ed25519Signature2020': {'EdDSA'}, 'EcdsaKoblitzSignature2016': {'ES256K'}, 'EcdsaSecp256k1Signature2019': {'ES256K'}, 'EcdsaSecp256r1Signature2019': {'ES256'}, 'ecdsa-rdfc-2019': {'ES256'}, 'ecdsa-jcs-2019': {'ES256'}}` |
+| `mosip.certify.credential-config.proof-types-supported`                | Supported proof types for credentials.                                                   | `{'jwt': {'proof_signing_alg_values_supported': {'RS256', 'PS256', 'ES256', 'EdDSA'}}}`                                                                                                                                                                                                           |
+
+## Validations and Rules
+
+**Note** : 
+In case of VCIssuance plugin mode, `ldp_vc` and `mso_mdoc` formats are supported by credential-configurations endpoints. 
+In case of DataProviderPlugin mode, `ldp_vc` and `vc+sd-jwt` formats are supported by credential-configurations endpoints.
+
+Inji Certify checks your configuration for required fields and possible duplicates:
+
+- **Required fields** depend on the credential format.
+- **No duplicate configurations**: You cannot add two configurations with the same key details. For example, 
+  - for `ldp_vc` format, combination of context & type should be unique. 
+  - for `mso_mdoc` format, docType value should be unique.
+  - for `vc+sd-jwt` format, sdJwtVct value should be unique.
+
+If you miss a required field or try to add a duplicate, Certify will return an error.
+
+---

--- a/docs/Data-Integrity-Proof-Support.md
+++ b/docs/Data-Integrity-Proof-Support.md
@@ -1,0 +1,35 @@
+# Data Integrity Proof Data Feature
+
+## Overview
+
+The Data Integrity Proof suite provides cryptographic proof mechanisms for Verifiable Credentials (VCs) using the Data Integrity Proof standard. This feature is essential for ensuring the authenticity and integrity of credentials issued by Inji Certify.
+
+
+## Supported Algorithms
+
+The following signature algorithms are supported by the `Data Integrity Proof` suite:
+
+- **ecdsa-rdfc-2019**
+- **ecdsa-jcs-2019**
+- **eddsa-rdfc-2022**
+- **eddsa-jcs-2022**
+
+Supported signature algorithms for these crypto suites include: 
+- **ES256** (ECDSA using P-256 and SHA-256)
+- **ES256K** (ECDSA using secp256k1 and SHA-256)
+- **EdDSA** (Edwards-Curve Digital Signature Algorithm)
+
+> **Note:** The list of supported algorithms may be extended in future releases. Always refer to the latest [API documentation](https://mosip.stoplight.io/docs/inji-certify) for updates.
+
+## Usage Notes
+
+- The `signatureCryptoSuite` property must be set to one of supported Data Integrity proof algorithms in the credential configuration to use this suite.
+- The `signatureAlgo` property is mandatory and must match one of the supported algorithms. For example, signatureAlgo should be set to `ES256` or `ES256K` for supporting `ecdsa-rdfc-2019`, `ecdsa-jcs-2019` crypto suites.
+- If an unsupported algorithm is provided, Inji Certify will return an error during configuration validation.
+
+## References
+
+- [W3C Data Integrity Proofs](https://www.w3.org/TR/vc-data-integrity/)
+- [Inji Certify Credential Issuer Configuration](./Credential-Issuer-Configuration.md)
+
+---

--- a/docs/Data-Integrity-Proof-Support.md
+++ b/docs/Data-Integrity-Proof-Support.md
@@ -32,16 +32,14 @@ sequenceDiagram
     participant DataProviderPlugin as 🔌 Data Provider Plugin
     participant VelocityTemplatingEngine as ⚙️ Velocity Templating Engine
     participant W3CJsonLdCredential as 🔐 W3CJsonLdCredential
-    participant CertifyKeyChooser as 🔑 CertifyKeyChooser
-    participant DanubetechDataIntegrity as 🛡️ Danubetech Lib
-    participant CertifyProofGenerators as 📝 Proof Generators
+    participant DataIntegrityLib as 🛡️ DataIntegrity Lib
     participant KeyManager as ✍️ KeyManager
     end
 
     Client->>CredentialAPI: Request VC Issuance (format: ldp_vc)
 
     CredentialAPI->>CredentialConfiguration: Validate request & get config
-    CredentialConfiguration-->>CredentialAPI: Return success & config (with signatureCryptosuite)
+    CredentialConfiguration-->>CredentialAPI: Return success & config (with signatureCryptoSuite)
 
     CredentialAPI->>DataProviderPlugin: Request data
     DataProviderPlugin-->>CredentialAPI: Return raw data
@@ -53,23 +51,11 @@ sequenceDiagram
 
     CredentialAPI->>W3CJsonLdCredential: addProof()
 
-    W3CJsonLdCredential->>CertifyKeyChooser: Get proof object
-    CertifyKeyChooser->>CredentialConfiguration: Read signatureCryptosuite
-    CredentialConfiguration-->>CertifyKeyChooser: Return signatureCryptosuite value
+    W3CJsonLdCredential->>DataIntegrityLib: Generate DataIntegrityProof (with signatureCryptoSuite)
+    DataIntegrityLib->>KeyManager: Sign credential data
+    KeyManager-->>DataIntegrityLib: Return signature
+    DataIntegrityLib-->>W3CJsonLdCredential: Return DataIntegrityProof object
 
-    alt signatureCryptosuite indicates Data Integrity
-        CertifyKeyChooser->>DanubetechDataIntegrity: Generate DataIntegrityProof
-        DanubetechDataIntegrity->>KeyManager: Sign credential data
-        KeyManager-->>DanubetechDataIntegrity: Return signature
-        DanubetechDataIntegrity-->>CertifyKeyChooser: Return DataIntegrityProof object
-    else Normal Proof
-        CertifyKeyChooser->>CertifyProofGenerators: Generate JsonLdProof
-        CertifyProofGenerators->>KeyManager: Sign credential data
-        KeyManager-->>CertifyProofGenerators: Return signature
-        CertifyProofGenerators-->>CertifyKeyChooser: Return JsonLdProof object
-    end
-
-    CertifyKeyChooser-->>W3CJsonLdCredential: Return final proof object
     W3CJsonLdCredential-->>CredentialAPI: Return signed VC with proof
 
     CredentialAPI-->>Client: Return final ldp_vc

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,10 @@
 
 - [Local Development](./Local-Development.md)
 - [How to decide b/w VCIssuance & DataProviderPlugin while writing your own](./VCIssuance-vs-DataProvider.md)
+- [Adding credential configuration to Inji Certify](./Credential-Issuer-Configuration.md)
+- [SD-JWT VC Support](./SD-JWT-Support.md)
+- [Data Integrity Proof Support](./Data-Integrity-Proof-Support.md)
+- [VC Revocation Support](./VC-Revocation-Support.md)
 
 # Integrator READMEs
 

--- a/docs/SD-JWT-Support.md
+++ b/docs/SD-JWT-Support.md
@@ -1,0 +1,56 @@
+# SD-JWT Credential Support
+
+This document explains how to configure and use SD-JWT (Selective Disclosure JWT) credential format in the Inji Certify service.
+
+---
+
+## 1. How to Configure SD-JWT Credentials
+
+To add a new SD-JWT credential configuration, use the `/credential-configurations` endpoint with the following important fields in your JSON payload:
+
+- **credentialFormat**: Must be set to `vc+sd-jwt`
+- **signatureAlgo**: The signing algorithm (e.g., `ES256K`)
+- **sdJwtVct**: The VCT (Verifiable Credential Type) value for the credential
+
+For full details on the required fields and how to structure your request with examples, refer to the [Inji Certify API documentation](https://mosip.stoplight.io/docs/inji-certify).
+
+---
+
+## 2. Specific Configurations Required
+
+Add the following properties to your `application.yml` or `application.properties` to enable and control SD-JWT support:
+
+| Property Name                                                          | Description                                                                                                                                                               | Example Value                                       |
+|------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------|
+| `mosip.certify.credential-config.credential-signing-alg-values-supported` | Supported signing algorithms for SD-JWT                                                                                                                                   | `{ EC_SECP256K1_SIGN: [ "ES256K" ] }`               |
+| `mosip.certify.credential-config.proof-types-supported`                | Supported proof types for SD-JWT                                                                                                                                          | `{ vc+sd-jwt: [ "JWTProof" ] }`                     |
+| `mosip.certify.credential-config.cryptographic-binding-methods-supported` | Supported binding methods for SD-JWT                                                                                                                                      | `{ vc+sd-jwt: [ "did:jwk", "did:key" ] }`           |
+| `mosip.certify.data-provider-plugin.did-url` | The base Decentralized Identifier document URL used by the data provider plugin to resolve and bind DIDs for credential issuance.                                         | `did:web:someuser.github.io:somerepo:somedirectory` |
+|`mosip.kernel.keymanager.signature.kid.prepend`| The prefix to prepend to the `kid` field in SD-JWT credentials. This is useful for ensuring unique key identifiers across different systems. Default value will be blank. | `#`, `<DOMAIN_NAME>#` or `PAYLOAD_ISSUER`                           |
+---
+
+## 3. Configuring `kid` and DID Binding
+
+### `kid` (Key ID)
+- The `kid` field identifies the key used to sign the SD-JWT credential.
+- It should be a URI or DID fragment (e.g., `did:example:123#key-1`).
+- If not provided, the system may use a default key.
+- You can configure the `kid` prefix using the property `mosip.kernel.keymanager.signature.kid.prepend` to ensure uniqueness across different credentials.
+  - if you set it to `#`, the `kid` will be prefixed with `#`. example: `#<KEY_ID>`
+  - if you set it to `<DOMAIN_NAME>#`, the `kid` will be prefixed with the domain name followed by `#`. example: `example.com#<KEY_ID>`
+  - if you set it to `PAYLOAD_ISSUER`, the `kid` will be prefixed with the issuer of the payload. example: `did:example:123#<KEY_ID>`
+
+### DID Binding
+- DID binding ensures the credential is cryptographically linked to a Decentralized Identifier (DID).
+- The supported binding methods for SD-JWT are `did:jwk` and `did:key` (see configuration above).
+- In the final SD-JWT credential, the `cnf` field in payload will contain the holderId in the following format : 
+{... cnf": { "kid": "did:jwk:<HOLDER_ID>" ... }}
+
+---
+
+## Notes
+
+- Ensure your signing keys, DIDs are properly registered and accessible to the Certify service.
+- For more details on the API, see the [Inji Certify API docs](https://mosip.stoplight.io/docs/inji-certify).
+
+---

--- a/docs/SD-JWT-Support.md
+++ b/docs/SD-JWT-Support.md
@@ -20,21 +20,19 @@ For full details on the required fields and how to structure your request with e
 
 Add the following properties to your `application.yml` or `application.properties` to enable and control SD-JWT support:
 
-| Property Name                                                          | Description                                                                                                                                                               | Example Value                                       |
-|------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------|
-| `mosip.certify.credential-config.credential-signing-alg-values-supported` | Supported signing algorithms for SD-JWT                                                                                                                                   | `{ EC_SECP256K1_SIGN: [ "ES256K" ] }`               |
-| `mosip.certify.credential-config.proof-types-supported`                | Supported proof types for SD-JWT                                                                                                                                          | `{ vc+sd-jwt: [ "JWTProof" ] }`                     |
-| `mosip.certify.credential-config.cryptographic-binding-methods-supported` | Supported binding methods for SD-JWT                                                                                                                                      | `{ vc+sd-jwt: [ "did:jwk", "did:key" ] }`           |
+| Property Name                                                          | Description                                                                                                                                                               | Example Value                                      |
+|------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------|
+| `mosip.certify.credential-config.credential-signing-alg-values-supported` | Supported signing algorithms for SD-JWT                                                                                                                                   | `{ 'RsaSignature2018': {'RS256'}, 'Ed25519Signature2018': {'EdDSA'}, 'Ed25519Signature2020': {'EdDSA'}, 'EcdsaKoblitzSignature2016': {'ES256K'}, 'EcdsaSecp256k1Signature2019': {'ES256K'}, 'EcdsaSecp256r1Signature2019': {'ES256'}, 'ecdsa-rdfc-2019': {'ES256'}, 'ecdsa-jcs-2019': {'ES256'}}`              |
+| `mosip.certify.credential-config.proof-types-supported`                | Supported proof types for SD-JWT                                                                                                                                          | `{'jwt': {'proof_signing_alg_values_supported': {'RS256', 'PS256', 'ES256', 'EdDSA'}}}`                     |
+| `mosip.certify.credential-config.cryptographic-binding-methods-supported` | Supported binding methods for SD-JWT                                                                                                                                      | `{ 'ldp_vc': {'did:jwk','did:key'}, 'mso_mdoc': {'cose_key'},'vc+sd-jwt': {'did:jwk','did:key'} }`          |
 | `mosip.certify.data-provider-plugin.did-url` | The base Decentralized Identifier document URL used by the data provider plugin to resolve and bind DIDs for credential issuance.                                         | `did:web:someuser.github.io:somerepo:somedirectory` |
-|`mosip.kernel.keymanager.signature.kid.prepend`| The prefix to prepend to the `kid` field in SD-JWT credentials. This is useful for ensuring unique key identifiers across different systems. Default value will be blank. | `#`, `<DOMAIN_NAME>#` or `PAYLOAD_ISSUER`                           |
+|`mosip.kernel.keymanager.signature.kid.prepend`| The prefix to prepend to the `kid` field in SD-JWT credentials. This is useful for ensuring unique key identifiers across different systems. Default value will be blank. | `#`, `<DOMAIN_NAME>#` or `PAYLOAD_ISSUER`                          |
 ---
 
 ## 3. Configuring `kid` and DID Binding
 
 ### `kid` (Key ID)
-- The `kid` field identifies the key used to sign the SD-JWT credential.
-- It should be a URI or DID fragment (e.g., `did:example:123#key-1`).
-- If not provided, the system may use a default key.
+- The `kid` field identifies the keyID of the certificate that is used for signing the VC.
 - You can configure the `kid` prefix using the property `mosip.kernel.keymanager.signature.kid.prepend` to ensure uniqueness across different credentials.
   - if you set it to `#`, the `kid` will be prefixed with `#`. example: `#<KEY_ID>`
   - if you set it to `<DOMAIN_NAME>#`, the `kid` will be prefixed with the domain name followed by `#`. example: `example.com#<KEY_ID>`

--- a/docs/SD-JWT-Support.md
+++ b/docs/SD-JWT-Support.md
@@ -29,6 +29,43 @@ Add the following properties to your `application.yml` or `application.propertie
 |`mosip.kernel.keymanager.signature.kid.prepend`| The prefix to prepend to the `kid` field in SD-JWT credentials. This is useful for ensuring unique key identifiers across different systems. Default value will be blank. | `#`, `<DOMAIN_NAME>#` or `PAYLOAD_ISSUER`                          |
 ---
 
+## 3. Sequence Diagram for SD-JWT Credential Issuance
+
+```mermaid
+sequenceDiagram
+    participant Client as 🌐 Client
+    box Inji Certify #E6F3FF
+    participant CredentialAPI as 🔗 Credential API
+    participant CredentialConfiguration as ⚙️ Credential Configuration
+    participant DataProviderPlugin as 🔌 Data Provider Plugin
+    participant VelocityTemplatingEngine as ⚙️ Velocity Templating Engine
+    participant SDJWTCredential as 🔐 SDJWTCredential
+    end
+
+    Client->>CredentialAPI: Request VC Issuance (format: vc+sd-jwt)
+
+    CredentialAPI->>CredentialConfiguration: Validate VC request & get template
+    CredentialConfiguration-->>CredentialAPI: Return validation success & template
+
+    CredentialAPI->>DataProviderPlugin: Request data
+    DataProviderPlugin-->>CredentialAPI: Return raw data
+
+    CredentialAPI->>VelocityTemplatingEngine: Format raw data with template
+    VelocityTemplatingEngine-->>CredentialAPI: Return formatted credential data
+
+    CredentialAPI->>SDJWTCredential: Instantiate with formatted data
+
+    CredentialAPI->>SDJWTCredential: createCredential()
+    note right of SDJWTCredential: Generates the SD-JWT structure with disclosures.
+    SDJWTCredential-->>CredentialAPI: Return unsigned SD-JWT credential
+
+    CredentialAPI->>SDJWTCredential: addProof(unsigned credential)
+    note right of SDJWTCredential: Signs the JWT and adds the final proof alongwith disclosures.
+    SDJWTCredential-->>CredentialAPI: Return signed vc+sd-jwt
+
+    CredentialAPI-->>Client: Return final vc+sd-jwt
+```
+
 ## 3. Configuring `kid` and DID Binding
 
 ### `kid` (Key ID)

--- a/docs/SD-JWT-Support.md
+++ b/docs/SD-JWT-Support.md
@@ -66,7 +66,7 @@ sequenceDiagram
     CredentialAPI-->>Client: Return final vc+sd-jwt
 ```
 
-## 3. Configuring `kid` and DID Binding
+## 4. Configuring `kid` and DID Binding
 
 ### `kid` (Key ID)
 - The `kid` field identifies the keyID of the certificate that is used for signing the VC.

--- a/docs/VC-Revocation-Support.md
+++ b/docs/VC-Revocation-Support.md
@@ -1,0 +1,173 @@
+
+# VC Revocation Feature
+
+**Note**: This feature is currently in experimental mode and may change in future releases.
+
+This document explains how the Credential Status feature works in Inji Certify. This feature lets you revoke or suspend verifiable credentials (VCs) in a privacy-preserving and scalable way, using a W3C-compliant status list.
+
+---
+
+## Overview
+
+With this feature, the system can:
+
+- Issue and manage [BitstringStatusListCredential](https://www.w3.org/TR/vc-bitstring-status-list/) credentials.
+- Assign and track a unique status index for each credential.
+- Update the status of credentials (for example, to revoke or suspend them).
+- Store and retrieve status information efficiently.
+- Add status information directly into each issued credential.
+
+---
+
+## Key Data and Storage
+
+- **Status List Credential**: Stores the status list, its purpose (like revocation), and its current state.
+- **Ledger**: Keeps a record of each issued credential, including its status and searchable attributes.
+- **Credential Status Transaction**: Logs every status change (such as a revocation) for tracking and audit.
+
+**Database tables used:**
+
+- `status_list_credential`
+- `status_list_available_indices`
+- `ledger`
+- `credential_status_transaction`
+
+---
+
+## Status List Credential Structure
+
+A status list credential is a special Verifiable Credential with this structure:
+
+```json
+{
+  ....
+    "@context": [
+       "https://www.w3.org/ns/credentials/v2"
+    ],
+  "credentialStatus": {
+    "statusPurpose": "revocation",
+    "statusListIndex": "10",
+    "id": "https://some.example-service.com/v1/certify/status-list/45564e0c-27c9-4a83-bc87-a0ad1bce79d1#10",
+    "type": "BitstringStatusListEntry",
+    "statusListCredential": "https://some.example-service.com/v1/certify/status-list/45564e0c-27c9-4a83-bc87-a0ad1bce79d1"
+  },
+  "proof": { ... },
+  ...
+}
+```
+
+---
+
+## How It Works
+
+### 1. Issuing a Credential with Status
+
+- When a new credential is issued, the system:
+    - Finds or creates a status list for the required purpose (like revocation).
+    - Assigns the next available index in the list to the credential.
+    - Adds a `credentialStatus` section to the credential, for example:
+      ```json
+      "credentialStatus": {
+        "id": "<status-list-url>#<index>",
+        "type": "BitstringStatusListEntry",
+        "statusPurpose": "<revocation>",
+        "statusListIndex": "<index>",
+        "statusListCredential": "<status-list-url>"
+      }
+      ```
+    - Saves the credential and its status details in the ledger.
+
+### 2. Retrieving a Status List
+
+- You can fetch a status list credential as JSON using the API endpoint:  
+  `/credentials/status-list/{id}`
+- You can fetch the ledger entry for the credential using `/ledger-search` endpoint to get the status information and other details. Indexed attributes can be used to filter the search results.
+  - Sample request of ledger search : 
+    ```json
+    {
+      "credentialId": "afce16e8-02ac-4210-80d9-a0a20132bda3",
+      "issuerId": "did:web:sample.github.io:my-files:sample",
+      "credentialType": "FarmerCredential,VerifiableCredential",
+      "indexedAttributesEquals": {
+        "key1": "Bengaluru",
+        "key2": "Karnataka"
+      }
+    }
+    ```
+
+  - Sample response of ledger search : 
+      ```json
+      [
+        {
+          "credentialId": "afce16e8-02ac-4210-80d9-a0a20132bda3",
+          "issuerId": "did:web:sample.github.io:my-files:sample",
+          "statusListCredentialUrl": "7bf52e81-f3bb-40ec-a0f9-a714847fd067",
+          "statusListIndex": 5,
+          "statusPurpose": "revocation",
+          "issueDate": "2025-08-07T11:57:39",
+          "expirationDate": null,
+          "credentialType": "MockVerifiableCredential,VerifiableCredential",
+          "statusTimestamp": "2025-08-07T11:57:39"
+        }
+      ]
+      ```
+
+### 3. Updating Credential Status
+
+- To change the status (for example, to revoke a credential), use the API endpoint:  
+  `/credentials/status`  
+  Provide:
+    - The credential’s ID
+    - The credential status details (purpose, status list, index)
+    - The new status (true for revoked/suspended, false for active)
+- The system records this change for audit and updates the ledger.
+
+---
+
+## Configuration
+
+Add these properties to your application configuration:
+
+```properties
+mosip.certify.status-list.signature-crypto-suite=Ed25519Signature2020
+mosip.certify.status-list.signature-algo=EdDSA
+mosip.certify.statuslist.size-in-kb=16
+mosip.certify.data-provider-plugin.credential-status.supported-purposes={'revocation'}
+```
+
+---
+
+## Enabling the Feature
+
+1. **Database Setup**: Make sure the following tables exist:
+    - `status_list_credential`
+    - `status_list_available_indices`
+    - `ledger`
+    - `credential_status_transaction`
+
+2. **Configuration**: Set the required properties as shown above.
+
+3. **API Usage**:
+    - Use `/credentials/status-list/{id}` to fetch status list credentials.
+    - Use `/credentials/status` to update the status of a credential.
+    - Use `/ledger-search` to retrieve credentials and their status information.
+
+For more details on the API endpoints and request/response formats, refer to the [Inji Certify API documentation](https://mosip.stoplight.io/docs/inji-certify).
+
+---
+
+## Notes
+
+- Only the `BitstringStatusListCredential` type is supported.
+- To activate this feature, you must configure the application with the required properties. Without these, the feature will not work.
+- The size of each status list can be configured.
+- Only the described flows and fields are implemented. This feature is currently in experimental mode and may change in future releases.
+
+---
+
+## References
+
+- [W3C VC Status List 2021](https://www.w3.org/TR/vc-bitstring-status-list/)
+- [VC Data Model v2](https://www.w3.org/TR/vc-data-model-2.0/)
+
+---

--- a/docs/postman-collections/Inji-certify-credential-status-and-ledger-search.postman_collection.json
+++ b/docs/postman-collections/Inji-certify-credential-status-and-ledger-search.postman_collection.json
@@ -1,0 +1,123 @@
+{
+	"info": {
+		"_postman_id": "a772b684-a5be-46a8-8b3f-cb40e57b7888",
+		"name": "Inji Certify Credential Status and Ledger Search",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "46457899"
+	},
+	"item": [
+		{
+			"name": "Credential Status list by ID",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"credentialId\": \"52b55d02-613f-432f-b29e-ae842bc404a8\",\n    \"credentialStatus\": {\n        \"statusPurpose\": \"revocation\",\n        \"statusListIndex\": \"5\",\n        \"id\": \"https://injicertify-mock.dev-int-inji.mosip.net/v1/certify/status-list/7bf52e81-f3bb-40ec-a0f9-a714847fd067#5\",\n        \"type\": \"BitstringStatusListEntry\",\n        \"statusListCredential\": \"https://injicertify-mock.dev-int-inji.mosip.net/v1/certify/status-list/7bf52e81-f3bb-40ec-a0f9-a714847fd067\"\n    },\n    \"status\": false,\n    \"indexAllocator\": \"test\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "https://injicertify-mock.dev-int-inji.mosip.net/v1/certify//credentials/status-list/45564e0c-27c9-4a83-bc87-a0ad1bce79d1",
+					"protocol": "https",
+					"host": [
+						"injicertify-mock",
+						"dev-int-inji",
+						"mosip",
+						"net"
+					],
+					"path": [
+						"v1",
+						"certify",
+						"",
+						"credentials",
+						"status-list",
+						"45564e0c-27c9-4a83-bc87-a0ad1bce79d1"
+					]
+				},
+				"description": "Generated from cURL: curl --location --request GET 'https://injicertify-mock.dev-int-inji.mosip.net/v1/certify//credentials/status-list/45564e0c-27c9-4a83-bc87-a0ad1bce79d1' \\\n--header 'Content-Type: application/json' \\\n--data '{\n    \"credentialId\": \"52b55d02-613f-432f-b29e-ae842bc404a8\",\n    \"credentialStatus\": {\n        \"statusPurpose\": \"revocation\",\n        \"statusListIndex\": \"5\",\n        \"id\": \"https://injicertify-mock.dev-int-inji.mosip.net/v1/certify/status-list/7bf52e81-f3bb-40ec-a0f9-a714847fd067#5\",\n        \"type\": \"BitstringStatusListEntry\",\n        \"statusListCredential\": \"https://injicertify-mock.dev-int-inji.mosip.net/v1/certify/status-list/7bf52e81-f3bb-40ec-a0f9-a714847fd067\"\n    },\n    \"status\": false,\n    \"indexAllocator\": \"test\"\n}'"
+			},
+			"response": []
+		},
+		{
+			"name": "Credential Status Update",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "accept",
+						"value": "application/json"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n  \"credentialId\": \"52b55d02-613f-432f-b29e-ae842bc404a8\",\n  \"credentialStatus\": {\n    \"statusPurpose\": \"revocation\",\n    \"statusListIndex\": 5,\n    \"id\": \"http://localhost:8090/v1/certify/status-list/7bf52e81-f3bb-40ec-a0f9-a714847fd067#5\",\n    \"type\": \"BitstringStatusListEntry\",\n    \"statusListCredential\": \"http://localhost:8090/v1/certify/status-list/7bf52e81-f3bb-40ec-a0f9-a714847fd067\"\n  },\n  \"status\": false,\n  \"indexAllocator\": \"test\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{certifyurl}}/credentials/status",
+					"host": [
+						"{{certifyurl}}"
+					],
+					"path": [
+						"credentials",
+						"status"
+					]
+				},
+				"description": "Generated from cURL: curl -X 'POST' \\\n  'http://localhost:8090/v1/certify/credentials/status' \\\n  -H 'accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n  \"credentialId\": \"52b55d02-613f-432f-b29e-ae842bc404a8\",\n  \"credentialStatus\": {\n    \"statusPurpose\": \"revocation\",\n    \"statusListIndex\": 5,\n    \"id\": \"http://localhost:8090/v1/certify/status-list/7bf52e81-f3bb-40ec-a0f9-a714847fd067#5\",\n    \"type\": \"BitstringStatusListEntry\",\n    \"statusListCredential\": \"http://localhost:8090/v1/certify/status-list/7bf52e81-f3bb-40ec-a0f9-a714847fd067\"\n  },\n  \"status\": false,\n  \"indexAllocator\": \"test\"\n}'"
+			},
+			"response": []
+		},
+		{
+			"name": "Ledger Search",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"credentialId\": \"52b55d02-613f-432f-b29e-ae842bc404a8\",\n    \"issuerId\": \"did:web:mosip.github.io:inji-config:collab:mock-identity\",\n    \"credentialType\": \"MockVerifiableCredential,VerifiableCredential\",\n    \"indexedAttributesEquals\": {\n        \"postalCode\": \"10106\"\n    }\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{certifyurl}}/ledger-search",
+					"host": [
+						"{{certifyurl}}"
+					],
+					"path": [
+						"ledger-search"
+					]
+				},
+				"description": "Generated from cURL: curl --location 'https://injicertify-mock.dev-int-inji.mosip.net/v1/certify//ledger-search' \\\n--header 'Content-Type: application/json' \\\n--data '{\n    \"credentialId\": \"52b55d02-613f-432f-b29e-ae842bc404a8\",\n    \"issuerId\": \"did:web:mosip.github.io:inji-config:collab:mock-identity\",\n    \"credentialType\": \"MockVerifiableCredential,VerifiableCredential\",\n    \"indexedAttributesEquals\": {\n        \"postalCode\": \"10106\"\n    }\n}'"
+			},
+			"response": []
+		}
+	]
+}

--- a/docs/postman-collections/inji-certify-with-mock-identity.postman_collection.json
+++ b/docs/postman-collections/inji-certify-with-mock-identity.postman_collection.json
@@ -2581,12 +2581,11 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{certifyurl}}/credential-configurations/.well-known/openid-credential-issuer",
+							"raw": "{{certifyurl}}/.well-known/openid-credential-issuer",
 							"host": [
 								"{{certifyurl}}"
 							],
 							"path": [
-								"credential-configurations",
 								".well-known",
 								"openid-credential-issuer"
 							]

--- a/docs/postman-collections/inji-certify-with-mock-mdoc-vci.postman_collection.json
+++ b/docs/postman-collections/inji-certify-with-mock-mdoc-vci.postman_collection.json
@@ -631,12 +631,11 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{certifyurl}}/credential-configurations/.well-known/openid-credential-issuer",
+							"raw": "{{certifyurl}}/.well-known/openid-credential-issuer",
 							"host": [
 								"{{certifyurl}}"
 							],
 							"path": [
-								"credential-configurations",
 								".well-known",
 								"openid-credential-issuer"
 							]

--- a/docs/postman-collections/inji-certify-with-sunbird-insurance.postman_collection.json
+++ b/docs/postman-collections/inji-certify-with-sunbird-insurance.postman_collection.json
@@ -1074,12 +1074,11 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{certifyurl}}/credential-configurations/.well-known/openid-credential-issuer",
+							"raw": "{{certifyurl}}/.well-known/openid-credential-issuer",
 							"host": [
 								"{{certifyurl}}"
 							],
 							"path": [
-								"credential-configurations",
 								".well-known",
 								"openid-credential-issuer"
 							]


### PR DESCRIPTION
1. Added docs for : 

- Credential Configuration endpoints
- SD-JWT support
- VC Revocation
- Data Integrity

2. Updated docker-compose to mention steps that optional while running inji-certify service only (without web)
3. Updated postman collection to have credential status and ledger search endpoints. Updated the well-known endpoint with the new one.