### PR TITLE
[INJICERT-1176] Fix issue with ES256 did key proof_jwt validation

### DIFF
--- a/certify-service/src/main/java/io/mosip/certify/proof/DIDkeysProofManager.java
+++ b/certify-service/src/main/java/io/mosip/certify/proof/DIDkeysProofManager.java
@@ -59,7 +59,7 @@ public class DIDkeysProofManager implements JwtProofKeyManager {
             ECPoint ecPoint = curve.decodePoint(Arrays.copyOfRange(b, 2, b.length));
             byte[] xBytes = BigIntegers.asUnsignedByteArray(ecPoint.getAffineXCoord().toBigInteger());
             byte[] yBytes = BigIntegers.asUnsignedByteArray(ecPoint.getAffineYCoord().toBigInteger());
-            JWK j = new ECKey.Builder(Curve.P_256, Base64URL.encode(xBytes), Base64URL.encode(yBytes)).build();
+            JWK j = new ECKey.Builder(Curve.P_256, Base64URL.encode(xBytes), Base64URL.encode(yBytes)).keyID(header.getKeyID()).build();
             return Optional.of(j);
         } else if (b[0] == (byte) 0x85 && b[1] == (byte) 0x24) {
             // RSA2048

--- a/certify-service/src/test/java/io/mosip/certify/proof/DIDkeysProofManagerTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/proof/DIDkeysProofManagerTest.java
@@ -109,6 +109,7 @@ public class DIDkeysProofManagerTest {
         assertEquals("EC", result.getKeyType().getValue());
         assertEquals("-wim35fhXPUsGq78EeP90JV1Fq0YvvYTbc_0kqhB6cQ", ((ECKey) result).getX().toString());
         assertEquals("42YsvtOfjrHASU_mJTraPLeEuA-At3YsXQwbRZDpM_A", ((ECKey) result).getY().toString());
+        assertEquals("did:key:zDnaehKu2hNcmLBhd5iNkh3v6Q4ncq75fT4EXKMtietgzR1bZ", result.getKeyID() );
     }
 
     @Test


### PR DESCRIPTION
RCA : The issue was happening because during the JWK construction in `DIDkeysProofManager` class, the KeyID was not being added to the final JWK returned from the `getKeyFromHeader` method. This is a required field which is validated in `process` method of `DefaultJWTProcessor` class.