### PR TITLE
[INJICERT-1183] Allow partial updates in credential-config API

### DIFF
--- a/certify-core/src/main/java/io/mosip/certify/core/dto/CredentialConfigurationUpdateDTO.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/dto/CredentialConfigurationUpdateDTO.java
@@ -1,0 +1,48 @@
+package io.mosip.certify.core.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
+import lombok.Data;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CredentialConfigurationUpdateDTO {
+
+    private String vcTemplate;
+
+    private String didUrl;
+
+    private String keyManagerAppId;
+
+    private String keyManagerRefId;
+
+    private String signatureAlgo;
+
+    private String signatureCryptoSuite;
+
+    private String sdClaim;
+
+    @Valid
+    private List<MetaDataDisplayDTO> metaDataDisplay;
+
+    private List<String> displayOrder;
+
+    private String scope;
+
+    @JsonProperty("credentialSubjectDefinition")
+    private Map<String, CredentialSubjectParametersDTO> credentialSubjectDefinition;
+
+    @JsonProperty("msoMdocClaims")
+    private Map<String, Map<String, ClaimsDisplayFieldsConfigDTO>> msoMdocClaims;
+
+    @JsonProperty("sdJwtClaims")
+    private Map<String, ClaimsDisplayFieldsConfigDTO> sdJwtClaims;
+
+    private List<Map<String, String>> pluginConfigurations;
+
+    private List<String> credentialStatusPurposes;
+}

--- a/certify-core/src/main/java/io/mosip/certify/core/spi/CredentialConfigurationService.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/spi/CredentialConfigurationService.java
@@ -3,6 +3,7 @@ package io.mosip.certify.core.spi;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.mosip.certify.core.dto.CredentialConfigResponse;
 import io.mosip.certify.core.dto.CredentialConfigurationDTO;
+import io.mosip.certify.core.dto.CredentialConfigurationUpdateDTO;
 import io.mosip.certify.core.dto.CredentialIssuerMetadataDTO;
 
 public interface CredentialConfigurationService {
@@ -11,7 +12,7 @@ public interface CredentialConfigurationService {
 
     CredentialConfigurationDTO getCredentialConfigurationById(String id) throws JsonProcessingException;
 
-    CredentialConfigResponse updateCredentialConfiguration(String id, CredentialConfigurationDTO credentialConfigurationDTO) throws JsonProcessingException;
+    CredentialConfigResponse updateCredentialConfiguration(String id, CredentialConfigurationUpdateDTO credentialConfigurationDTO) throws JsonProcessingException;
 
     String deleteCredentialConfigurationById(String id);
 

--- a/certify-service/src/main/java/io/mosip/certify/controller/CredentialConfigController.java
+++ b/certify-service/src/main/java/io/mosip/certify/controller/CredentialConfigController.java
@@ -3,6 +3,7 @@ package io.mosip.certify.controller;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.mosip.certify.core.dto.CredentialConfigResponse;
 import io.mosip.certify.core.dto.CredentialConfigurationDTO;
+import io.mosip.certify.core.dto.CredentialConfigurationUpdateDTO;
 import io.mosip.certify.core.spi.CredentialConfigurationService;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
@@ -35,7 +36,7 @@ public class CredentialConfigController {
 
     @PutMapping(value = "/{credentialConfigKeyId}", produces = "application/json")
     public ResponseEntity<CredentialConfigResponse> updateCredentialConfiguration(@PathVariable String credentialConfigKeyId,
-                                                             @Valid @RequestBody CredentialConfigurationDTO credentialConfigurationRequest) throws JsonProcessingException {
+                                                             @Valid @RequestBody CredentialConfigurationUpdateDTO credentialConfigurationRequest) throws JsonProcessingException {
 
         CredentialConfigResponse credentialConfigResponse = credentialConfigurationService.updateCredentialConfiguration(credentialConfigKeyId, credentialConfigurationRequest);
         return new ResponseEntity<>(credentialConfigResponse, HttpStatus.OK);

--- a/certify-service/src/main/java/io/mosip/certify/services/CredentialConfigurationServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/CredentialConfigurationServiceImpl.java
@@ -203,7 +203,7 @@ public class CredentialConfigurationServiceImpl implements CredentialConfigurati
      */
     @Override
     @CacheEvict(cacheNames = CREDENTIAL_CONFIG_CACHE_NAME, key = "@credentialCacheKeyGenerator.generateKeyFromCredentialConfigKeyId(#credentialConfigKeyId)", condition = "#credentialConfigKeyId != null")
-    public CredentialConfigResponse updateCredentialConfiguration(String credentialConfigKeyId, CredentialConfigurationDTO credentialConfigurationDTO){
+    public CredentialConfigResponse updateCredentialConfiguration(String credentialConfigKeyId, CredentialConfigurationUpdateDTO credentialConfigurationDTO){
         Optional<CredentialConfig> optional = credentialConfigRepository.findByCredentialConfigKeyId(credentialConfigKeyId);
 
         if(optional.isEmpty()) {

--- a/certify-service/src/main/java/io/mosip/certify/utils/CredentialConfigMapper.java
+++ b/certify-service/src/main/java/io/mosip/certify/utils/CredentialConfigMapper.java
@@ -2,6 +2,7 @@ package io.mosip.certify.utils;
 
 import io.mosip.certify.core.dto.ClaimsDisplayFieldsConfigDTO;
 import io.mosip.certify.core.dto.CredentialConfigurationDTO;
+import io.mosip.certify.core.dto.CredentialConfigurationUpdateDTO;
 import io.mosip.certify.entity.CredentialConfig;
 import io.mosip.certify.entity.attributes.ClaimsDisplayFieldsConfigs;
 import org.mapstruct.*;
@@ -43,8 +44,11 @@ public interface CredentialConfigMapper {
     @Mapping(target = "status", ignore = true)
     @Mapping(target = "createdTimes", ignore = true)
     @Mapping(target = "updatedTimes", expression = "java(java.time.LocalDateTime.now())")
-    @Mapping(target = "context", source = "contextURLs", qualifiedByName = "listToCommaSeparatedString")
-    @Mapping(target = "credentialType", source = "credentialTypes", qualifiedByName = "listToCommaSeparatedString")
+    @Mapping(target = "context", ignore = true)
+    @Mapping(target = "credentialType", ignore = true)
+    @Mapping(target = "credentialFormat", ignore = true)
+    @Mapping(target = "docType", ignore = true)
+    @Mapping(target = "sdJwtVct", ignore = true)
     @Mapping(target = "display", source = "metaDataDisplay")
     @Mapping(target = "order", source = "displayOrder")
     @Mapping(target = "cryptographicBindingMethodsSupported", ignore = true)
@@ -52,7 +56,8 @@ public interface CredentialConfigMapper {
     @Mapping(target = "proofTypesSupported", ignore = true)
     @Mapping(target = "msoMdocClaims", source = "msoMdocClaims", qualifiedByName = "mapClaimsToEntity")
     @Mapping(target = "credentialSubject", source = "credentialSubjectDefinition")
-    void updateEntityFromDto(CredentialConfigurationDTO dto, @MappingTarget CredentialConfig entity);
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void updateEntityFromDto(CredentialConfigurationUpdateDTO dto, @MappingTarget CredentialConfig entity);
 
     ClaimsDisplayFieldsConfigs toEntity(ClaimsDisplayFieldsConfigDTO dto);
     ClaimsDisplayFieldsConfigDTO toDto(ClaimsDisplayFieldsConfigs dto);

--- a/certify-service/src/test/java/io/mosip/certify/controller/CredentialConfigControllerTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/controller/CredentialConfigControllerTest.java
@@ -1,10 +1,7 @@
 package io.mosip.certify.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.mosip.certify.core.dto.CredentialConfigResponse;
-import io.mosip.certify.core.dto.CredentialConfigurationDTO;
-import io.mosip.certify.core.dto.CredentialSubjectParametersDTO;
-import io.mosip.certify.core.dto.ParsedAccessToken;
+import io.mosip.certify.core.dto.*;
 import io.mosip.certify.core.spi.CredentialConfigurationService;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,6 +41,9 @@ public class CredentialConfigControllerTest {
     @Mock
     private CredentialConfigurationDTO credentialConfigurationDTO;
 
+    @Mock
+    private CredentialConfigurationUpdateDTO credentialConfigurationUpdateDTO;
+
     @Before
     public void setup() {
         credentialConfigurationDTO = new CredentialConfigurationDTO();
@@ -65,6 +65,15 @@ public class CredentialConfigControllerTest {
         credentialConfigurationDTO.setCredentialSubjectDefinition(Map.of(
                 "name", new CredentialSubjectParametersDTO(List.of(new CredentialSubjectParametersDTO.Display("Full Name", "en")))
         ));
+        credentialConfigurationUpdateDTO = new CredentialConfigurationUpdateDTO();
+        credentialConfigurationUpdateDTO.setVcTemplate(credentialConfigurationDTO.getVcTemplate());
+        credentialConfigurationUpdateDTO.setDidUrl(credentialConfigurationDTO.getDidUrl());
+        credentialConfigurationUpdateDTO.setMetaDataDisplay(credentialConfigurationDTO.getMetaDataDisplay());
+        credentialConfigurationUpdateDTO.setDisplayOrder(credentialConfigurationDTO.getDisplayOrder());
+        credentialConfigurationUpdateDTO.setScope(credentialConfigurationDTO.getScope());
+        credentialConfigurationUpdateDTO.setSignatureCryptoSuite(credentialConfigurationDTO.getSignatureCryptoSuite());
+        credentialConfigurationUpdateDTO.setPluginConfigurations(credentialConfigurationDTO.getPluginConfigurations());
+        credentialConfigurationUpdateDTO.setCredentialSubjectDefinition(credentialConfigurationDTO.getCredentialSubjectDefinition());
     }
 
     @Test
@@ -101,10 +110,10 @@ public class CredentialConfigControllerTest {
         CredentialConfigResponse credentialConfigResponse = new CredentialConfigResponse();
         credentialConfigResponse.setId("farmer-credential-config-001");
         credentialConfigResponse.setStatus("active");
-        Mockito.when(credentialConfigurationService.updateCredentialConfiguration(Mockito.anyString(), eq(credentialConfigurationDTO))).thenReturn(credentialConfigResponse);
+        Mockito.when(credentialConfigurationService.updateCredentialConfiguration(Mockito.anyString(), eq(credentialConfigurationUpdateDTO))).thenReturn(credentialConfigResponse);
 
         mockMvc.perform(put("/credential-configurations/1")
-                        .content(objectMapper.writeValueAsBytes(credentialConfigurationDTO))
+                        .content(objectMapper.writeValueAsBytes(credentialConfigurationUpdateDTO))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").exists())

--- a/certify-service/src/test/java/io/mosip/certify/services/CredentialConfigurationServiceImplTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/CredentialConfigurationServiceImplTest.java
@@ -183,8 +183,8 @@ public class CredentialConfigurationServiceImplTest {
         when(credentialConfigRepository.findByCredentialConfigKeyId(eq(expectedId))).thenReturn(optionalConfig);
 
 
-        CredentialConfigurationDTO mockDto = new CredentialConfigurationDTO(); // Dummy DTO for the mapper call
-        doNothing().when(credentialConfigMapper).updateEntityFromDto(any(CredentialConfigurationDTO.class), any(CredentialConfig.class));
+        CredentialConfigurationUpdateDTO mockDto = new CredentialConfigurationUpdateDTO(); // Dummy DTO for the mapper call
+        doNothing().when(credentialConfigMapper).updateEntityFromDto(any(CredentialConfigurationUpdateDTO.class), any(CredentialConfig.class));
 
 
         when(credentialConfigRepository.save(any(CredentialConfig.class)))
@@ -213,7 +213,7 @@ public class CredentialConfigurationServiceImplTest {
                 .thenReturn(Optional.empty());
 
         CredentialConfigException exception = assertThrows(CredentialConfigException.class, () ->
-                credentialConfigurationService.updateCredentialConfiguration("12345678", new CredentialConfigurationDTO()));
+                credentialConfigurationService.updateCredentialConfiguration("12345678", new CredentialConfigurationUpdateDTO()));
 
         assertEquals("Configuration not found with the provided id: " + "12345678", exception.getMessage());
     }

--- a/docs/inji-certify-openapi.yaml
+++ b/docs/inji-certify-openapi.yaml
@@ -127,7 +127,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CredentialConfigurationDTO'
+              $ref: '#/components/schemas/CredentialConfigurationUpdateDTO'
             examples:
               Example 1:
                 value:
@@ -171,11 +171,7 @@ paths:
                     - LegalReserveAreaToBeRestored
                     - PermanentPreservationAreasToBeRestored
                   didUrl: 'did:web:www.example.com:inji-config:collab:landregistry'
-                  contextURLs:
-                    - 'https://www.w3.org/ns/credentials/v2'
-                    - 'https://www.example.com/inji-config/contexts/landregistry-statement-dataIntegrity-context-automation.json'
                   signatureCryptoSuite: eddsa-rdfc-2022
-                  credentialConfigKeyId: landstatement_dataIntegrity_2.0
                   metaDataDisplay:
                     - background_image:
                         uri: 'https://www.example.com/inji-config/logos/agro-vertias-logo.png'
@@ -186,12 +182,8 @@ paths:
                         url: 'https://www.example.com/inji-config/logos/agro-vertias-logo.png'
                       text_color: '#000000'
                       locale: en
-                  credentialFormat: ldp_vc
                   scope: land_statement_vc_ldp
                   keyManagerAppId: CERTIFY_VC_SIGN_ED25519
-                  credentialTypes:
-                    - VerifiableCredential
-                    - landstatement_dataIntegrity
                   signatureAlgo: EdDSA
       responses:
         '200':
@@ -1508,8 +1500,105 @@ components:
             - eddsa-rdfc-2022
             - eddsa-jcs-2022
         credentialStatusPurposes:
+          type: array
+          description: 'List of purposes for which credential status is maintained. Currently, the allowed values for this field will be driven by following config - `mosip.certify.data-provider-plugin.credential-status.allowed-status-purposes` and only single status purpose is supported currently.'
+          items:
+            x-stoplight:
+              id: 2pdknc31ugrva
+            type: string
+    CredentialConfigurationUpdateDTO:
+      type: object
+      x-stoplight:
+        id: tnw8iqu3crxhy
+      title: CredentialConfigurationUpdateDTO
+      required:
+        - metaDataDisplay
+        - scope
+      properties:
+        vcTemplate:
           type: string
-          description: 'List of purposes for which credential status is maintained, comma-separated values are supported here. Currently, the value for this field will be driven by following config - `mosip.certify.data-provider-plugin.credential-status.supported-purposes`. Value sent in the request will be ignored. '
+          description: Base64 encoded template identifier for the Verifiable Credential. Mandatory if mosip.certify.plugin-mode is set to ‘DataProvider’ during creation.
+        didUrl:
+          type: string
+          description: URL of the Decentralized Identifier (DID) document. Mandatory for DataProvider plugin mode.
+        keyManagerAppId:
+          type: string
+          description: Application ID for the key manager used in signing. Required for DataProvider plugin mode.
+        keyManagerRefId:
+          type: string
+          description: Reference ID for the key manager. Applicable for DataProvider plugin mode.
+        signatureAlgo:
+          description: |-
+            Signature or proof algorithm used for credential signing. This field is required for certain credential formats, such as vc+sd-jwt and optionally for ldp_vc when the signatureCryptoSuite is one of DataIntegrityProof suite (e.g. ecdsa-rdfc-2019, ecdsa-jcs-2019, etc). It ensures compatibility between the cryptographic suite and the signing algorithm. Mapping of signatureCryptoSuite and signatureAlgo values for DataIntegrityProof suite scenario :
+
+            signatureCryptoSuite |  signatureAlgo
+            ---------|----------
+             eddsa-rdfc-2022, eddsa-jcs-2022 | EdDSA 
+             ecdsa-rdfc-2019, ecdsa-jcs-2019 | ES256K,ES256 
+
+          enum:
+            - EdDSA
+            - ES256K
+            - ES256
+          type: string
+        sdClaim:
+          type: string
+          description: Comma-separated list for selective disclosure claim configuration. Applicable for vc+sd-jwt credential type.
+        metaDataDisplay:
+          type: array
+          description: 'To configure the display properties (e.g., logo, name, colors, and localization) for metadata associated with the Verifiable Credential type.'
+          items:
+            $ref: '#/components/schemas/MetaDataDisplayDTO'
+        displayOrder:
+          type: array
+          description: 'List specifying the order of claims or fields in the credential that are defined in credentialSubjectDefinition field, to be used while showing the credential in UI.'
+          items:
+            type: string
+        scope:
+          type: string
+          description: Scope value for the credential configuration. This value is matched with the scope value in Auth Token while processing the credential issuance request.
+        pluginConfigurations:
+          type: array
+          description: 'Holds a list of plugin-specific configuration parameters as key-value pairs. Each entry in the list represents configuration settings required by external plugins or modules integrated with the credential issuance process. This allows dynamic extension and customization of credential behavior based on the needs of different plugins, such as data providers, signature providers, or custom validation logic.'
+          items:
+            type: object
+            additionalProperties:
+              type: string
+        credentialSubjectDefinition:
+          type: object
+          description: 'Represents the subject of the Verifiable Credential, containing the claims and attributes about the entity (such as a person, organization, or device) to whom the credential is issued. Applicable for ldp_vc credential type.'
+          additionalProperties:
+            $ref: '#/components/schemas/CredentialSubjectParametersDTO'
+        msoMdocClaims:
+          description: Claims included in the credential. Applicable for mso_mdoc and vc+sd-jwt credential formats.
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties:
+              $ref: '#/components/schemas/ClaimsDisplayFieldsConfigDTO'
+        sdJwtClaims:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ClaimsDisplayFieldsConfigDTO'
+        signatureCryptoSuite:
+          description: 'Holds value for signature crypto suites supported for key algorithms like Ed25519Signature2020,EcdsaSecp256k1Signature2019, etc. It will also be applicable for data integrity proof crypto suites, for e.g. ecds-rdfc-2019, eddsa-rdfc-2022, etc. Mandatory for DataProvider plugin. The values should be only be those supported by certify.'
+          type: string
+          enum:
+            - RsaSignature2018
+            - Ed25519Signature2018
+            - Ed25519Signature2020
+            - EcdsaKoblitzSignature2016
+            - EcdsaSecp256k1Signature2019
+            - EcdsaSecp256r1Signature2019
+            - ecdsa-rdfc-2019
+            - ecdsa-jcs-2019
+            - eddsa-rdfc-2022
+            - eddsa-jcs-2022
+        credentialStatusPurposes:
+          type: array
+          description: 'List of purposes for which credential status is maintained. Currently, the allowed values for this field will be driven by following config - `mosip.certify.data-provider-plugin.credential-status.allowed-status-purposes` and only single status purpose is supported currently.'
+          items:
+            type: string
     CredentialConfigResponse:
       type: object
       properties:


### PR DESCRIPTION
Fix the issue where user was forced to send the whole request body in update credential configuration API to avoid overwriting the existing field values.