### PR TITLE
[INJICERT-1193] Change authorization url type from list to string

### DIFF
--- a/certify-service/src/main/java/io/mosip/certify/services/CredentialConfigurationServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/CredentialConfigurationServiceImpl.java
@@ -42,8 +42,8 @@ public class CredentialConfigurationServiceImpl implements CredentialConfigurati
     @Value("${mosip.certify.domain.url:}")
     private String credentialIssuer;
 
-    @Value("#{'${mosip.certify.authorization.url}'.split(',')}")
-    private List<String> authUrlList;
+    @Value("${mosip.certify.authorization.url}")
+    private String authUrl;
 
     @Value("${server.servlet.path}")
     private String servletPath;
@@ -271,7 +271,7 @@ public class CredentialConfigurationServiceImpl implements CredentialConfigurati
                     });
             credentialIssuerMetadata.setCredentialConfigurationSupportedDTO(credentialConfigurationSupportedMap);
             credentialIssuerMetadata.setCredentialIssuer(credentialIssuer);
-            credentialIssuerMetadata.setAuthorizationServers(authUrlList);
+            credentialIssuerMetadata.setAuthorizationServers(Collections.singletonList(authUrl));
             String credentialEndpoint = credentialIssuer + servletPath + "/issuance" + (!version.equals("latest") ? "/" + version : "") + "/credential";
             credentialIssuerMetadata.setCredentialEndpoint(credentialEndpoint);
             credentialIssuerMetadata.setDisplay(issuerDisplay);
@@ -289,7 +289,7 @@ public class CredentialConfigurationServiceImpl implements CredentialConfigurati
                     });
             credentialIssuerMetadata.setCredentialConfigurationSupportedDTO(credentialConfigurationSupportedMap); // Use a different setter for vd12
             credentialIssuerMetadata.setCredentialIssuer(credentialIssuer);
-            credentialIssuerMetadata.setAuthorizationServers(authUrlList);
+            credentialIssuerMetadata.setAuthorizationServers(Collections.singletonList(authUrl));
             String credentialEndpoint = credentialIssuer + servletPath + "/issuance/" + version + "/credential";
             credentialIssuerMetadata.setCredentialEndpoint(credentialEndpoint);
             credentialIssuerMetadata.setDisplay(issuerDisplay);
@@ -308,7 +308,7 @@ public class CredentialConfigurationServiceImpl implements CredentialConfigurati
                     });
             credentialIssuerMetadata.setCredentialConfigurationSupportedDTO(credentialConfigurationSupportedList); // Use a different setter for vd11
             credentialIssuerMetadata.setCredentialIssuer(credentialIssuer);
-            credentialIssuerMetadata.setAuthorizationServers(authUrlList);
+            credentialIssuerMetadata.setAuthorizationServers(Collections.singletonList(authUrl));
             String credentialEndpoint = credentialIssuer + servletPath + "/issuance/" + version + "/credential";
             credentialIssuerMetadata.setCredentialEndpoint(credentialEndpoint);
             credentialIssuerMetadata.setDisplay(issuerDisplay);

--- a/certify-service/src/test/java/io/mosip/certify/services/CredentialConfigurationServiceImplTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/CredentialConfigurationServiceImplTest.java
@@ -87,7 +87,7 @@ public class CredentialConfigurationServiceImplTest {
         credentialConfigurationDTO.setCredentialSubjectDefinition(Map.of("name", new CredentialSubjectParametersDTO(List.of(new CredentialSubjectParametersDTO.Display("Full Name", "en")))));
 
         ReflectionTestUtils.setField(credentialConfigurationService, "credentialIssuer", "http://example.com/");
-        ReflectionTestUtils.setField(credentialConfigurationService, "authUrlList", List.of("http://auth.com"));
+        ReflectionTestUtils.setField(credentialConfigurationService, "authUrl", "http://auth.com");
         ReflectionTestUtils.setField(credentialConfigurationService, "servletPath", "v1/test");
         ReflectionTestUtils.setField(credentialConfigurationService, "pluginMode", "DataProvider");
         ReflectionTestUtils.setField(credentialConfigurationService, "issuerDisplay", List.of(Map.of()));


### PR DESCRIPTION
The credential config service implementation was interpreting the mosip.certify.authorization.url as List<String>, whereas the config supports only single URL. Changing the data type in the service to reflect the same and its a mandatory configuration now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified authorization server configuration to accept a single URL, improving clarity and reducing setup complexity. Behavior remains unchanged for end users.
* **Tests**
  * Updated test setup to align with the new single-URL configuration approach, maintaining existing test coverage and outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->