### PR TITLE
[INJICERT-1214] Set default cron job duration to 1min and update scheduler lock at least time

### DIFF
--- a/certify-service/src/main/java/io/mosip/certify/services/StatusListUpdateBatchJob.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/StatusListUpdateBatchJob.java
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 
 /**
  * Batch job service for updating Status List Credentials
- * Runs hourly to process new credential status transactions and update status lists
+ * Runs every minute(can be configured) to process new credential status transactions and update status lists
  */
 @Slf4j
 @Service


### PR DESCRIPTION
As per review call demo feedback, setting default cron job duration to 1min and update scheduler lock at least time - 50s. The lock at least time is set 50sec to ensure if the current job completes before that time, there is enough for scheduler to release the lock for the next run to execute. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Status list updates now run every minute (previously hourly), providing fresher, near real-time information.
  - Scheduling lock duration reduced so subsequent runs can start sooner, minimizing delays.
  - Changes result in quicker reflection of recent updates and faster progression of related workflows.
  - No action required from users; behavior is automatic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->