### PR TITLE
[INJICERT-1201] Fix redis-serialization issue for renderTemplateDTO

### DIFF
--- a/certify-core/src/main/java/io/mosip/certify/core/dto/RenderingTemplateDTO.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/dto/RenderingTemplateDTO.java
@@ -1,11 +1,14 @@
-package io.mosip.certify.api.dto;
+package io.mosip.certify.core.dto;
 
 import lombok.Data;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
 
 @Data
-public class RenderingTemplateDTO {
+public class RenderingTemplateDTO implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     private String id;
     private String template;
     private LocalDateTime createdTimes;

--- a/certify-core/src/main/java/io/mosip/certify/core/spi/RenderingTemplateService.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/spi/RenderingTemplateService.java
@@ -5,7 +5,7 @@
  */
 package io.mosip.certify.core.spi;
 
-import io.mosip.certify.api.dto.RenderingTemplateDTO;
+import io.mosip.certify.core.dto.RenderingTemplateDTO;
 
 public interface RenderingTemplateService {
     RenderingTemplateDTO getTemplate(String id);

--- a/certify-service/src/main/java/io/mosip/certify/controller/RenderingTemplateController.java
+++ b/certify-service/src/main/java/io/mosip/certify/controller/RenderingTemplateController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import io.mosip.certify.api.dto.RenderingTemplateDTO;
+import io.mosip.certify.core.dto.RenderingTemplateDTO;
 import io.mosip.certify.core.exception.RenderingTemplateException;
 import io.mosip.certify.core.spi.RenderingTemplateService;
 import lombok.extern.slf4j.Slf4j;

--- a/certify-service/src/main/java/io/mosip/certify/services/RenderingTemplateServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/RenderingTemplateServiceImpl.java
@@ -11,7 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 
-import io.mosip.certify.api.dto.RenderingTemplateDTO;
+import io.mosip.certify.core.dto.RenderingTemplateDTO;
 import io.mosip.certify.core.constants.ErrorConstants;
 import io.mosip.certify.core.exception.RenderingTemplateException;
 import io.mosip.certify.core.spi.RenderingTemplateService;

--- a/certify-service/src/test/java/io/mosip/certify/controller/RenderingTemplateControllerTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/controller/RenderingTemplateControllerTest.java
@@ -15,7 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import io.mosip.certify.api.dto.RenderingTemplateDTO;
+import io.mosip.certify.core.dto.RenderingTemplateDTO;
 import io.mosip.certify.core.constants.ErrorConstants;
 import io.mosip.certify.core.dto.ParsedAccessToken;
 import io.mosip.certify.core.exception.RenderingTemplateException;

--- a/certify-service/src/test/java/io/mosip/certify/services/RenderingTemplateServiceImplTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/RenderingTemplateServiceImplTest.java
@@ -11,7 +11,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import io.mosip.certify.api.dto.RenderingTemplateDTO;
+import io.mosip.certify.core.dto.RenderingTemplateDTO;
 import io.mosip.certify.core.constants.ErrorConstants;
 import io.mosip.certify.core.exception.RenderingTemplateException;
 import io.mosip.certify.entity.RenderingTemplate;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized rendering template data model within the application architecture for improved code structure.
  * Enhanced serialization support for rendering template processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->