### PR TITLE
[INJICERT-1268] Fixes in open-api-docs and docker default config

### DIFF
--- a/docker-compose/docker-compose-injistack/config/certify-default.properties
+++ b/docker-compose/docker-compose-injistack/config/certify-default.properties
@@ -35,11 +35,11 @@ mosip.certify.security.auth.put-urls={}
 mosip.certify.security.auth.get-urls={}
 
 mosip.certify.security.ignore-csrf-urls=**/actuator/**,/favicon.ico,**/error,\
-  **/swagger-ui/**,**/v3/api-docs/**,\
-  **/issuance/**,**/credential-configurations/**,**/.well-known/**,**/ledger-search/**,**/credentials/**
+  **/swagger-ui/**,**/v3/api-docs/**,**/issuance/**,**/system-info/**,**/credential-configurations/**,\
+  **/.well-known/**,**/ledger-search/**,**/credentials/**
 
 mosip.certify.security.ignore-auth-urls=**/actuator/**,**/error,**/swagger-ui/**,\
-  **/v3/api-docs/**, **/issuance/**,**/rendering-template/**, **/system-info/**,**/credential-configurations/**,\
+  **/v3/api-docs/**, **/issuance/**,**/rendering-template/**,**/system-info/**,**/credential-configurations/**,\
   **/.well-known/**,**/ledger-search/**,**/credentials/**
 
 # This property specifies URL patterns for which CORS (Cross-Origin Resource Sharing) is enabled for HTTP GET requests. It allows the application to accept cross-origin GET requests on the specified endpoints, improving security and flexibility for frontend integrations.
@@ -166,15 +166,17 @@ spring.cache.cache-names=${mosip.certify.cache.names}
 management.health.redis.enabled=false
 
 mosip.certify.access-token-expire-seconds=86400
+mosip.certify.certificatedatacache-expire-seconds=3600
+mosip.certify.common.cache-expire-seconds=3600
 
-mosip.certify.cache.names=userinfo,vcissuance,certificatedatacache,credentialConfig
+mosip.certify.cache.names=userinfo,vcissuance,certificatedatacache,credentialConfig,renderTemplate
 # Cache size setup is applicable only for 'simple' cache type.
 # Cache size configuration will not be considered with 'Redis' cache type
 mosip.certify.cache.size={'userinfo': 200, 'vcissuance' : 2000 }
 
 
 # Cache expire in seconds is applicable for both 'simple' and 'Redis' cache type
-mosip.certify.cache.expire-in-seconds={'userinfo': ${mosip.certify.access-token-expire-seconds}, 'vcissuance': ${mosip.certify.access-token-expire-seconds}}
+mosip.certify.cache.expire-in-seconds={'userinfo': ${mosip.certify.access-token-expire-seconds}, 'vcissuance': ${mosip.certify.access-token-expire-seconds}, 'certificatedatacache': ${mosip.certify.certificatedatacache-expire-seconds}, 'credentialConfig': ${mosip.certify.common.cache-expire-seconds}, 'renderTemplate': ${mosip.certify.common.cache-expire-seconds}}
 mosip.certify.credential-config.cryptographic-binding-methods-supported={\
   'ldp_vc': {'did:jwk','did:key'},\
   'mso_mdoc': {'cose_key'},\

--- a/docs/inji-certify-openapi.yaml
+++ b/docs/inji-certify-openapi.yaml
@@ -372,7 +372,7 @@ paths:
                     organizationUnit: IT
                     country: US
                     state: California
-                    location: Bangalore
+                    location: Sacramento
       responses:
         '200':
           description: OK
@@ -418,7 +418,7 @@ paths:
                     ip: 192.168.1.10
                   request:
                     partnerDomain: partner.example.com
-                    caCertificateData: MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAn...
+                    certificateData: MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAn...
       responses:
         '200':
           description: OK

--- a/docs/postman-collections/inji-certify-with-mock-identity.postman_collection.json
+++ b/docs/postman-collections/inji-certify-with-mock-identity.postman_collection.json
@@ -2653,6 +2653,33 @@
               "response": []
             },
             {
+              "name": "Upload CA Certificate",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\r\n  \"request\": {\r\n    \"partnerDomain\": \"PARTNER.EXAMPLE.COM\",\r\n    \"certificateData\": \"-----BEGIN CERTIFICATE-----\\r\\nMIICGzCCAcKgAwIBAgIUXHQkDQN5KqqEJlnYCkuKovsunewwCgYIKoZIzj0EAwIw\\r\\nZTELMAkGA1UEBhMCSU4xCzAJBgNVBAgMAlVQMRAwDgYDVQQHDAdMdWNrbm93MQ0w\\r\\nCwYDVQQKDARBS1RVMRkwFwYDVQQLDBBBS1RVLVRFQ0gtQ0VOVEVSMQ0wCwYDVQQD\\r\\nDARBS1RVMB4XDTI1MTExNDA3MTM0NFoXDTM1MTExMjA3MTM0NFowZTELMAkGA1UE\\r\\nBhMCSU4xCzAJBgNVBAgMAlVQMRAwDgYDVQQHDAdMdWNrbm93MQ0wCwYDVQQKDARB\\r\\nS1RVMRkwFwYDVQQLDBBBS1RVLVRFQ0gtQ0VOVEVSMQ0wCwYDVQQDDARBS1RVMFYw\\r\\nEAYHKoZIzj0CAQYFK4EEAAoDQgAE1eilPVdRddVUfddMyeg3zhrUWL7whGnkUslA\\r\\n+6am9N7Gipxkczll\\/Z8Rj0IcASEfEQLVtdLvz33iFXQnSYskGaNTMFEwHQYDVR0O\\r\\nBBYEFKSZPU+iz0dbRWb7xc4NFX50yxd6MB8GA1UdIwQYMBaAFKSZPU+iz0dbRWb7\\r\\nxc4NFX50yxd6MA8GA1UdEwEB\\/wQFMAMBAf8wCgYIKoZIzj0EAwIDRwAwRAIgBLgy\\r\\nqI9DahV3v5LEQ6ubAP8peHPWOr13TkV+v17kwIMCICXyzmj5TVRWNOvzE4ji\\/pSR\\r\\nWmJjl\\/CDcMt\\/ZmlnzG8n\\r\\n-----END CERTIFICATE-----\"\r\n  }\r\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{certifyurl}}/system-info/upload-ca-certificate",
+                  "host": [
+                    "{{certifyurl}}"
+                  ],
+                  "path": [
+                    "system-info",
+                    "upload-ca-certificate"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
               "name": "fetch certificate",
               "protocolProfileBehavior": {
                 "disableBodyPruning": true


### PR DESCRIPTION
* [INJICERT-1268] Fixes in open-api-docs and docker default config



* [INJICERT-1268] Fix upload-ca-certificate request body



---------

[INJICERT-1268]: https://mosip.atlassian.net/browse/INJICERT-1268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INJICERT-1268]: https://mosip.atlassian.net/browse/INJICERT-1268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CA certificate upload endpoint for system configuration management.

* **Documentation**
  * Updated API documentation examples with current field naming and endpoint specifications.
  * Enhanced Postman testing collection with new certificate upload request templates.

* **Chores**
  * Optimized cache expiration settings for improved system performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->