### PR TITLE
[INJICERT-1288] Add back publish to nexus job

### DIFF
--- a/.github/workflows/push-trigger.yml
+++ b/.github/workflows/push-trigger.yml
@@ -94,6 +94,20 @@ jobs:
         run: |
           echo "Condition Met: ${{ steps.check_output.outputs.is_condition }}"
 
+  publish_to_nexus:
+    if: "${{ !contains(github.ref, 'master') && github.event_name != 'pull_request' }}"
+    needs: build-maven-inji-certify
+    uses: mosip/kattu/.github/workflows/maven-publish-to-nexus.yml@master-java21
+    with:
+      SERVICE_LOCATION: ./
+    secrets:
+      OSSRH_USER: ${{ secrets.OSSRH_USER }}
+      OSSRH_SECRET: ${{ secrets.OSSRH_SECRET }}
+      OSSRH_URL: ${{ secrets.OSSRH_CENTRAL_URL }}
+      OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+      GPG_SECRET: ${{ secrets.GPG_SECRET }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+
   build-dockers:
     needs: build-maven-inji-certify
     strategy:
@@ -132,7 +146,7 @@ jobs:
 
 # Removing publish_to_nexus for now from the list until migration to central nexus is done.
   build-docker-inji-certify-with-plugins:
-    needs: [ maven-build-inji-certify-with-plugins, check_snapshot_version ]
+    needs: [ maven-build-inji-certify-with-plugins, check_snapshot_version, publish_to_nexus ]
     if: ${{ needs.check_snapshot_version.outputs.is_condition == 'true' }}
     strategy:
       matrix:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated artifact publishing to Nexus in the CI/CD pipeline for non-master branch scenarios.
  * Updated build orchestration to ensure artifact publishing completes successfully before Docker image builds proceed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->