### PR TITLE
[INJICERT-990] - Remove unnecessary config for presentation during issuance feature

### DIFF
--- a/certify-core/src/main/java/io/mosip/certify/core/dto/InputDescriptor.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/dto/InputDescriptor.java
@@ -9,6 +9,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+import java.util.Map;
+
 /**
  * Input Descriptor DTO for Presentation Definition
  * Describes credential requirements and constraints
@@ -35,9 +38,12 @@ public class InputDescriptor {
     @JsonProperty("purpose")
     private String purpose;
 
+    @JsonProperty("format")
+    private Map<String, Map<String, List<String>>> format;
     /**
      * Constraints that must be satisfied for this input
      */
     @JsonProperty("constraints")
     private InputConstraints constraints;
+
 }

--- a/certify-service/src/main/java/io/mosip/certify/services/IarPresentationService.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/IarPresentationService.java
@@ -53,9 +53,6 @@ public class IarPresentationService {
     @Value("${mosip.certify.verify.service.vp-result-endpoint:http://localhost:8080}")
     private String verifyServiceVpResultEndpoint;
 
-    @Value("${mosip.certify.iar.verification.success-status:SUCCESS}")
-    private String verificationSuccessStatus;
-
     @Value("${mosip.certify.iar.authorization-code.length:24}")
     private int authorizationCodeLength;
 
@@ -69,9 +66,6 @@ public class IarPresentationService {
     public void validateConfiguration() {
         if (!StringUtils.hasText(verifyServiceVpResultEndpoint)) {
             throw new IllegalStateException("mosip.certify.verify.service.vp-result-endpoint must be configured");
-        }
-        if (!StringUtils.hasText(verificationSuccessStatus)) {
-            throw new IllegalStateException("mosip.certify.iar.verification.success-status must be configured");
         }
         log.info("IarPresentationService configuration validation successful");
     }
@@ -229,9 +223,9 @@ public class IarPresentationService {
             
             if (verificationResult != null) {
                 String vpResultStatus = (String) verificationResult.get("vpResultStatus");
-                log.debug("Verify service vpResultStatus: {}, expected success value: {}", vpResultStatus, verificationSuccessStatus);
-                
-                if (verificationSuccessStatus.equals(vpResultStatus)) {
+                log.debug("Verify service vpResultStatus: {}", vpResultStatus);
+
+                if ("SUCCESS".equals(vpResultStatus)) {
                     response.setStatus(IarStatus.OK.getValue());
                     response.setVerificationDetails(verificationResult);
                     log.info("VP cryptographic verification successful for transaction_id: {}, vpResultStatus: {}", transactionId, vpResultStatus);

--- a/certify-service/src/main/java/io/mosip/certify/services/IarServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/IarServiceImpl.java
@@ -64,7 +64,7 @@ public class IarServiceImpl implements IarService {
     @Value("${mosip.certify.oauth.token.type:Bearer}")
     private String tokenType;
 
-    @Value("${mosip.certify.oauth.issuer.issuer:http://localhost/8090}")
+    @Value("${mosip.certify.oauth.issuer:http://localhost/8090}")
     private String issuer;
 
     @Value("${mosip.certify.oauth.access-token.audience:http://localhost/8090/v1/certify/issuance/credential}")

--- a/certify-service/src/main/resources/application-local.properties
+++ b/certify-service/src/main/resources/application-local.properties
@@ -278,13 +278,8 @@ mosip.certify.oauth.code-challenge-methods-supported=S256
 mosip.certify.oauth.interactive-authorization-endpoint=${mosip.certify.domain.url}/v1/certify/oauth/iar
 
 ## ------------------------------------------- IAR (Interactive Authorization Request) Configuration -------------------------------------------
-mosip.certify.iar.session-timeout-seconds=1800
-mosip.certify.iar.require-interaction=true
 mosip.certify.iar.identity-data=uin,vid,UIN,UID
 
-
-# OpenID4VP response configuration
-mosip.certify.iar.openid4vp.response-mode=iar-post
 
 # OAuth Token Configuration
 mosip.certify.oauth.token.expires-in-seconds=3600
@@ -297,8 +292,6 @@ mosip.certify.oauth.access-token.audience=${mosip.certify.identifier}/v1/certify
 # Authorization Code Configuration
 mosip.certify.iar.authorization-code.expires-minutes=10
 mosip.certify.iar.authorization-code.length=24
-
-
 
 # Verify service integration
 # Only configure the base URL and VP request endpoint - other endpoints are obtained dynamically from verify service

--- a/certify-service/src/test/resources/application-test.properties
+++ b/certify-service/src/test/resources/application-test.properties
@@ -19,15 +19,6 @@ mosip.certify.domain.url=http://localhost:8090
 mosip.certify.discovery.issuer-id=${mosipbox.public.url}${server.servlet.path}
 mosip.certify.data-provider-plugin.did-url=http://localhost/pub.key.json
 
-## ------------------------------------------- IAR Test Configuration -------------------------------------------
-mosip.certify.iar.default-client-id=test-wallet-client
-mosip.certify.iar.session-timeout-seconds=300
-mosip.certify.iar.require-interaction=true
-mosip.certify.iar.presentation.default-id=test-employment-check
-mosip.certify.iar.presentation.identity-descriptor-id=test-identity
-mosip.certify.iar.presentation.contract-descriptor-id=test-contract
-mosip.certify.iar.openid4vp.response-mode=iar-post
-
 ##---------------------------------------------------------------------------------------------------------------------
 spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration,org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration
 

--- a/docker-compose/docker-compose-injistack/config/certify-default.properties
+++ b/docker-compose/docker-compose-injistack/config/certify-default.properties
@@ -227,28 +227,6 @@ mosip.certify.oauth.interactive-authorization-endpoint=${mosip.certify.domain.ur
 mosip.certify.oauth.access-token.audience=${mosip.certify.identifier}/v1/certify/issuance/credential
 
 
-## ---------------------------------------- Presentation Definition Configuration --------------------------------------------------------
-
-# Path to presentation definition configuration file (JSON format similar to inji-verify)
-mosip.certify.presentation-definition.config-file=file:///home/mosip/certify-config.json
-
-# Default credential type to use when specific type not found in configuration
-mosip.certify.presentation-definition.default-credential-type=MOSIPVerifiableCredential
-
-# Default presentation definition ID
-mosip.certify.presentation-definition.default-id=default-presentation
-
-# Default credential type for IAR presentation requests
-mosip.certify.iar.presentation.default-credential-type=MOSIPVerifiableCredential
-
-## ---------------------------------------- Legacy IAR Presentation Configuration (Fallback) --------------------------------------------------------
-
-# Legacy presentation definition configuration (used as fallback when configuration service fails)
-mosip.certify.iar.presentation.identity-descriptor-id=identity
-mosip.certify.iar.presentation.contract-descriptor-id=contract
-mosip.certify.iar.presentation.fields.given-name=$.credentialSubject.given_name
-mosip.certify.iar.presentation.fields.family-name=$.credentialSubject.family_name
-mosip.certify.iar.presentation.fields.contract-id=$.credentialSubject.contract_id
 
 ## ---------------------------------------- Verify Service Configuration --------------------------------------------------------
 
@@ -266,6 +244,7 @@ mosip.certify.verify.service.presentation-definition.purpose=Relying party is re
 
 # Input Descriptor
 mosip.certify.verify.service.presentation-definition.input-descriptors[0].id=id card credential
+mosip.certify.verify.service.presentation-definition.input-descriptors[0].format.ldp_vc.proof_type[0]=RsaSignature2018
 
 # Constraints ? Fields
 mosip.certify.verify.service.presentation-definition.input-descriptors[0].constraints.fields[0].path[0]=$.type


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined VP verification by removing configuration-based status mapping in favor of standard checks.
  * Removed IAR session timeout and interaction requirement settings.
  * Removed legacy presentation definition configuration and replaced with explicit LDP-VP proof type settings.
  * Added support for RsaSignature2018 proof type specification for credential verification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->