### PR TITLE
fix: update iar request param names to snake case

### DIFF
--- a/certify-core/src/main/java/io/mosip/certify/core/dto/AuthorizationDetail.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/dto/AuthorizationDetail.java
@@ -24,28 +24,8 @@ public class AuthorizationDetail {
     private String type;
 
     /**
-     * Locations where the credential can be obtained
-     */
-    @JsonProperty("locations")
-    private String[] locations;
-
-    /**
      * Credential configuration identifier
      */
     @JsonProperty("credential_configuration_id")
     private String credentialConfigurationId;
-
-    /**
-     * Format of the credential (e.g., "jwt_vc", "ldp_vc", "vc+sd-jwt")
-     */
-    @JsonProperty("format")
-    private String format;
-
-    /**
-     * Verifiable Credential Type (VCT) - required when format is present
-     * Used for VC+SD-JWT format to specify the credential type
-     */
-    @JsonProperty("vct")
-    private String vct;
-
 }

--- a/certify-core/src/main/java/io/mosip/certify/core/dto/IarRequest.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/dto/IarRequest.java
@@ -5,7 +5,6 @@
  */
 package io.mosip.certify.core.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.mosip.certify.core.validation.ValidIar;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -27,59 +26,50 @@ public class IarRequest {
     /**
      * OAuth 2.0 Response Type - typically "code"
      */
-    @JsonProperty("response_type")
-    private String responseType;
+    private String response_type;
 
     /**
      * OAuth 2.0 Client Identifier
      */
-    @JsonProperty("client_id")
-    private String clientId;
+    private String client_id;
 
     /**
      * PKCE Code Challenge
      */
-    @JsonProperty("code_challenge")
-    private String codeChallenge;
+    private String code_challenge;
 
     /**
      * PKCE Code Challenge Method - typically "S256"
      */
-    @JsonProperty("code_challenge_method")
-    private String codeChallengeMethod;
+    private String code_challenge_method;
 
     /**
      * OAuth 2.0 Redirect URI
      */
-    @JsonProperty("redirect_uri")
-    private String redirectUri;
+    private String redirect_uri;
 
     /**
      * Supported interaction types - e.g., "openid4vp_presentation"
      */
-    @JsonProperty("interaction_types_supported")
-    private String interactionTypesSupported;
+    private String interaction_types_supported;
 
 
     /**
      * Authorization details as per OpenID4VCI specification
      * Specifies the credential types being requested
      */
-    @JsonProperty("authorization_details")
-    private List<AuthorizationDetail> authorizationDetails;
+    private List<AuthorizationDetail> authorization_details;
 
     // Fields from IarAuthorizationRequest (for VP presentation responses)
     
     /**
      * Authorization session identifier from initial IAR response
      */
-    @JsonProperty("auth_session")
-    private String authSession;
+    private String auth_session;
 
     /**
      * OpenID4VP presentation response (unencrypted or encrypted JWT)
      */
-    @JsonProperty("openid4vp_presentation")
-    private String openid4vpPresentation;
+    private String openid4vp_response;
 
 }

--- a/certify-core/src/main/java/io/mosip/certify/core/dto/OAuthTokenRequest.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/dto/OAuthTokenRequest.java
@@ -5,7 +5,6 @@
  */
 package io.mosip.certify.core.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import jakarta.validation.constraints.NotBlank;
 import io.mosip.certify.core.validation.ValidOAuthTokenRequest;
@@ -24,26 +23,22 @@ public class OAuthTokenRequest {
      * REQUIRED. Value MUST be set to "authorization_code", "urn:ietf:params:oauth:grant-type:pre-authorized_code", or "refresh_token"
      */
     @NotBlank(message = "grant_type is required")
-    @JsonProperty("grant_type")
-    private String grantType;
+    private String grant_type;
 
     /**
      * REQUIRED (for authorization_code grant). The authorization code received from the authorization server.
      */
-    @JsonProperty("code")
     private String code;
 
 
     /**
      * REQUIRED (for PKCE). Code verifier used in the Proof Key for Code Exchange (PKCE) extension.
      */
-    @JsonProperty("code_verifier")
-    private String codeVerifier;
+    private String code_verifier;
 
     /**
      * REQUIRED (for refresh_token grant). The refresh token issued to the client.
      */
-    @JsonProperty("refresh_token")
-    private String refreshToken;
+    private String refresh_token;
 
 }

--- a/certify-core/src/main/java/io/mosip/certify/core/spi/IarService.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/spi/IarService.java
@@ -22,11 +22,11 @@ public interface IarService {
      * Determines whether this is an initial authorization request or VP presentation response
      * and routes to the appropriate processing method
      * 
-     * @param unifiedRequest The unified request containing either authorization or presentation data
+     * @param iarRequest The interactive authorization request containing either authorization or presentation data
      * @return Object containing either IarResponse or IarAuthorizationResponse
      * @throws CertifyException if request processing fails
      */
-    Object handleIarRequest(IarRequest unifiedRequest) throws CertifyException;
+    Object handleIarRequest(IarRequest iarRequest) throws CertifyException;
 
     /**
      * Process OAuth Token Request (Step 19-20)

--- a/certify-core/src/main/java/io/mosip/certify/core/validation/IarValidator.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/validation/IarValidator.java
@@ -20,13 +20,13 @@ public class IarValidator implements ConstraintValidator<ValidIar, IarRequest> {
 			return false;
 		}
 
-		boolean hasAuthSession = StringUtils.hasText(value.getAuthSession());
-		boolean hasVp = StringUtils.hasText(value.getOpenid4vpPresentation());
+		boolean hasAuthSession = StringUtils.hasText(value.getAuth_session());
+		boolean hasVp = StringUtils.hasText(value.getOpenid4vp_response());
 
 		boolean hasInitial =
-			StringUtils.hasText(value.getResponseType()) &&
-			StringUtils.hasText(value.getCodeChallenge()) &&
-			StringUtils.hasText(value.getCodeChallengeMethod());
+			StringUtils.hasText(value.getResponse_type()) &&
+			StringUtils.hasText(value.getCode_challenge()) &&
+			StringUtils.hasText(value.getCode_challenge_method());
 
 		// Exactly one of the flows must be present
 		boolean isPresentationFlow = hasAuthSession && hasVp;
@@ -38,7 +38,7 @@ public class IarValidator implements ConstraintValidator<ValidIar, IarRequest> {
 
 		context.disableDefaultConstraintViolation();
 		context.buildConstraintViolationWithTemplate(
-			"Invalid IAR request: either provide auth_session and openid4vp_presentation, or the initial authorization parameters"
+			"Invalid IAR request: either provide auth_session and openid4vp_response, or the initial authorization parameters"
 		).addConstraintViolation();
 		return false;
 	}

--- a/certify-core/src/main/java/io/mosip/certify/core/validation/OAuthTokenRequestValidator.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/validation/OAuthTokenRequestValidator.java
@@ -22,48 +22,46 @@ public class OAuthTokenRequestValidator implements ConstraintValidator<ValidOAut
         }
 
         // Validate grant_type
-        if (!StringUtils.hasText(value.getGrantType())) {
+        if (!StringUtils.hasText(value.getGrant_type())) {
             context.disableDefaultConstraintViolation();
             context.buildConstraintViolationWithTemplate("grant_type is required")
-                   .addPropertyNode("grantType")
+                   .addPropertyNode("grant_type")
                    .addConstraintViolation();
             return false;
         }
 
         // Only support authorization_code grant type for now
-        if (!"authorization_code".equals(value.getGrantType())) {
+        if (!"authorization_code".equals(value.getGrant_type())) {
             context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate("Unsupported grant_type: " + value.getGrantType() + ". Only 'authorization_code' is supported")
-                   .addPropertyNode("grantType")
+            context.buildConstraintViolationWithTemplate("Unsupported grant_type: " + value.getGrant_type() + ". Only 'authorization_code' is supported")
+                   .addPropertyNode("grant_type")
                    .addConstraintViolation();
             return false;
         }
 
         // For authorization_code grant, validate required fields
-        if ("authorization_code".equals(value.getGrantType())) {
-            boolean hasCode = StringUtils.hasText(value.getCode());
-            boolean hasCodeVerifier = StringUtils.hasText(value.getCodeVerifier());
+        boolean hasCode = StringUtils.hasText(value.getCode());
+        boolean hasCodeVerifier = StringUtils.hasText(value.getCode_verifier());
 
-            if (!hasCode) {
-                context.disableDefaultConstraintViolation();
-                context.buildConstraintViolationWithTemplate("code is required for authorization_code grant")
-                       .addPropertyNode("code")
-                       .addConstraintViolation();
-                return false;
-            }
-
-            if (!hasCodeVerifier) {
-                context.disableDefaultConstraintViolation();
-                context.buildConstraintViolationWithTemplate("code_verifier is required for PKCE")
-                       .addPropertyNode("codeVerifier")
-                       .addConstraintViolation();
-                return false;
-            }
-            
-            // redirect_uri is optional since we don't support redirect_to_web
-            // client_id is optional for public clients per RFC 7636 Section 3.2
-            // No validation needed for client_id or redirect_uri presence
+        if (!hasCode) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate("code is required for authorization_code grant")
+                   .addPropertyNode("code")
+                   .addConstraintViolation();
+            return false;
         }
+
+        if (!hasCodeVerifier) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate("code_verifier is required for PKCE")
+                   .addPropertyNode("code_verifier")
+                   .addConstraintViolation();
+            return false;
+        }
+
+        // redirect_uri is optional since we don't support redirect_to_web
+        // client_id is optional for public clients per RFC 7636 Section 3.2
+        // No validation needed for client_id or redirect_uri presence
 
         return true;
     }

--- a/certify-core/src/main/java/io/mosip/certify/core/validation/ValidIar.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/validation/ValidIar.java
@@ -20,7 +20,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Constraint(validatedBy = IarValidator.class)
 @Documented
 public @interface ValidIar {
-	String message() default "Invalid IAR request: provide either (auth_session and openid4vp_presentation) or initial authorization parameters";
+	String message() default "Invalid IAR request: provide either (auth_session and openid4vp_response) or initial authorization parameters";
 
 	Class<?>[] groups() default {};
 

--- a/certify-service/src/main/java/io/mosip/certify/controller/OAuthController.java
+++ b/certify-service/src/main/java/io/mosip/certify/controller/OAuthController.java
@@ -43,7 +43,7 @@ public class OAuthController {
      * POST /oauth/iar
      * 
      * Handles both initial authorization requests and VP presentation responses.
-     * Determines the request type based on the presence of auth_session and openid4vp_presentation.
+     * Determines the request type based on the presence of auth_session and openid4vp_response.
      * 
      * For initial requests: Returns IarResponse containing status, auth_session, and openid4vp_request if interaction required
      * For VP presentations: Returns IarAuthorizationResponse containing authorization code or error
@@ -92,7 +92,7 @@ public class OAuthController {
                  produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> processTokenRequest(@Valid OAuthTokenRequest tokenRequest)
             throws CertifyException {
-        log.info("Processing OAuth token request for grant_type: {}", tokenRequest.getGrantType());
+        log.info("Processing OAuth token request for grant_type: {}", tokenRequest.getGrant_type());
 
         try {
             // Process the token request

--- a/certify-service/src/test/java/io/mosip/certify/controller/OAuthControllerTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/controller/OAuthControllerTest.java
@@ -75,12 +75,12 @@ class OAuthControllerTest {
         // Act & Assert
         mockMvc.perform(post("/oauth/iar")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .param("responseType", "code")
-                .param("clientId", "test-client")
-                .param("codeChallenge", "test-challenge")
-                .param("codeChallengeMethod", "S256")
-                .param("redirectUri", "https://test.com/callback")
-                .param("interactionTypesSupported", "openid4vp_presentation"))
+                .param("response_type", "code")
+                .param("client_id", "test-client")
+                .param("code_challenge", "test-challenge")
+                .param("code_challenge_method", "S256")
+                .param("redirect_uri", "https://test.com/callback")
+                .param("interaction_types_supported", "openid4vp_presentation"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.status").value("require_interaction"))
@@ -104,11 +104,11 @@ class OAuthControllerTest {
         // Act & Assert
         mockMvc.perform(post("/oauth/iar")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .param("responseType", "code")
-                .param("clientId", "test-client")
-                .param("codeChallenge", "test-challenge")
-                .param("codeChallengeMethod", "S256")
-                .param("redirectUri", "https://test.com/callback"))
+                .param("response_type", "code")
+                .param("client_id", "test-client")
+                .param("code_challenge", "test-challenge")
+                .param("code_challenge_method", "S256")
+                .param("redirect_uri", "https://test.com/callback"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("ok"))
                 .andExpect(jsonPath("$.type").doesNotExist())
@@ -126,11 +126,11 @@ class OAuthControllerTest {
         // Act & Assert - Only required parameters
         mockMvc.perform(post("/oauth/iar")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .param("responseType", "code")
-                .param("clientId", "test-client")
-                .param("codeChallenge", "test-challenge")
-                .param("codeChallengeMethod", "S256")
-                .param("redirectUri", "https://test.com/callback"))
+                .param("response_type", "code")
+                .param("client_id", "test-client")
+                .param("code_challenge", "test-challenge")
+                .param("code_challenge_method", "S256")
+                .param("redirect_uri", "https://test.com/callback"))
                 .andExpect(status().isOk());
 
         verify(iarService, times(1)).handleIarRequest(any(IarRequest.class));
@@ -145,12 +145,12 @@ class OAuthControllerTest {
         // Act & Assert - All parameters including optional ones
         mockMvc.perform(post("/oauth/iar")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .param("responseType", "code")
-                .param("clientId", "test-client")
-                .param("codeChallenge", "test-challenge")
-                .param("codeChallengeMethod", "S256")
-                .param("redirectUri", "https://test.com/callback")
-                .param("interactionTypesSupported", "openid4vp_presentation"))
+                .param("response_type", "code")
+                .param("client_id", "test-client")
+                .param("code_challenge", "test-challenge")
+                .param("code_challenge_method", "S256")
+                .param("redirect_uri", "https://test.com/callback")
+                .param("interaction_types_supported", "openid4vp_presentation"))
                 .andExpect(status().isOk());
 
         verify(iarService, times(1)).handleIarRequest(any(IarRequest.class));
@@ -161,12 +161,12 @@ class OAuthControllerTest {
         // Arrange - Test with missing required parameters to trigger validation failure
         // This test should trigger @ValidIar validation failure at Spring level
 
-        // Act & Assert - Missing codeChallenge should cause validation to fail
+        // Act & Assert - Missing code_challenge should cause validation to fail
         mockMvc.perform(post("/oauth/iar")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .param("responseType", "code")
-                .param("codeChallengeMethod", "S256")
-                .param("redirectUri", "https://test.com/callback"))
+                .param("response_type", "code")
+                .param("code_challenge_method", "S256")
+                .param("redirect_uri", "https://test.com/callback"))
                 .andExpect(status().isBadRequest()); // Validation failure should return 400 Bad Request
 
         // The service should not be called if validation fails
@@ -182,11 +182,11 @@ class OAuthControllerTest {
         // Act & Assert
         mockMvc.perform(post("/oauth/iar")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .param("responseType", "code")
-                .param("clientId", "test-client")
-                .param("codeChallenge", "test-challenge")
-                .param("codeChallengeMethod", "S256")
-                .param("redirectUri", "https://test.com/callback"))
+                .param("response_type", "code")
+                .param("client_id", "test-client")
+                .param("code_challenge", "test-challenge")
+                .param("code_challenge_method", "S256")
+                .param("redirect_uri", "https://test.com/callback"))
                 .andExpect(status().isBadRequest())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.error").value("interaction_required"))
@@ -204,11 +204,11 @@ class OAuthControllerTest {
         // Act & Assert
         mockMvc.perform(post("/oauth/iar")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .param("responseType", "code")
-                .param("clientId", "test-client")
-                .param("codeChallenge", "test-challenge")
-                .param("codeChallengeMethod", "S256")
-                .param("redirectUri", "https://test.com/callback"))
+                .param("response_type", "code")
+                .param("client_id", "test-client")
+                .param("code_challenge", "test-challenge")
+                .param("code_challenge_method", "S256")
+                .param("redirect_uri", "https://test.com/callback"))
                 .andExpect(status().isInternalServerError())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.error").value("server_error"))
@@ -218,7 +218,7 @@ class OAuthControllerTest {
     }
 
     @Test
-    void processInteractiveAuthorizationRequest_differentCodeChallengeMethods() throws Exception {
+    void processInteractiveAuthorizationRequest_differentcode_challenge_methods() throws Exception {
         // Arrange
         IarResponse mockResponse = createMockIarResponse(IarStatus.REQUIRE_INTERACTION);
         when(iarService.handleIarRequest(any(IarRequest.class))).thenReturn(mockResponse);
@@ -226,21 +226,21 @@ class OAuthControllerTest {
         // Test S256 method
         mockMvc.perform(post("/oauth/iar")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .param("responseType", "code")
-                .param("clientId", "test-client")
-                .param("codeChallenge", "test-challenge-s256")
-                .param("codeChallengeMethod", "S256")
-                .param("redirectUri", "https://test.com/callback"))
+                .param("response_type", "code")
+                .param("client_id", "test-client")
+                .param("code_challenge", "test-challenge-s256")
+                .param("code_challenge_method", "S256")
+                .param("redirect_uri", "https://test.com/callback"))
                 .andExpect(status().isOk());
 
         // Test S256 method again (plain method removed for security)
         mockMvc.perform(post("/oauth/iar")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .param("responseType", "code")
-                .param("clientId", "test-client")
-                .param("codeChallenge", "test-challenge-s256-2")
-                .param("codeChallengeMethod", "S256")
-                .param("redirectUri", "https://test.com/callback"))
+                .param("response_type", "code")
+                .param("client_id", "test-client")
+                .param("code_challenge", "test-challenge-s256-2")
+                .param("code_challenge_method", "S256")
+                .param("redirect_uri", "https://test.com/callback"))
                 .andExpect(status().isOk());
 
         verify(iarService, times(2)).handleIarRequest(any(IarRequest.class));
@@ -255,21 +255,21 @@ class OAuthControllerTest {
         // Test with code response type
         mockMvc.perform(post("/oauth/iar")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .param("responseType", "code")
-                .param("clientId", "test-client")
-                .param("codeChallenge", "test-challenge")
-                .param("codeChallengeMethod", "S256")
-                .param("redirectUri", "https://test.com/callback"))
+                .param("response_type", "code")
+                .param("client_id", "test-client")
+                .param("code_challenge", "test-challenge")
+                .param("code_challenge_method", "S256")
+                .param("redirect_uri", "https://test.com/callback"))
                 .andExpect(status().isOk());
 
         // Test with vp_token response type
         mockMvc.perform(post("/oauth/iar")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .param("responseType", "vp_token")
-                .param("clientId", "test-client")
-                .param("codeChallenge", "test-challenge")
-                .param("codeChallengeMethod", "S256")
-                .param("redirectUri", "https://test.com/callback"))
+                .param("response_type", "vp_token")
+                .param("client_id", "test-client")
+                .param("code_challenge", "test-challenge")
+                .param("code_challenge_method", "S256")
+                .param("redirect_uri", "https://test.com/callback"))
                 .andExpect(status().isOk());
 
         verify(iarService, times(2)).handleIarRequest(any(IarRequest.class));
@@ -284,11 +284,11 @@ class OAuthControllerTest {
         // Act & Assert - Should accept form-urlencoded content type
         mockMvc.perform(post("/oauth/iar")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .param("responseType", "code")
-                .param("clientId", "test-client")
-                .param("codeChallenge", "test-challenge")
-                .param("codeChallengeMethod", "S256")
-                .param("redirectUri", "https://test.com/callback"))
+                .param("response_type", "code")
+                .param("client_id", "test-client")
+                .param("code_challenge", "test-challenge")
+                .param("code_challenge_method", "S256")
+                .param("redirect_uri", "https://test.com/callback"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
 
@@ -309,12 +309,12 @@ class OAuthControllerTest {
         // Act & Assert - Test with authorization details
         mockMvc.perform(post("/oauth/iar")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .param("responseType", "code")
-                .param("clientId", "test-client")
-                .param("codeChallenge", "test-challenge")
-                .param("codeChallengeMethod", "S256")
-                .param("redirectUri", "https://test.com/callback")
-                .param("interactionTypesSupported", "openid4vp_presentation"))
+                .param("response_type", "code")
+                .param("client_id", "test-client")
+                .param("code_challenge", "test-challenge")
+                .param("code_challenge_method", "S256")
+                .param("redirect_uri", "https://test.com/callback")
+                .param("interaction_types_supported", "openid4vp_presentation"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.status").value("require_interaction"))
@@ -325,7 +325,7 @@ class OAuthControllerTest {
     }
 
     @Test
-    void processInteractiveAuthorizationRequest_emptyClientId_success() throws Exception {
+    void processInteractiveAuthorizationRequest_emptyclient_id_success() throws Exception {
         // Arrange
         IarResponse mockResponse = createMockIarResponse(IarStatus.REQUIRE_INTERACTION);
         when(iarService.handleIarRequest(any(IarRequest.class))).thenReturn(mockResponse);
@@ -333,11 +333,11 @@ class OAuthControllerTest {
         // Act & Assert - Test with empty client_id (public client)
         mockMvc.perform(post("/oauth/iar")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .param("responseType", "code")
-                .param("clientId", "") // Empty client ID
-                .param("codeChallenge", "test-challenge")
-                .param("codeChallengeMethod", "S256")
-                .param("redirectUri", "https://test.com/callback"))
+                .param("response_type", "code")
+                .param("client_id", "") // Empty client ID
+                .param("code_challenge", "test-challenge")
+                .param("code_challenge_method", "S256")
+                .param("redirect_uri", "https://test.com/callback"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
 
@@ -345,7 +345,7 @@ class OAuthControllerTest {
     }
 
     @Test
-    void processInteractiveAuthorizationRequest_missingRedirectUri_success() throws Exception {
+    void processInteractiveAuthorizationRequest_missingredirect_uri_success() throws Exception {
         // Arrange
         IarResponse mockResponse = createMockIarResponse(IarStatus.REQUIRE_INTERACTION);
         when(iarService.handleIarRequest(any(IarRequest.class))).thenReturn(mockResponse);
@@ -353,10 +353,10 @@ class OAuthControllerTest {
         // Act & Assert - Test without redirect_uri (optional parameter)
         mockMvc.perform(post("/oauth/iar")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .param("responseType", "code")
-                .param("clientId", "test-client")
-                .param("codeChallenge", "test-challenge")
-                .param("codeChallengeMethod", "S256"))
+                .param("response_type", "code")
+                .param("client_id", "test-client")
+                .param("code_challenge", "test-challenge")
+                .param("code_challenge_method", "S256"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.status").value("require_interaction"));
@@ -365,7 +365,7 @@ class OAuthControllerTest {
     }
 
     @Test
-    void processInteractiveAuthorizationRequest_missingInteractionTypesSupported_success() throws Exception {
+    void processInteractiveAuthorizationRequest_missinginteraction_types_supported_success() throws Exception {
         // Arrange
         IarResponse mockResponse = createMockIarResponse(IarStatus.REQUIRE_INTERACTION);
         when(iarService.handleIarRequest(any(IarRequest.class))).thenReturn(mockResponse);
@@ -373,11 +373,11 @@ class OAuthControllerTest {
         // Act & Assert - Test without interaction_types_supported (optional parameter)
         mockMvc.perform(post("/oauth/iar")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .param("responseType", "code")
-                .param("clientId", "test-client")
-                .param("codeChallenge", "test-challenge")
-                .param("codeChallengeMethod", "S256")
-                .param("redirectUri", "https://test.com/callback"))
+                .param("response_type", "code")
+                .param("client_id", "test-client")
+                .param("code_challenge", "test-challenge")
+                .param("code_challenge_method", "S256")
+                .param("redirect_uri", "https://test.com/callback"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.status").value("require_interaction"));
@@ -394,11 +394,11 @@ class OAuthControllerTest {
         // Act & Assert
         mockMvc.perform(post("/oauth/token")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .param("grantType", "authorization_code")
+                .param("grant_type", "authorization_code")
                 .param("code", "invalid-code")
-                .param("redirectUri", "https://test.com/callback")
-                .param("clientId", "test-client")
-                .param("codeVerifier", "test-verifier"))
+                .param("redirect_uri", "https://test.com/callback")
+                .param("client_id", "test-client")
+                .param("code_verifier", "test-verifier"))
                 .andExpect(status().isBadRequest())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.error").value("invalid_grant"))
@@ -416,11 +416,11 @@ class OAuthControllerTest {
         // Act & Assert
         mockMvc.perform(post("/oauth/token")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .param("grantType", "authorization_code")
+                .param("grant_type", "authorization_code")
                 .param("code", "test-code")
-                .param("redirectUri", "https://test.com/callback")
-                .param("clientId", "invalid-client")
-                .param("codeVerifier", "test-verifier"))
+                .param("redirect_uri", "https://test.com/callback")
+                .param("client_id", "invalid-client")
+                .param("code_verifier", "test-verifier"))
                 .andExpect(status().isBadRequest())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.error").value("invalid_client"))
@@ -434,7 +434,7 @@ class OAuthControllerTest {
         // Act & Assert - Missing required parameters should return 400 with OAuth error format
         mockMvc.perform(post("/oauth/token")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .param("grantType", "authorization_code"))
+                .param("grant_type", "authorization_code"))
                 .andExpect(status().isBadRequest())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.error").value("invalid_request"))
@@ -452,8 +452,8 @@ class OAuthControllerTest {
         // Act & Assert
         mockMvc.perform(post("/oauth/iar")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .param("authSession", "test-session-123")
-                .param("openid4vpPresentation", "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9..."))
+                .param("auth_session", "test-session-123")
+                .param("openid4vp_response", "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9..."))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.status").value("ok"))
@@ -471,8 +471,8 @@ class OAuthControllerTest {
         // Act & Assert
         mockMvc.perform(post("/oauth/iar")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .param("authSession", "test-session-123")
-                .param("openid4vpPresentation", "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9..."))
+                .param("auth_session", "test-session-123")
+                .param("openid4vp_response", "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9..."))
                 .andExpect(status().isBadRequest())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.status").value("error"))
@@ -482,11 +482,11 @@ class OAuthControllerTest {
     }
 
     @Test
-    void processVpPresentation_missingAuthSession_returnsBadRequest() throws Exception {
+    void processVpPresentation_missingauth_session_returnsBadRequest() throws Exception {
         // Act & Assert - Missing auth_session should cause validation failure
         mockMvc.perform(post("/oauth/iar")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .param("openid4vpPresentation", "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9..."))
+                .param("openid4vp_response", "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9..."))
                 .andExpect(status().isBadRequest());
 
         // The service should not be called if validation fails
@@ -495,10 +495,10 @@ class OAuthControllerTest {
 
     @Test
     void processVpPresentation_missingVpPresentation_returnsBadRequest() throws Exception {
-        // Act & Assert - Missing openid4vp_presentation should cause validation failure
+        // Act & Assert - Missing openid4vp_response should cause validation failure
         mockMvc.perform(post("/oauth/iar")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .param("authSession", "test-session-123"))
+                .param("auth_session", "test-session-123"))
                 .andExpect(status().isBadRequest());
 
         // The service should not be called if validation fails
@@ -517,8 +517,8 @@ class OAuthControllerTest {
         // Act & Assert
         mockMvc.perform(post("/oauth/iar")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .param("authSession", "test-session-123")
-                .param("openid4vpPresentation", "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9..."))
+                .param("auth_session", "test-session-123")
+                .param("openid4vp_response", "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9..."))
                 .andExpect(status().isInternalServerError())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.error").value("server_error"))
@@ -536,8 +536,8 @@ class OAuthControllerTest {
         // Act & Assert - Test with JWT VP token
         mockMvc.perform(post("/oauth/iar")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .param("authSession", "test-session-jwt")
-                .param("openid4vpPresentation", "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJ3YWxsZXQiLCJhdWQiOiJ2ZXJpZmllciIsInN1YiI6InRlc3QtdXNlciJ9.signature"))
+                .param("auth_session", "test-session-jwt")
+                .param("openid4vp_response", "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJ3YWxsZXQiLCJhdWQiOiJ2ZXJpZmllciIsInN1YiI6InRlc3QtdXNlciJ9.signature"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("ok"))
                 .andExpect(jsonPath("$.code").value("iar_auth_jwt123456789"));
@@ -555,8 +555,8 @@ class OAuthControllerTest {
         String jsonVpPresentation = "{\"vp_token\":{\"type\":\"VerifiablePresentation\",\"verifiableCredential\":[]},\"presentation_submission\":{\"id\":\"test-submission\"}}";
         mockMvc.perform(post("/oauth/iar")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .param("authSession", "test-session-json")
-                .param("openid4vpPresentation", jsonVpPresentation))
+                .param("auth_session", "test-session-json")
+                .param("openid4vp_response", jsonVpPresentation))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("ok"))
                 .andExpect(jsonPath("$.code").value("iar_auth_json123456789"));
@@ -576,8 +576,8 @@ class OAuthControllerTest {
         // Act & Assert - Should accept form-urlencoded content type for VP presentation
         mockMvc.perform(post("/oauth/iar")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .param("authSession", "test-session-123")
-                .param("openid4vpPresentation", "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9..."))
+                .param("auth_session", "test-session-123")
+                .param("openid4vp_response", "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9..."))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
 
@@ -585,12 +585,12 @@ class OAuthControllerTest {
     }
 
     @Test
-    void processVpPresentation_emptyAuthSession_returnsBadRequest() throws Exception {
+    void processVpPresentation_emptyauth_session_returnsBadRequest() throws Exception {
         // Act & Assert - Empty auth_session should cause validation failure
         mockMvc.perform(post("/oauth/iar")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .param("authSession", "")
-                .param("openid4vpPresentation", "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9..."))
+                .param("auth_session", "")
+                .param("openid4vp_response", "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9..."))
                 .andExpect(status().isBadRequest());
 
         verify(iarService, never()).handleIarRequest(any(IarRequest.class));
@@ -598,11 +598,11 @@ class OAuthControllerTest {
 
     @Test
     void processVpPresentation_emptyVpPresentation_returnsBadRequest() throws Exception {
-        // Act & Assert - Empty openid4vp_presentation should cause validation failure
+        // Act & Assert - Empty openid4vp_response should cause validation failure
         mockMvc.perform(post("/oauth/iar")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .param("authSession", "test-session-123")
-                .param("openid4vpPresentation", ""))
+                .param("auth_session", "test-session-123")
+                .param("openid4vp_response", ""))
                 .andExpect(status().isBadRequest());
 
         verify(iarService, never()).handleIarRequest(any(IarRequest.class));
@@ -613,8 +613,8 @@ class OAuthControllerTest {
         // Act & Assert - Whitespace-only parameters should cause validation failure
         mockMvc.perform(post("/oauth/iar")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .param("authSession", "   ")
-                .param("openid4vpPresentation", "   "))
+                .param("auth_session", "   ")
+                .param("openid4vp_response", "   "))
                 .andExpect(status().isBadRequest());
 
         verify(iarService, never()).handleIarRequest(any(IarRequest.class));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized OAuth/IAR request fields to snake_case across APIs, validators and service flows
  * Renamed openid4vp_presentation to openid4vp_response throughout the codebase
  * Removed three unused authorization detail fields

* **Tests**
  * Updated tests to use snake_case parameters and adjusted assertions

* **Documentation**
  * Updated method docs and log messages to reflect renamed parameters

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->