### PR TITLE
[INJICERT-1277] Initialise Interactive Authorization service only if authorization module is certify

### DIFF
--- a/certify-service/src/main/java/io/mosip/certify/services/IarServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/IarServiceImpl.java
@@ -16,6 +16,7 @@ import io.mosip.certify.core.spi.IarService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
@@ -35,6 +36,7 @@ import io.mosip.certify.utils.AccessTokenJwtUtil;
  */
 @Slf4j
 @Service
+@ConditionalOnProperty(value = "mosip.certify.authorization-module", havingValue = "certify")
 public class IarServiceImpl implements IarService {
 
     @Autowired

--- a/certify-service/src/test/resources/application-test.properties
+++ b/certify-service/src/test/resources/application-test.properties
@@ -108,6 +108,8 @@ crypto.PrependThumbprint.enable=true
 
 mosip.certify.cache.security.secretkey.reference-id=TRANSACTION_CACHE
 
+mosip.certify.authorization-module=certify
+
 ## ------------------------------------------- OAuth AS Metadata Configuration -------------------------------------------
 mosip.certify.oauth.issuer=http://localhost:8090
 mosip.certify.oauth.token-endpoint=http://localhost:8090/v1/certify/oauth/token


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Configuration**
  * Added new configuration property to control authorization module behavior, enabling operators to activate or deactivate the feature based on specific deployment requirements without code modifications.

* **Chores**
  * Enhanced service initialization with conditional loading capabilities, ensuring authorization services are activated only when explicitly configured in application properties. This improves deployment flexibility and optimizes resource usage across different environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->