### PR TITLE
[INJICERT-1298] Update github repo references to github.io/inji and maven groupId to io.inji

### DIFF
--- a/api-test/metadata.xml
+++ b/api-test/metadata.xml
@@ -8,7 +8,7 @@
 	<url>http://maven.apache.org</url>
 
 	<parent>
-		<groupId>io.mosip</groupId>
+		<groupId>io.inji</groupId>
 		<artifactId>mosip-parent</artifactId>
 		<version>1.0.10</version>
 	</parent>

--- a/api-test/pom.xml
+++ b/api-test/pom.xml
@@ -2,12 +2,12 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>io.mosip.certify</groupId>
+	<groupId>io.inji.certify</groupId>
 	<artifactId>apitest-injicertify</artifactId>
 	<packaging>jar</packaging>
 	<name>apitest-injicertify</name>
 	<description>Parent project of apitest-injicertify</description>
-	<url>https://github.com/mosip/inji-certify</url>
+	<url>https://github.com/inji/inji-certify</url>
 	<version>0.14.0-SNAPSHOT</version>
 
 	<licenses>
@@ -18,9 +18,9 @@
 	</licenses>
 
 	<scm>
-		<connection>scm:git:git://github.com/mosip/inji-certify.git</connection>
-		<developerConnection>scm:git:ssh://github.com:mosip/inji-certify.git</developerConnection>
-		<url>https://github.com/mosip/inji-certify</url>
+		<connection>scm:git:git://github.com/inji/inji-certify.git</connection>
+		<developerConnection>scm:git:ssh://github.com:inji/inji-certify.git</developerConnection>
+		<url>https://github.com/inji/inji-certify</url>
 		<tag>HEAD</tag>
 	</scm>
 
@@ -28,8 +28,8 @@
 		<developer>
 			<name>Mosip</name>
 			<email>mosip.emailnotifier@gmail.com</email>
-			<organization>io.mosip</organization>
-			<organizationUrl>https://github.com/mosip/inji-certify</organizationUrl>
+			<organization>io.inji</organization>
+			<organizationUrl>https://inji.io</organizationUrl>
 		</developer>
 	</developers>
 

--- a/certify-core/pom.xml
+++ b/certify-core/pom.xml
@@ -8,12 +8,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.mosip.certify</groupId>
+        <groupId>io.inji.certify</groupId>
         <artifactId>certify-parent</artifactId>
         <version>0.14.0-SNAPSHOT</version>
     </parent>
 
-    <groupId>io.mosip.certify</groupId>
+    <groupId>io.inji.certify</groupId>
     <artifactId>certify-core</artifactId>
     <name>certify-core</name>
     <version>${project.parent.version}</version>
@@ -36,7 +36,7 @@
             <version>${google.guava.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.mosip.certify</groupId>
+            <groupId>io.inji.certify</groupId>
             <artifactId>certify-integration-api</artifactId>
             <version>${project.parent.version}</version>
         </dependency>

--- a/certify-integration-api/pom.xml
+++ b/certify-integration-api/pom.xml
@@ -4,12 +4,12 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.mosip.certify</groupId>
+        <groupId>io.inji.certify</groupId>
         <artifactId>certify-parent</artifactId>
         <version>0.14.0-SNAPSHOT</version>
     </parent>
 
-    <groupId>io.mosip.certify</groupId>
+    <groupId>io.inji.certify</groupId>
     <artifactId>certify-integration-api</artifactId>
     <version>0.14.0-SNAPSHOT</version>
     <name>certify-integration-api</name>

--- a/certify-service-with-plugins/pom.xml
+++ b/certify-service-with-plugins/pom.xml
@@ -7,17 +7,17 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.mosip.certify</groupId>
+        <groupId>io.inji.certify</groupId>
         <artifactId>certify-parent</artifactId>
         <version>0.14.0-SNAPSHOT</version>
     </parent>
 
-    <groupId>io.mosip.certify</groupId>
+    <groupId>io.inji.certify</groupId>
     <artifactId>certify-service-with-plugins</artifactId>
     <version>0.14.0-SNAPSHOT</version>
     <name>certify-service-with-plugins</name>
     <description>certify vci service</description>
-    <url>https://github.com/mosip/inji-certify</url>
+    <url>https://github.com/inji/inji-certify</url>
 
     <licenses>
         <license>
@@ -30,20 +30,20 @@
         <developer>
             <name>Mosip</name>
             <email>mosip.emailnotifier@gmail.com</email>
-            <organization>io.mosip</organization>
-            <organizationUrl>https://github.com/mosip/inji-certify</organizationUrl>
+            <organization>io.inji</organization>
+            <organizationUrl>https://inji.io</organizationUrl>
         </developer>
     </developers>
 
     <properties>
         <certify-plugins.location>target</certify-plugins.location>
-        <mock-certify-plugin.version>0.5.0</mock-certify-plugin.version>
+        <mock-certify-plugin.version>0.5.0-SNAPSHOT</mock-certify-plugin.version>
         <mock-certify-plugin.fileName>mock-certify-plugin.jar</mock-certify-plugin.fileName>
-        <mosip-identity-certify-plugin.version>0.5.0</mosip-identity-certify-plugin.version>
+        <mosip-identity-certify-plugin.version>0.5.0-SNAPSHOT</mosip-identity-certify-plugin.version>
         <mosip-identity-certify-plugin.fileName>mosip-identity-certify-plugin.jar</mosip-identity-certify-plugin.fileName>
-        <postgres-dataprovider-plugin.version>0.5.0</postgres-dataprovider-plugin.version>
+        <postgres-dataprovider-plugin.version>0.5.0-SNAPSHOT</postgres-dataprovider-plugin.version>
         <postgres-dataprovider-plugin.fileName>postgres-dataprovider-plugin.jar</postgres-dataprovider-plugin.fileName>
-        <sunbird-rc-certify-integration-plugin.version>0.5.0</sunbird-rc-certify-integration-plugin.version>
+        <sunbird-rc-certify-integration-plugin.version>0.5.0-SNAPSHOT</sunbird-rc-certify-integration-plugin.version>
         <sunbird-rc-certify-integration-plugin.fileName>sunbird-rc-certify-integration-impl.jar</sunbird-rc-certify-integration-plugin.fileName>
     </properties>
     <build>
@@ -64,7 +64,7 @@
                 <configuration>
                     <artifactItems>
                         <artifactItem>
-                            <groupId>io.mosip.certify</groupId>
+                            <groupId>io.inji.certify</groupId>
                             <artifactId>mock-certify-plugin</artifactId>
                             <version>${mock-certify-plugin.version}</version>
                             <outputDirectory>${certify-plugins.location}</outputDirectory>
@@ -72,7 +72,7 @@
                             <type>jar</type>
                         </artifactItem>
                         <artifactItem>
-                            <groupId>io.mosip.certify</groupId>
+                            <groupId>io.inji.certify</groupId>
                             <artifactId>mosip-identity-certify-plugin</artifactId>
                             <version>${mosip-identity-certify-plugin.version}</version>
                             <outputDirectory>${certify-plugins.location}</outputDirectory>
@@ -80,7 +80,7 @@
                             <type>jar</type>
                         </artifactItem>
                         <artifactItem>
-                            <groupId>io.mosip.certify</groupId>
+                            <groupId>io.inji.certify</groupId>
                             <artifactId>postgres-dataprovider-plugin</artifactId>
                             <version>${postgres-dataprovider-plugin.version}</version>
                             <outputDirectory>${certify-plugins.location}</outputDirectory>
@@ -88,7 +88,7 @@
                             <type>jar</type>
                         </artifactItem>
                         <artifactItem>
-                            <groupId>io.mosip.certify.sunbirdrc</groupId>
+                            <groupId>io.inji.certify.sunbirdrc</groupId>
                             <artifactId>sunbird-rc-certify-integration-impl</artifactId>
                             <version>${sunbird-rc-certify-integration-plugin.version}</version>
                             <outputDirectory>${certify-plugins.location}</outputDirectory>

--- a/certify-service/pom.xml
+++ b/certify-service/pom.xml
@@ -7,12 +7,12 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.mosip.certify</groupId>
+        <groupId>io.inji.certify</groupId>
         <artifactId>certify-parent</artifactId>
         <version>0.14.0-SNAPSHOT</version>
     </parent>
 
-    <groupId>io.mosip.certify</groupId>
+    <groupId>io.inji.certify</groupId>
     <artifactId>certify-service</artifactId>
     <version>0.14.0-SNAPSHOT</version>
     <name>certify-service</name>
@@ -74,7 +74,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>io.mosip.certify</groupId>
+            <groupId>io.inji.certify</groupId>
             <artifactId>certify-core</artifactId>
             <version>0.14.0-SNAPSHOT</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -13,13 +13,13 @@
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>io.mosip.certify</groupId>
+	<groupId>io.inji.certify</groupId>
 	<artifactId>certify-parent</artifactId>
 	<version>0.14.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>certify</name>
 	<description>Parent project for MOSIP certify</description>
-	<url>https://github.com/mosip/inji-certify</url>
+	<url>https://github.com/inji/inji-certify</url>
 
 	<licenses>
 		<license>
@@ -29,9 +29,9 @@
 	</licenses>
 
 	<scm>
-		<connection>scm:git:git://github.com/mosip/inji-certify.git</connection>
-		<developerConnection>scm:git:ssh://github.com:mosip/inji-certify.git</developerConnection>
-		<url>https://github.com/mosip/inji-certify</url>
+		<connection>scm:git:git://github.com/inji/inji-certify.git</connection>
+		<developerConnection>scm:git:ssh://github.com:inji/inji-certify.git</developerConnection>
+		<url>https://github.com/inji/inji-certify</url>
 		<tag>HEAD</tag>
 	</scm>
 
@@ -39,8 +39,8 @@
 		<developer>
 			<name>Mosip</name>
 			<email>mosip.emailnotifier@gmail.com</email>
-			<organization>io.mosip</organization>
-			<organizationUrl>https://github.com/mosip/inji-certify</organizationUrl>
+			<organization>io.inji</organization>
+			<organizationUrl>https://inji.io</organizationUrl>
 		</developer>
 	</developers>
 


### PR DESCRIPTION
Update Maven groupId to io.inji
Update github repo link to inji org

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Maven project coordinates and namespace identifiers across build configuration files.
  * Updated repository URLs and SCM connection details to the new project repository.
  * Updated developer/organization metadata and organization URL.
  * Bumped several plugin version properties to snapshot variants.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->