### PR TITLE
[INJICERT-1277] Add publish_to_nexus dependency for building inji-certify-with-plugins docker image

### DIFF
--- a/.github/workflows/push-trigger.yml
+++ b/.github/workflows/push-trigger.yml
@@ -145,7 +145,7 @@ jobs:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
 
   build-docker-inji-certify-with-plugins:
-    needs: [ maven-build-inji-certify-with-plugins, check_snapshot_version ]
+    needs: [ maven-build-inji-certify-with-plugins, check_snapshot_version, publish_to_nexus ]
     if: ${{ needs.check_snapshot_version.outputs.is_condition == 'true' }}
     strategy:
       matrix:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release pipeline execution order to ensure publishing steps complete before subsequent build processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->