### PR TITLE
[INJICERT-1277] Add jwks for certify sevice app id

### DIFF
--- a/certify-service/src/main/java/io/mosip/certify/services/JwksServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/JwksServiceImpl.java
@@ -27,6 +27,7 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.*;
 
+import static io.mosip.certify.core.constants.Constants.CERTIFY_SERVICE_APP_ID;
 import static io.mosip.certify.core.constants.Constants.ED25519_REF_ID;
 
 @Service
@@ -62,6 +63,10 @@ public class JwksServiceImpl implements JwksService {
                 jwkList.addAll(getJwks(response));
             });
         });
+
+        // Add jwks for CERTIFY_SERVICE_APP_ID
+        AllCertificatesDataResponseDto responseDto = keymanagerService.getAllCertificates(CERTIFY_SERVICE_APP_ID, Optional.empty());
+        jwkList.addAll(getJwks(responseDto));
 
         Map<String, Object> response = new HashMap<>();
         response.put("keys", jwkList);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The JWKS endpoint now automatically includes all service-wide certificates in the JSON Web Key Set response, complementing the set of previously configured key aliases. This enhancement improves the overall availability and accessibility of cryptographic keys for client authentication and digital token verification operations, ensuring comprehensive key distribution across the platform.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->