### PR TITLE
[INJICERT-976] Add fallback to auth url for empty auth server mapping

### DIFF
--- a/certify-service/src/main/java/io/mosip/certify/controller/CredentialLedgerController.java
+++ b/certify-service/src/main/java/io/mosip/certify/controller/CredentialLedgerController.java
@@ -21,7 +21,7 @@ public class CredentialLedgerController {
     @Autowired
     private CredentialLedgerService credentialLedgerService;
 
-    @PostMapping("/ledger-search")
+    @PostMapping(value = "/ledger-search", produces = "application/json")
     public ResponseEntity<List<CredentialStatusResponse>> searchCredentials(
             @Valid @RequestBody CredentialLedgerSearchRequest request) {
         List<CredentialStatusResponse> result = credentialLedgerService.searchCredentialLedger(request);
@@ -31,7 +31,7 @@ public class CredentialLedgerController {
         return ResponseEntity.ok(result);
     }
 
-    @PostMapping("/v2/ledger-search")
+    @PostMapping(value = "/v2/ledger-search", produces = "application/json")
     public ResponseEntity<List<CredentialStatusResponse>> searchCredentialsV2(
             @Valid @RequestBody CredentialLedgerSearchRequest request) {
         List<CredentialStatusResponse> result = credentialLedgerService.searchCredentialLedgerV2(request);

--- a/certify-service/src/main/java/io/mosip/certify/controller/CredentialStatusController.java
+++ b/certify-service/src/main/java/io/mosip/certify/controller/CredentialStatusController.java
@@ -44,7 +44,7 @@ public class CredentialStatusController {
         return statusListCredentialService.getStatusListCredential(id);
     }
 
-    @PostMapping("/status")
+    @PostMapping(value = "/status", produces = "application/json")
     public ResponseEntity<CredentialStatusResponse> updateCredential(
             @Valid @RequestBody UpdateCredentialStatusRequest updateCredentialStatusRequest) {
         CredentialStatusResponse result = credentialStatusService.updateCredentialStatus(updateCredentialStatusRequest);
@@ -54,7 +54,7 @@ public class CredentialStatusController {
         return ResponseEntity.ok(result);
     }
 
-    @PostMapping("/v2/status")
+    @PostMapping(value = "/v2/status", produces = "application/json")
     public ResponseEntity<CredentialStatusResponse> updateCredentialV2(
             @Valid @RequestBody UpdateCredentialStatusRequestV2 updateCredentialStatusRequestV2) {
         CredentialStatusResponse result = credentialStatusService.updateCredentialStatusV2(updateCredentialStatusRequestV2);

--- a/certify-service/src/main/java/io/mosip/certify/controller/SystemInfoController.java
+++ b/certify-service/src/main/java/io/mosip/certify/controller/SystemInfoController.java
@@ -23,6 +23,7 @@ import io.mosip.kernel.partnercertservice.service.spi.PartnerCertificateManagerS
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -49,7 +50,7 @@ public class SystemInfoController {
     @Value("${mosip.certify.audit.claim-name:preferred_username}")
     private String claimName;
 
-    @GetMapping(value = "/certificate")
+    @GetMapping(value = "/certificate", produces = "application/json")
     public ResponseWrapper<KeyPairGenerateResponseDto> getCertificate(
             @Valid @NotBlank(message = VCIErrorConstants.INVALID_REQUEST) @RequestParam("applicationId") String applicationId,
             @RequestParam("referenceId") Optional<String> referenceId) {
@@ -63,7 +64,7 @@ public class SystemInfoController {
         return responseWrapper;
     }
 
-    @PostMapping(value = "/uploadCertificate")
+    @PostMapping(value = "/uploadCertificate", produces = "application/json")
     public ResponseWrapper<UploadCertificateResponseDto> uploadSignedCertificate(
             @Valid @RequestBody RequestWrapper<UploadCertificateRequestDto> requestWrapper) {
         ResponseWrapper<UploadCertificateResponseDto> responseWrapper = new ResponseWrapper<>();
@@ -77,7 +78,7 @@ public class SystemInfoController {
         return responseWrapper;
     }
 
-    @PostMapping("/generate-csr")
+    @PostMapping(value = "/generate-csr", produces = "application/json")
     public ResponseWrapper<KeyPairGenerateResponseDto> generateCSR(
             @Valid @RequestBody RequestWrapper<CSRGenerateRequestDto> requestWrapper) {
 
@@ -95,7 +96,7 @@ public class SystemInfoController {
         return responseWrapper;
     }
 
-    @PostMapping("/upload-ca-certificate")
+    @PostMapping(value = "/upload-ca-certificate", produces = "application/json")
     public ResponseWrapper<CACertificateResponseDto> uploadCACertificate(
             @Valid @RequestBody RequestWrapper<CACertificateRequestDto> requestWrapper) {
 

--- a/certify-service/src/main/java/io/mosip/certify/controller/VCIssuanceController.java
+++ b/certify-service/src/main/java/io/mosip/certify/controller/VCIssuanceController.java
@@ -86,7 +86,7 @@ public class VCIssuanceController {
     }
 
     @Deprecated
-    @GetMapping(value = "/.well-known/did.json")
+    @GetMapping(value = "/.well-known/did.json", produces = "application/json")
     public Map<String, Object> getDIDDocument() {
        return vcIssuanceService.getDIDDocument();
     }

--- a/certify-service/src/main/java/io/mosip/certify/controller/WellKnownController.java
+++ b/certify-service/src/main/java/io/mosip/certify/controller/WellKnownController.java
@@ -34,12 +34,12 @@ public class WellKnownController {
         return credentialConfigurationService.fetchCredentialIssuerMetadata(version);
     }
 
-    @GetMapping(value = "/.well-known/did.json")
+    @GetMapping(value = "/.well-known/did.json", produces = "application/json")
     public Map<String, Object> getDIDDocument() {
         return vcIssuanceService.getDIDDocument();
     }
 
-    @GetMapping("/.well-known/jwks.json")
+    @GetMapping(value = "/.well-known/jwks.json", produces = "application/json")
     public ResponseEntity<Map<String, Object>> getJwks() {
         try {
             Map<String, Object> response = jwksService.getJwks();

--- a/certify-service/src/main/java/io/mosip/certify/services/CredentialConfigurationServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/CredentialConfigurationServiceImpl.java
@@ -277,7 +277,7 @@ public class CredentialConfigurationServiceImpl implements CredentialConfigurati
             case "latest" -> buildMetadataVD13(credentialConfigList, version);
             case "vd12"   -> buildMetadataVD12(credentialConfigList, version);
             case "vd11"   -> buildMetadataVD11(credentialConfigList, version);
-            default       -> throw new CertifyException("Unsupported version: " + version);
+            default       -> throw new CertifyException("UNSUPPORTED_METADATA_VERSION", "Unsupported version: " + version);
         };
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Credential metadata assembled per version for clearer issuer, endpoint, and display info.
* **Bug Fixes**
  * Only active credential configurations are considered.
  * Authorization server resolution now defaults sensibly for empty mappings and removes duplicates.
  * Several endpoints now explicitly declare JSON responses; some update operations return 204 No Content when appropriate.
* **Chores**
  * Internal refactor and cleanup with no changes to public APIs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->