### PR TITLE
[DSD-9740] Fix uncaught certify exception

### DIFF
--- a/certify-service/src/main/java/io/mosip/certify/services/CertifyIssuanceServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/CertifyIssuanceServiceImpl.java
@@ -309,6 +309,9 @@ public class CertifyIssuanceServiceImpl implements VCIssuanceService {
         } catch (JSONException | JsonProcessingException e) {
             log.error(e.getMessage(), e);
             throw new CertifyException(ErrorConstants.JSON_PROCESSING_ERROR, "Invalid JSON data encountered during credential generation. Please check the data provider response and template configurations.");
+        } catch (CertifyException e) {
+            log.error("Error during signing qr data: {}", e.getMessage());
+            throw new CertifyException("ERROR_SIGNING_QR_DATA", e.getMessage());
         }
     }
 

--- a/certify-service/src/test/java/io/mosip/certify/services/CertifyIssuanceServiceImplTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/CertifyIssuanceServiceImplTest.java
@@ -322,7 +322,7 @@ public class CertifyIssuanceServiceImplTest {
         when(credentialFactory.getCredential(DEFAULT_FORMAT_LDP)).thenReturn(Optional.empty());
 
         CertifyException ex = assertThrows(CertifyException.class, () -> issuanceService.getCredential(request));
-        assertEquals(VCIErrorConstants.UNSUPPORTED_CREDENTIAL_FORMAT, ex.getErrorCode());
+        assertEquals("ERROR_SIGNING_QR_DATA", ex.getErrorCode());
     }
 
     @Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved error handling in the credential generation workflow to standardize error reporting and messaging when QR data signing failures occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->