### PR TITLE
[INJICERT-904] - add validation for nonce available in access token and proof jwt

### DIFF
--- a/certify-service/src/main/java/io/mosip/certify/proof/JwtProofValidator.java
+++ b/certify-service/src/main/java/io/mosip/certify/proof/JwtProofValidator.java
@@ -25,22 +25,14 @@ import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
 import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
 import com.nimbusds.jwt.proc.DefaultJWTProcessor;
-
-import io.mosip.certify.core.constants.Constants;
 import io.mosip.certify.core.constants.ErrorConstants;
-import io.mosip.certify.core.constants.VCIErrorConstants;
 import io.mosip.certify.core.dto.CredentialProof;
-import io.mosip.certify.core.dto.CredentialRequest;
-import io.mosip.certify.core.dto.ParsedAccessToken;
-import io.mosip.certify.core.exception.CertifyException;
 import io.mosip.certify.core.exception.InvalidRequestException;
-import io.mosip.certify.exception.InvalidNonceException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.*;
 
@@ -72,31 +64,6 @@ public class JwtProofValidator implements ProofValidator {
     }
 
     @Override
-    public void validateCNonce(String cNonce, int cNonceExpireSeconds, ParsedAccessToken parsedAccessToken, CredentialRequest credentialRequest) {
-        // No specific validation for CNonce in JWT proof, as it is not part of the JWT structure.
-        // CNonce validation is typically handled at the request level before the proof validation.
-        if (parsedAccessToken.getClaims().containsKey(Constants.C_NONCE)
-                && credentialRequest.getProof().getJwt() != null) {
-            // issue a c_nonce and return the error
-            try {
-                SignedJWT proofJwt = SignedJWT.parse(credentialRequest.getProof().getJwt());
-                String proofJwtNonce = Optional.ofNullable(proofJwt.getJWTClaimsSet().getStringClaim("nonce")).orElse("");
-                String authZServerNonce = Optional.ofNullable(parsedAccessToken.getClaims().get(Constants.C_NONCE)).map(Object::toString).orElse("");
-                if (authZServerNonce.equals(StringUtils.EMPTY) || !cNonce.equals(proofJwtNonce)) {
-                    // AuthZ server didn't give in a protected c_nonce
-                    //  and c_nonce given in proofJwt doesn't match Certify generated c_nonce
-                    throw new InvalidNonceException(cNonce, cNonceExpireSeconds);
-                }
-            } catch (ParseException e) {
-                // check iff specific error exists for invalid holderKey
-                throw new CertifyException(VCIErrorConstants.INVALID_PROOF, "Error encountered during proof jwt parsing.");
-            }
-        } else {
-            throw new InvalidNonceException(cNonce, cNonceExpireSeconds);
-        }
-    }
-
-    @Override
     public boolean validate(String clientId, String cNonce, CredentialProof credentialProof, Map<String, Object> proofConfiguration) {
         if(credentialProof.getJwt() == null || credentialProof.getJwt().isBlank()) {
             log.error("Found invalid jwt in the credential proof");
@@ -121,9 +88,17 @@ public class JwtProofValidator implements ProofValidator {
                 throw new InvalidRequestException(ErrorConstants.PROOF_HEADER_INVALID_KEY);
             }
 
+            if (StringUtils.isEmpty(cNonce) && jwt.getJWTClaimsSet().getClaim("nonce") != null) {
+                log.error("Nonce claim is present in proof JWT but no c_nonce is expected");
+                return false;
+            }
+
             JWTClaimsSet.Builder proofJwtClaimsBuilder = new JWTClaimsSet.Builder()
-                    .audience(credentialIdentifier)
-                    .claim("nonce", cNonce);
+                    .audience(credentialIdentifier);
+            if (!StringUtils.isEmpty(cNonce)) {
+                proofJwtClaimsBuilder = proofJwtClaimsBuilder
+                        .claim("nonce", cNonce);
+            }
 
             // if the proof contains issuer claim, then it should match with the client id ref: https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-ID1.html#section-7.2.1.1-2.2.2.1
             // https://github.com/openid/OpenID4VCI/issues/349

--- a/certify-service/src/main/java/io/mosip/certify/proof/ProofValidator.java
+++ b/certify-service/src/main/java/io/mosip/certify/proof/ProofValidator.java
@@ -35,6 +35,4 @@ public interface ProofValidator {
      * @return public key as did:jwk equivalent
      */
     String getKeyMaterial(CredentialProof credentialProof);
-
-    void validateCNonce(String cNonce, int cNonceExpireSeconds, ParsedAccessToken parsedAccessToken, CredentialRequest credentialRequest);
 }

--- a/certify-service/src/main/java/io/mosip/certify/services/CertifyIssuanceServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/CertifyIssuanceServiceImpl.java
@@ -167,8 +167,8 @@ public class CertifyIssuanceServiceImpl implements VCIssuanceService {
 
         // 3. Proof Validation
         ProofValidator proofValidator = proofValidatorFactory.getProofValidator(credentialRequest.getProof().getProof_type());
-        String validCNonce = VCIssuanceUtil.getValidClientNonce(vciCacheService, parsedAccessToken, cNonceExpireSeconds, securityHelperService, log);
-        proofValidator.validateCNonce(validCNonce, cNonceExpireSeconds, parsedAccessToken, credentialRequest);
+        String validCNonce = VCIssuanceUtil.validateAndGetClientNonce(vciCacheService, parsedAccessToken,
+                cNonceExpireSeconds, securityHelperService, credentialRequest.getProof(), log);
         if(!proofValidator.validate((String)parsedAccessToken.getClaims().get(Constants.CLIENT_ID), validCNonce,
                 credentialRequest.getProof(), credentialMetadata.getProofTypesSupported())) {
             throw new CertifyException(VCIErrorConstants.INVALID_PROOF, "Error encountered during proof jwt parsing.");

--- a/certify-service/src/main/java/io/mosip/certify/services/VCIssuanceServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/VCIssuanceServiceImpl.java
@@ -97,7 +97,8 @@ public class VCIssuanceServiceImpl implements VCIssuanceService {
         }
 
         ProofValidator proofValidator = proofValidatorFactory.getProofValidator(credentialRequest.getProof().getProof_type());
-        String validCNonce = VCIssuanceUtil.getValidClientNonce(vciCacheService, parsedAccessToken, cNonceExpireSeconds, securityHelperService, log);
+        String validCNonce = VCIssuanceUtil.validateAndGetClientNonce(vciCacheService, parsedAccessToken,
+                cNonceExpireSeconds, securityHelperService, credentialRequest.getProof(), log);
         if(!proofValidator.validate((String)parsedAccessToken.getClaims().get(Constants.CLIENT_ID), validCNonce,
                 credentialRequest.getProof(), credentialMetadata.getProofTypesSupported())) {
             throw new CertifyException(VCIErrorConstants.INVALID_PROOF, "Error encountered during proof jwt parsing.");

--- a/certify-service/src/main/java/io/mosip/certify/utils/VCIssuanceUtil.java
+++ b/certify-service/src/main/java/io/mosip/certify/utils/VCIssuanceUtil.java
@@ -1,5 +1,6 @@
 package io.mosip.certify.utils;
 
+import com.nimbusds.jwt.SignedJWT;
 import foundation.identity.jsonld.JsonLDObject;
 import io.mosip.certify.core.constants.Constants;
 import io.mosip.certify.core.constants.ErrorConstants;
@@ -13,9 +14,11 @@ import io.mosip.certify.exception.InvalidNonceException;
 import io.mosip.certify.services.VCICacheService;
 import io.mosip.certify.api.dto.VCResult;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.springframework.security.oauth2.jwt.JwtClaimNames;
 
+import java.text.ParseException;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -147,44 +150,92 @@ public class VCIssuanceUtil {
         return transformedConfig;
     }
 
-    public static String getValidClientNonce(VCICacheService vciCacheService, ParsedAccessToken parsedAccessToken,
-                                             int configuredCNonceExpireSeconds, SecurityHelperService securityHelperService, Logger log) {
-        VCIssuanceTransaction transaction = vciCacheService.getVCITransaction(parsedAccessToken.getAccessTokenHash());
-        String cNonce = (transaction == null) ?
-                (String) parsedAccessToken.getClaims().get(Constants.C_NONCE) :
+    public static String validateAndGetClientNonce(VCICacheService vciCacheService, ParsedAccessToken parsedAccessToken,
+                                             int configuredCNonceExpireSeconds, SecurityHelperService securityHelperService,
+                                                   CredentialProof credentialProof, Logger log) {
+        String accessTokenHash = parsedAccessToken.getAccessTokenHash();
+        VCIssuanceTransaction transaction = vciCacheService.getVCITransaction(accessTokenHash);
+        String authZServerNonce = (transaction == null) ?
+                Optional.ofNullable(parsedAccessToken.getClaims().get(Constants.C_NONCE)).map(Object::toString).orElse("") :
                 transaction.getCNonce();
 
-        Object nonceExpireSecondsClaim = parsedAccessToken.getClaims().getOrDefault(Constants.C_NONCE_EXPIRES_IN, 0);
-        int cNonceExpire = (transaction == null) ?
-                determineCNonceExpiry(nonceExpireSecondsClaim) :
-                transaction.getCNonceExpireSeconds();
+        int cNonceExpire;
+        if (transaction == null) {
+            int tokenExpiry = determineCNonceExpiry(parsedAccessToken.getClaims().get(Constants.C_NONCE_EXPIRES_IN));
+            cNonceExpire = tokenExpiry > 0 ? tokenExpiry : configuredCNonceExpireSeconds;
+        } else {
+            cNonceExpire = transaction.getCNonceExpireSeconds();
+        }
+
+        String proofJwtNonce = null;
+        boolean proofJwtHasNonceClaim = false;
+        if (credentialProof.getJwt() != null && !credentialProof.getJwt().isBlank()) {
+            try {
+                SignedJWT proofJwt = SignedJWT.parse(credentialProof.getJwt());
+                Map<String, Object> proofClaims = proofJwt.getJWTClaimsSet().getClaims();
+                proofJwtHasNonceClaim = proofClaims.containsKey("nonce");
+                if (proofJwtHasNonceClaim) {
+                    proofJwtNonce = proofJwt.getJWTClaimsSet().getStringClaim("nonce");
+                    if (StringUtils.isBlank(proofJwtNonce)) {
+                        log.error("Nonce claim is present in proof JWT but is blank");
+                        throw new CertifyException(VCIErrorConstants.INVALID_PROOF, "Nonce claim must not be empty.");
+                    }
+                }
+            } catch (ParseException e) {
+                // check iff specific error exists for invalid holderKey
+                throw new CertifyException(VCIErrorConstants.INVALID_PROOF, "Error encountered during proof jwt parsing.");
+            }
+        } else if (!StringUtils.isEmpty(authZServerNonce)) {
+            // Access token has nonce but no JWT provided to extract proof nonce from
+            log.error("JWT proof is required but not provided in credential proof");
+            throw new CertifyException(VCIErrorConstants.INVALID_PROOF, "JWT proof is required when nonce is present in access token.");
+        }
+
+        if (StringUtils.isEmpty(authZServerNonce) && !proofJwtHasNonceClaim) {
+            return null;
+        }
+
+        if (StringUtils.isEmpty(authZServerNonce) && proofJwtHasNonceClaim) {
+            log.error("Nonce present in proof JWT but missing in access token");
+            throw new CertifyException(VCIErrorConstants.INVALID_PROOF, "Nonce must not be present in the proof JWT.");
+        }
 
         long issuedEpoch;
         if (transaction == null) {
             Object iatClaimValue = parsedAccessToken.getClaims().get(JwtClaimNames.IAT);
-            if (iatClaimValue == null) {
-                issuedEpoch = Instant.MIN.getEpochSecond();
-            } else if (iatClaimValue instanceof Instant) {
-                issuedEpoch = ((Instant) iatClaimValue).getEpochSecond();
-            } else if (iatClaimValue instanceof Number) {
-                issuedEpoch = ((Number) iatClaimValue).longValue();
-            } else {
-                throw new IllegalStateException("IAT claim is of an unexpected type: " + iatClaimValue.getClass().getName());
-            }
+            issuedEpoch = switch (iatClaimValue) {
+                case null -> Instant.MIN.getEpochSecond();
+                case Instant instant -> instant.getEpochSecond();
+                case Number number -> number.longValue();
+                default ->
+                        throw new IllegalStateException("IAT claim is of an unexpected type: " + iatClaimValue.getClass().getName());
+            };
         } else {
             issuedEpoch = transaction.getCNonceIssuedEpoch();
         }
 
-        if (cNonce == null ||
-                cNonceExpire <= 0 ||
-                (issuedEpoch + cNonceExpire) < LocalDateTime.now(ZoneOffset.UTC).toEpochSecond(ZoneOffset.UTC)) {
-            String accessTokenHash = parsedAccessToken.getAccessTokenHash();
-            log.error("Client Nonce not found / expired in the access token, generate new cNonce for accessTokenHash: {}",
+        boolean nonceExpired = !StringUtils.isEmpty(authZServerNonce) &&
+                (cNonceExpire <= 0 ||
+                        (issuedEpoch + cNonceExpire) < LocalDateTime.now(ZoneOffset.UTC).toEpochSecond(ZoneOffset.UTC));
+
+        if (nonceExpired) {
+            log.error("Client Nonce expired in the access token, generate new authZServerNonce for accessTokenHash: {}",
                     accessTokenHash != null ? accessTokenHash.substring(0, Math.min(accessTokenHash.length(), 10)) + "..." : "null");
-            VCIssuanceTransaction newTransaction = createOrUpdateVCITransaction(securityHelperService, configuredCNonceExpireSeconds, vciCacheService, accessTokenHash, transaction);
-            throw new InvalidNonceException(newTransaction.getCNonce(), newTransaction.getCNonceExpireSeconds());
+            VCIssuanceTransaction newTransaction = createOrUpdateVCITransaction(
+                    securityHelperService, configuredCNonceExpireSeconds, vciCacheService, accessTokenHash, transaction);
+            authZServerNonce = newTransaction.getCNonce();
+            cNonceExpire = newTransaction.getCNonceExpireSeconds();
         }
-        return cNonce;
+        if (!StringUtils.isEmpty(authZServerNonce) && StringUtils.isEmpty(proofJwtNonce)) {
+            log.error("Nonce missing in the proof JWT but present in access token");
+            throw new InvalidNonceException(authZServerNonce, cNonceExpire);
+        }
+
+        if (authZServerNonce.equals(proofJwtNonce)) {
+            return authZServerNonce;
+        } else {
+            throw new InvalidNonceException(authZServerNonce, cNonceExpire);
+        }
     }
 
     public static int determineCNonceExpiry(Object nonceExpireSecondsClaim) {

--- a/certify-service/src/main/resources/vp_request_config.json
+++ b/certify-service/src/main/resources/vp_request_config.json
@@ -16,7 +16,7 @@
             {
               "path": ["$.type"],
               "filter": {
-                "type": "object",
+                "type": "string",
                 "pattern": "MOSIPVerifiableCredential"
               }
             }

--- a/certify-service/src/test/java/io/mosip/certify/services/CertifyIssuanceServiceImplTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/CertifyIssuanceServiceImplTest.java
@@ -1,7 +1,6 @@
 package io.mosip.certify.services;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.*;
 import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jose.jwk.RSAKey;
@@ -227,8 +226,13 @@ public class CertifyIssuanceServiceImplTest {
         req.setCredential_definition(requestCredDef);
 
         CredentialProof proof = new CredentialProof();
-        proof.setProof_type("openid4vci-proof+jwt");
+        proof.setProof_type("jwt");
+        proof.setJwt(createValidJWT(TEST_CNONCE));
+        req.setProof(proof);
+        return req;
+    }
 
+    private String createValidJWT(String nonce) {
         RSAKeyGenerator rsaKeyGenerator = new RSAKeyGenerator(2048);
         RSAKey r;
         try {
@@ -241,7 +245,7 @@ public class CertifyIssuanceServiceImplTest {
                 r.toPublicJWK(), null, null, null, null, null, null, null);
         JWTClaimsSet proofJwtBody;
         try {
-            Map<String, Object> pj = Map.of("aud", "fake-aud", "nonce", TEST_CNONCE, "iss", "test-client");
+            Map<String, Object> pj = Map.of("aud", "fake-aud", "nonce", nonce, "iss", "test-client");
             proofJwtBody = JWTClaimsSet.parse(pj);
         } catch (ParseException e) {
             fail("failed to create a JWTClaimsSet");
@@ -254,9 +258,7 @@ public class CertifyIssuanceServiceImplTest {
         } catch (JOSEException e) {
             fail("failed to create a signer");
         }
-        proof.setJwt(requestProofJWT.serialize());
-        req.setProof(proof);
-        return req;
+        return requestProofJWT.serialize();
     }
 
     @Test
@@ -343,6 +345,11 @@ public class CertifyIssuanceServiceImplTest {
     @Test
     public void getCredential_ExpiredNonce_ThrowsInvalidNonceException() {
         request = createValidCredentialRequest(DEFAULT_FORMAT_LDP);
+        CredentialProof proof = new CredentialProof();
+        proof.setProof_type("jwt");
+        proof.setJwt(createValidJWT("expired-cnonce"));
+        request.setProof(proof);
+
         VCIssuanceTransaction expiredTransaction = new VCIssuanceTransaction();
         expiredTransaction.setCNonce("expired-cnonce");
         expiredTransaction.setCNonceExpireSeconds(10);
@@ -355,11 +362,13 @@ public class CertifyIssuanceServiceImplTest {
         when(vciCacheService.setVCITransaction(eq(TEST_ACCESS_TOKEN_HASH), any(VCIssuanceTransaction.class)))
                 .thenAnswer(invocation -> invocation.getArgument(1));
 
-        assertThrows(InvalidNonceException.class, () -> issuanceService.getCredential(request));
+        InvalidNonceException invalidNonceException = assertThrows(InvalidNonceException.class, () -> issuanceService.getCredential(request));
+        assertEquals("new-generated-cnonce", invalidNonceException.getClientNonce());
+        assertEquals("invalid_proof", invalidNonceException.getErrorCode());
     }
 
     @Test
-    public void getCredential_NullTransactionForCNonceAndNoCNonceInToken_ThrowsInvalidNonceException() {
+    public void getCredential_NonceInProofJwtButNotInAccessToken_ThrowsCertifyException() {
         request = createValidCredentialRequest(DEFAULT_FORMAT_LDP);
         Map<String, Object> claimsWithoutCNonce = new HashMap<>(claimsFromAccessToken);
         claimsWithoutCNonce.remove(Constants.C_NONCE); // Ensure c_nonce isn't in access token claims
@@ -368,12 +377,9 @@ public class CertifyIssuanceServiceImplTest {
 
         when(parsedAccessToken.isActive()).thenReturn(true);
         when(parsedAccessToken.getClaims()).thenReturn(claimsWithoutCNonce);
-        when(vciCacheService.getVCITransaction(TEST_ACCESS_TOKEN_HASH)).thenReturn(null);
-        when(securityHelperService.generateSecureRandomString(anyInt())).thenReturn("new-generated-cnonce");
-        when(vciCacheService.setVCITransaction(eq(TEST_ACCESS_TOKEN_HASH), any(VCIssuanceTransaction.class)))
-                .thenAnswer(invocation -> invocation.getArgument(1));
 
-        assertThrows(InvalidNonceException.class, () -> issuanceService.getCredential(request));
+        CertifyException certifyException = assertThrows(CertifyException.class, () -> issuanceService.getCredential(request));
+        assertEquals(VCIErrorConstants.INVALID_PROOF, certifyException.getErrorCode());
     }
 
     @Test

--- a/certify-service/src/test/java/io/mosip/certify/services/VCIssuanceServiceImplTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/VCIssuanceServiceImplTest.java
@@ -1,5 +1,14 @@
 package io.mosip.certify.services;
 
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
 import foundation.identity.jsonld.JsonLDObject;
 import io.mosip.certify.api.dto.VCRequestDto;
 import io.mosip.certify.api.dto.VCResult;
@@ -147,7 +156,7 @@ public class VCIssuanceServiceImplTest {
                 .thenReturn(mockGlobalCredentialIssuerMetadataDTO);
     }
 
-    private CredentialRequest createValidCredentialRequest(String format) {
+    private CredentialRequest createValidCredentialRequest(String format) throws Exception {
         CredentialRequest req = new CredentialRequest();
         req.setFormat(format);
 
@@ -156,7 +165,7 @@ public class VCIssuanceServiceImplTest {
             req.setDoctype("org.iso.18013.5.1.mDL"); // For mso_mdoc
             req.setFormat(VCFormats.MSO_MDOC.toString());
             req.setClaims( Map.ofEntries(Map.entry("claim1","claim2")));
-        } else if (VCFormats.SD_JWT.equals(format)) {
+        } else if (VCFormats.VC_SD_JWT.equals(format)) {
             req.setFormat(CredentialFormat.VC_SD_JWT.toString());
             requestInnerCredDef.setContext(List.of("https://www.w3.org/2018/credentials/v1"));
             requestInnerCredDef.setType(List.of("VerifiableCredential", "TestJWTCredential"));
@@ -175,13 +184,46 @@ public class VCIssuanceServiceImplTest {
 
         CredentialProof proof = new CredentialProof();
         proof.setProof_type("jwt"); // Example proof type
-        proof.setJwt("dummy.jwt.token");
+        proof.setJwt(createValidJWT(TEST_CNONCE, true));
         req.setProof(proof);
         return req;
     }
 
+    private String createValidJWT(String cNonce, boolean addNonce) throws Exception {
+        // Generate a 2048-bit RSA key pair
+        RSAKey rsaJWK = new RSAKeyGenerator(2048)
+                .keyID(UUID.randomUUID().toString())
+                .generate();
+
+        // Extract public key for embedding in the JWT header
+        RSAKey rsaPublicJWK = rsaJWK.toPublicJWK();
+
+        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.RS256)
+                .type(new JOSEObjectType("openid4vci-proof+jwt"))
+                .jwk(rsaPublicJWK)  // Embed the public JWK
+                .build();
+
+        // Build JWT claims
+        JWTClaimsSet.Builder jwtClaimsBuilder = new JWTClaimsSet.Builder()
+                .audience("test-credential-id")
+                .issuer("test-client")
+                .issueTime(new Date())
+                .expirationTime(new Date(System.currentTimeMillis() + 60000)); // 1 min expiration
+        if (addNonce) { // Conditionally add nonce claim
+            jwtClaimsBuilder.claim("nonce", cNonce);
+        }
+
+        SignedJWT jwt = new SignedJWT(header, jwtClaimsBuilder.build());
+
+        // Sign JWT using private key
+        JWSSigner signer = new RSASSASigner(rsaJWK);
+        jwt.sign(signer);
+
+        return jwt.serialize();
+    }
+
     @Test
-    public void getCredential_LDP_WithValidTransaction_Success() throws VCIExchangeException {
+    public void getCredential_LDP_WithValidTransaction_Success() throws Exception {
         request = createValidCredentialRequest(VCFormats.LDP_VC);
         when(parsedAccessToken.isActive()).thenReturn(true);
         when(parsedAccessToken.getClaims()).thenReturn(claimsFromAccessToken);
@@ -203,8 +245,13 @@ public class VCIssuanceServiceImplTest {
     }
 
     @Test
-    public void getCredential_ExpiredNonce_ThrowsInvalidNonceException() {
+    public void getCredential_ExpiredNonce_ThrowsInvalidNonceException() throws Exception {
         request = createValidCredentialRequest(VCFormats.LDP_VC);
+        CredentialProof proof = new CredentialProof();
+        proof.setProof_type("jwt");
+        proof.setJwt(createValidJWT("expired-cnonce", true));
+        request.setProof(proof);
+
         VCIssuanceTransaction expiredTransaction = new VCIssuanceTransaction();
         expiredTransaction.setCNonce("expired-cnonce");
         expiredTransaction.setCNonceExpireSeconds(10);
@@ -217,11 +264,69 @@ public class VCIssuanceServiceImplTest {
         when(vciCacheService.setVCITransaction(eq(TEST_ACCESS_TOKEN_HASH), any(VCIssuanceTransaction.class)))
                 .thenAnswer(invocation -> invocation.getArgument(1));
 
-        assertThrows(InvalidNonceException.class, () -> issuanceService.getCredential(request));
+        InvalidNonceException invalidNonceException = assertThrows(InvalidNonceException.class, () -> issuanceService.getCredential(request));
+        assertEquals("new-generated-cnonce", invalidNonceException.getClientNonce());
+        assertEquals("invalid_proof", invalidNonceException.getErrorCode());
     }
 
     @Test
-    public void getCredential_NullTransactionForCNonceAndNoCNonceInToken_ThrowsInvalidNonceException() {
+    public void getCredential_WithNoNonceInProofJwt_ThrowsInvalidNonceException() throws Exception {
+        request = createValidCredentialRequest(VCFormats.LDP_VC);
+        CredentialProof proof = new CredentialProof();
+        proof.setProof_type("jwt");
+        proof.setJwt(createValidJWT("", false)); // Create JWT without nonce
+        request.setProof(proof);
+
+        claimsFromAccessToken.put("c_nonce", TEST_CNONCE);
+        claimsFromAccessToken.put("iat", LocalDateTime.now(ZoneOffset.UTC).toEpochSecond(ZoneOffset.UTC));
+        when(parsedAccessToken.isActive()).thenReturn(true);
+        when(parsedAccessToken.getClaims()).thenReturn(claimsFromAccessToken);
+
+        InvalidNonceException invalidNonceException = assertThrows(InvalidNonceException.class, () -> issuanceService.getCredential(request));
+
+        assertEquals("test-cnonce", invalidNonceException.getClientNonce());
+        assertEquals("invalid_proof", invalidNonceException.getErrorCode());
+    }
+
+    @Test
+    public void getCredential_WithEmptyNonceInProofJwt_ThrowsCertifyException() throws Exception {
+        request = createValidCredentialRequest(VCFormats.LDP_VC);
+        CredentialProof proof = new CredentialProof();
+        proof.setProof_type("jwt");
+        proof.setJwt(createValidJWT("", true)); // Create JWT with empty nonce
+        request.setProof(proof);
+
+        claimsFromAccessToken.put("c_nonce", TEST_CNONCE);
+        claimsFromAccessToken.put("iat", LocalDateTime.now(ZoneOffset.UTC).toEpochSecond(ZoneOffset.UTC));
+        when(parsedAccessToken.isActive()).thenReturn(true);
+        when(parsedAccessToken.getClaims()).thenReturn(claimsFromAccessToken);
+
+        CertifyException certifyException = assertThrows(CertifyException.class, () -> issuanceService.getCredential(request));
+
+        assertEquals("invalid_proof", certifyException.getErrorCode());
+    }
+
+    @Test
+    public void getCredential_AuthNonceAndProofJwtNonceNotSame_ThrowsInvalidNonceException() throws Exception {
+        request = createValidCredentialRequest(VCFormats.LDP_VC);
+        CredentialProof proof = new CredentialProof();
+        proof.setProof_type("jwt");
+        proof.setJwt(createValidJWT("jwt-nonce", true));
+        request.setProof(proof);
+
+        claimsFromAccessToken.put("c_nonce", TEST_CNONCE);
+        claimsFromAccessToken.put("iat", LocalDateTime.now(ZoneOffset.UTC).toEpochSecond(ZoneOffset.UTC));
+        when(parsedAccessToken.isActive()).thenReturn(true);
+        when(parsedAccessToken.getClaims()).thenReturn(claimsFromAccessToken);
+
+        InvalidNonceException invalidNonceException = assertThrows(InvalidNonceException.class, () -> issuanceService.getCredential(request));
+
+        assertEquals("test-cnonce", invalidNonceException.getClientNonce());
+        assertEquals("invalid_proof", invalidNonceException.getErrorCode());
+    }
+
+    @Test
+    public void getCredential_NonceInProofJwtButNotInAccessToken_ThrowsCertifyException() throws Exception {
         request = createValidCredentialRequest(VCFormats.LDP_VC);
         Map<String, Object> claimsWithoutCNonce = new HashMap<>(claimsFromAccessToken);
         claimsWithoutCNonce.remove(Constants.C_NONCE);
@@ -229,16 +334,13 @@ public class VCIssuanceServiceImplTest {
 
         when(parsedAccessToken.isActive()).thenReturn(true);
         when(parsedAccessToken.getClaims()).thenReturn(claimsWithoutCNonce);
-        when(vciCacheService.getVCITransaction(TEST_ACCESS_TOKEN_HASH)).thenReturn(null);
-        when(securityHelperService.generateSecureRandomString(anyInt())).thenReturn("new-generated-cnonce");
-        when(vciCacheService.setVCITransaction(eq(TEST_ACCESS_TOKEN_HASH), any(VCIssuanceTransaction.class)))
-                .thenAnswer(invocation -> invocation.getArgument(1));
 
-        assertThrows(InvalidNonceException.class, () -> issuanceService.getCredential(request));
+        CertifyException ex = assertThrows(CertifyException.class, () -> issuanceService.getCredential(request));
+        assertEquals(VCIErrorConstants.INVALID_PROOF, ex.getErrorCode());
     }
 
     @Test
-    public void getCredential_LDP_PluginReturnsNullVCResult_Fail() throws VCIExchangeException {
+    public void getCredential_LDP_PluginReturnsNullVCResult_Fail() throws Exception {
         request = createValidCredentialRequest(VCFormats.LDP_VC);
         when(parsedAccessToken.isActive()).thenReturn(true);
         when(parsedAccessToken.getClaims()).thenReturn(claimsFromAccessToken);
@@ -254,7 +356,7 @@ public class VCIssuanceServiceImplTest {
     }
 
     @Test
-    public void getCredential_LDP_PluginReturnsVCResultWithNullCredential_Fail() throws VCIExchangeException {
+    public void getCredential_LDP_PluginReturnsVCResultWithNullCredential_Fail() throws Exception {
         request = createValidCredentialRequest(VCFormats.LDP_VC);
         when(parsedAccessToken.isActive()).thenReturn(true);
         when(parsedAccessToken.getClaims()).thenReturn(claimsFromAccessToken);
@@ -274,7 +376,7 @@ public class VCIssuanceServiceImplTest {
 
 
     @Test
-    public void getCredential_ValidRequest_MsoMDoc_Success() throws VCIExchangeException {
+    public void getCredential_ValidRequest_MsoMDoc_Success() throws Exception {
         request = createValidCredentialRequest(VCFormats.MSO_MDOC);
         // request.setDoctype("org.iso.18013.5.1.mDL"); // This is set in createValidCredentialRequest
 
@@ -297,7 +399,7 @@ public class VCIssuanceServiceImplTest {
     }
 
     @Test
-    public void getCredential_RequestValidatorFails_ThrowsInvalidRequestException() {
+    public void getCredential_RequestValidatorFails_ThrowsInvalidRequestException() throws Exception {
         request = createValidCredentialRequest(VCFormats.LDP_VC);
         request.setFormat("invalid format with spaces"); // Should cause validator to fail
 
@@ -307,7 +409,7 @@ public class VCIssuanceServiceImplTest {
 
 
     @Test
-    public void getCredential_InvalidScope_Fail() {
+    public void getCredential_InvalidScope_Fail() throws Exception {
         request = createValidCredentialRequest(VCFormats.LDP_VC);
         Map<String, Object> claimsWithInvalidScope = new HashMap<>(claimsFromAccessToken);
         claimsWithInvalidScope.put("scope", "unknown-scope");
@@ -321,7 +423,7 @@ public class VCIssuanceServiceImplTest {
     }
 
     @Test
-    public void getCredential_InvalidProof_Fail() {
+    public void getCredential_InvalidProof_Fail() throws Exception {
         request = createValidCredentialRequest(VCFormats.LDP_VC);
         when(parsedAccessToken.isActive()).thenReturn(true);
         when(parsedAccessToken.getClaims()).thenReturn(claimsFromAccessToken);
@@ -334,7 +436,7 @@ public class VCIssuanceServiceImplTest {
     }
 
     @Test
-    public void getCredential_NotAuthenticated_ThrowsException() {
+    public void getCredential_NotAuthenticated_ThrowsException() throws Exception {
         request = createValidCredentialRequest(VCFormats.LDP_VC);
         when(parsedAccessToken.isActive()).thenReturn(false); // Token not active
         assertThrows(NotAuthenticatedException.class, () -> issuanceService.getCredential(request));
@@ -356,7 +458,7 @@ public class VCIssuanceServiceImplTest {
     }
 
     @Test
-    public void getCredential_LDP_WithValidTransaction_throwVciExchangeException() throws VCIExchangeException {
+    public void getCredential_LDP_WithValidTransaction_throwVciExchangeException() throws Exception {
         request = createValidCredentialRequest(VCFormats.LDP_VC);
         when(parsedAccessToken.isActive()).thenReturn(true);
         when(parsedAccessToken.getClaims()).thenReturn(claimsFromAccessToken);
@@ -375,7 +477,7 @@ public class VCIssuanceServiceImplTest {
     }
 
     @Test
-    public void getCredential_JwtVcJson_Success() throws VCIExchangeException {
+    public void getCredential_JwtVcJson_Success() {
         try (
                 MockedStatic<CredentialRequestValidator> validatorMock = org.mockito.Mockito.mockStatic(CredentialRequestValidator.class);
                 MockedStatic<VCIssuanceUtil> utilMock = org.mockito.Mockito.mockStatic(VCIssuanceUtil.class)
@@ -394,8 +496,9 @@ public class VCIssuanceServiceImplTest {
             utilMock.when(() -> VCIssuanceUtil.getScopeCredentialMapping(
                     anyString(), anyString(), any(), any(CredentialRequest.class)
             )).thenReturn(Optional.of(mockMetadata));
-            utilMock.when(() -> VCIssuanceUtil.getValidClientNonce(
-                    any(VCICacheService.class), eq(parsedAccessToken), anyInt(), any(SecurityHelperService.class), any()
+            utilMock.when(() -> VCIssuanceUtil.validateAndGetClientNonce(
+                    any(VCICacheService.class), eq(parsedAccessToken), anyInt(), any(SecurityHelperService.class),
+                    any(CredentialProof.class), any()
             )).thenReturn(TEST_CNONCE);
 
             VCResult<String> jwtVcResult = new VCResult<>();
@@ -414,11 +517,13 @@ public class VCIssuanceServiceImplTest {
             assertNotNull(response);
             assertEquals("jwt_vc_credential_string", response.getCredential());
             verify(auditWrapper).logAudit(eq(io.mosip.certify.api.util.Action.VC_ISSUANCE), eq(io.mosip.certify.api.util.ActionStatus.SUCCESS), any(), isNull());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
 
     @Test
-    public void getCredential_JwtVcJson_InvalidFormat() throws VCIExchangeException {
+    public void getCredential_JwtVcJson_InvalidFormat() {
         try (
                 MockedStatic<CredentialRequestValidator> validatorMock = org.mockito.Mockito.mockStatic(CredentialRequestValidator.class);
                 MockedStatic<VCIssuanceUtil> utilMock = org.mockito.Mockito.mockStatic(VCIssuanceUtil.class)
@@ -447,8 +552,9 @@ public class VCIssuanceServiceImplTest {
             utilMock.when(() -> VCIssuanceUtil.getScopeCredentialMapping(
                     anyString(), anyString(), any(), any(CredentialRequest.class)
             )).thenReturn(Optional.of(mockMetadata));
-            utilMock.when(() -> VCIssuanceUtil.getValidClientNonce(
-                    any(VCICacheService.class), eq(parsedAccessToken), anyInt(), any(SecurityHelperService.class), any()
+            utilMock.when(() -> VCIssuanceUtil.validateAndGetClientNonce(
+                    any(VCICacheService.class), eq(parsedAccessToken), anyInt(), any(SecurityHelperService.class),
+                    any(CredentialProof.class), any()
             )).thenReturn(TEST_CNONCE);
 
             CertifyException ex = assertThrows(CertifyException.class, () -> issuanceService.getCredential(request));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client nonce handling now validates and derives nonces from signed proof JWTs as well as access tokens.

* **Bug Fixes**
  * Nonce claim is included only when expected, preventing unexpected nonce presence and improving error clarity.
  * Credential type configuration now expects a string value.

* **Refactor**
  * Simplified nonce validation flow and removed an older public nonce-validation entrypoint.

* **Tests**
  * Tests updated to use real signed JWT proofs covering missing, empty, mismatched and expired nonce scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->