### PR TITLE
[INJICERT-1239] fix: ensure default auth server is always included in issuer metadata

### DIFF
--- a/certify-service/src/main/java/io/mosip/certify/services/CredentialConfigurationServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/CredentialConfigurationServiceImpl.java
@@ -288,8 +288,14 @@ public class CredentialConfigurationServiceImpl implements CredentialConfigurati
                     });
             credentialIssuerMetadata.setCredentialConfigurationSupportedDTO(credentialConfigurationSupportedMap);
             credentialIssuerMetadata.setCredentialIssuer(credentialIssuer);
-            List<String> authServers = authorizationServerMapping.values().stream().distinct().toList();
-            credentialIssuerMetadata.setAuthorizationServers(authServers);
+            Set<String> authServers = new HashSet<>();
+            if (authUrl != null && !authUrl.isEmpty()) {
+                authServers.add(authUrl);
+            }
+            if (authorizationServerMapping != null) {
+                authServers.addAll(authorizationServerMapping.values());
+            }
+            credentialIssuerMetadata.setAuthorizationServers(new ArrayList<>(authServers));
             String credentialEndpoint = credentialIssuer + servletPath + "/issuance" + (!version.equals("latest") ? "/" + version : "") + "/credential";
             credentialIssuerMetadata.setCredentialEndpoint(credentialEndpoint);
             credentialIssuerMetadata.setDisplay(issuerDisplay);
@@ -308,8 +314,14 @@ public class CredentialConfigurationServiceImpl implements CredentialConfigurati
             credentialIssuerMetadata.setCredentialConfigurationSupportedDTO(credentialConfigurationSupportedMap); // Use a different setter for vd12
             credentialIssuerMetadata.setCredentialIssuer(credentialIssuer);
             // credentialIssuerMetadata.setAuthorizationServers(Collections.singletonList(authUrl));
-            List<String> authServers = authorizationServerMapping.values().stream().distinct().toList();
-            credentialIssuerMetadata.setAuthorizationServers(authServers);
+            Set<String> authServers = new HashSet<>();
+            if (authUrl != null && !authUrl.isEmpty()) {
+                authServers.add(authUrl);
+            }
+            if (authorizationServerMapping != null) {
+                authServers.addAll(authorizationServerMapping.values());
+            }
+            credentialIssuerMetadata.setAuthorizationServers(new ArrayList<>(authServers));
             String credentialEndpoint = credentialIssuer + servletPath + "/issuance/" + version + "/credential";
             credentialIssuerMetadata.setCredentialEndpoint(credentialEndpoint);
             credentialIssuerMetadata.setDisplay(issuerDisplay);
@@ -328,8 +340,14 @@ public class CredentialConfigurationServiceImpl implements CredentialConfigurati
                     });
             credentialIssuerMetadata.setCredentialConfigurationSupportedDTO(credentialConfigurationSupportedList); // Use a different setter for vd11
             credentialIssuerMetadata.setCredentialIssuer(credentialIssuer);
-            List<String> authServers = authorizationServerMapping.values().stream().distinct().toList();
-            credentialIssuerMetadata.setAuthorizationServers(authServers);
+            Set<String> authServers = new HashSet<>();
+            if (authUrl != null && !authUrl.isEmpty()) {
+                authServers.add(authUrl);
+            }
+            if (authorizationServerMapping != null) {
+                authServers.addAll(authorizationServerMapping.values());
+            }
+            credentialIssuerMetadata.setAuthorizationServers(new ArrayList<>(authServers));
             String credentialEndpoint = credentialIssuer + servletPath + "/issuance/" + version + "/credential";
             credentialIssuerMetadata.setCredentialEndpoint(credentialEndpoint);
             credentialIssuerMetadata.setDisplay(issuerDisplay);


### PR DESCRIPTION
### Description
This PR resolves an issue in the multiple authorization server support (Story #467) where the `authorization_servers` list in the Discovery Metadata (`.well-known/openid-credential-issuer`) was being published as an empty array when no custom server mappings were defined in the configuration. 

Since the list was empty, wallets were unable to discover any valid authorization server, causing the end-to-end credential issuance flow to fail during the authorization step.

### Key Changes
- **CredentialConfigurationServiceImpl**: Updated the metadata generation logic for `latest`, `vd12`, and `vd11` versions.
- **Merged Authorization Servers**: The logic now ensures that the internal default `authUrl` is always included in the `authorization_servers` list, combined with any external servers defined in the `as-mapping` configuration.
- **Robustness**: Replaced the direct stream of configuration values with a null-safe merge that ensures a functional discovery endpoint even in a default local setup.

### How to Verify
1. Start the application with an empty `mosip.certify.credential-config.as-mapping`.
2. Access the discovery endpoint: `/v1/certify/.well-known/openid-credential-issuer`.
3. Verify that the `authorization_servers` array contains the default authorization server URL instead of being an empty list `[]`.
4. (Optional) Add a custom mapping and verify that both the default and the mapping-specific servers appear in the list.

### Related User Story
Story #467
Parent: #453
