### PR TITLE
[INJICERT-1321] - Fix error code if something went wrong while generating VC via DataProvider Plugin

### DIFF
--- a/certify-core/src/main/java/io/mosip/certify/core/constants/ErrorConstants.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/constants/ErrorConstants.java
@@ -79,6 +79,7 @@ public class ErrorConstants {
     public static final String INVALID_QR_SIGNING_ALGORITHM = "invalid_qr_signing_algorithm";
     public static final String INVALID_QR_SIGNED_RESULT = "invalid_qr_signed_result";
     public static final String ERROR_SIGNING_QR_ENTRY = "error_signing_qr_entry";
+    public static final String ERROR_SIGNING_QR_DATA = "error_signing_qr_data";
     public static final String QR_CBOR_ENCODING_ERROR = "qr_cbor_encoding_error";
     public static final String INVALID_CREDENTIAL_CONFIGURATION_ID = "invalid_credential_configuration_id";
     public static final String MISSING_MANDATORY_CLAIM = "missing_mandatory_claim";

--- a/certify-service/src/main/java/io/mosip/certify/services/CertifyIssuanceServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/CertifyIssuanceServiceImpl.java
@@ -279,9 +279,20 @@ public class CertifyIssuanceServiceImpl implements VCIssuanceService {
             log.info("QR data JSON generated successfully");
 
             if (qrDataJson != null) {
-                List<String> claim169Values = signQrEntries(cred, qrDataJson, templateName);
-                updatedTemplateParams.put("claim_169_values", claim169Values);
-                log.info("Claim 169 values signed successfully for template");
+                try {
+                    List<String> claim169Values = signQrEntries(cred, qrDataJson, templateName);
+                    updatedTemplateParams.put("claim_169_values", claim169Values);
+                    log.info("Claim 169 values signed successfully for template");
+                } catch (JsonProcessingException e) {
+                    log.error(e.getMessage(), e);
+                    throw new CertifyException(ErrorConstants.JSON_PROCESSING_ERROR, "Invalid JSON data encountered during credential generation. Please check the data provider response and template configurations.");
+                } catch (CertifyException e) {
+                    log.error(e.getMessage(), e);
+                    throw e;
+                } catch (Exception e) {
+                    log.error("Error during signing qr data: {}", e.getMessage());
+                    throw new CertifyException(ErrorConstants.ERROR_SIGNING_QR_DATA, e.getMessage());
+                }
             } else {
                 log.warn("QR code not configured for template: {}. To enable qr code support, update the respective credential configuration.", templateName);
             }
@@ -306,12 +317,12 @@ public class CertifyIssuanceServiceImpl implements VCIssuanceService {
 
         } catch (DataProviderExchangeException e) {
             throw new CertifyException(e.getErrorCode());
-        } catch (JSONException | JsonProcessingException e) {
+        } catch (JSONException e) {
             log.error(e.getMessage(), e);
             throw new CertifyException(ErrorConstants.JSON_PROCESSING_ERROR, "Invalid JSON data encountered during credential generation. Please check the data provider response and template configurations.");
         } catch (CertifyException e) {
-            log.error("Error during signing qr data: {}", e.getMessage());
-            throw new CertifyException("ERROR_SIGNING_QR_DATA", e.getMessage());
+            log.error("CertifyException during credential generation: {}", e.getMessage());
+            throw e;
         }
     }
 

--- a/certify-service/src/main/resources/credential-configurations/farmer-local-config.json
+++ b/certify-service/src/main/resources/credential-configurations/farmer-local-config.json
@@ -23,7 +23,7 @@
       "alt_text": "Farmer Logo"
     },
     "background_color": "#12107c",
-    "background_image": { "uri": "https://mosip.github.io/inji-config/logos/agro-vertias-logo.png" },
+    "background_image": { "uri": "https://inji.github.io/inji-config/logos/agro-vertias-logo.png" },
     "text_color": "#FFFFFF"
   }],
   "displayOrder": [

--- a/certify-service/src/test/java/io/mosip/certify/services/CertifyIssuanceServiceImplTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/CertifyIssuanceServiceImplTest.java
@@ -324,7 +324,7 @@ public class CertifyIssuanceServiceImplTest {
         when(credentialFactory.getCredential(DEFAULT_FORMAT_LDP)).thenReturn(Optional.empty());
 
         CertifyException ex = assertThrows(CertifyException.class, () -> issuanceService.getCredential(request));
-        assertEquals("ERROR_SIGNING_QR_DATA", ex.getErrorCode());
+        assertEquals("unsupported_credential_format", ex.getErrorCode());
     }
 
     @Test
@@ -769,6 +769,35 @@ public class CertifyIssuanceServiceImplTest {
         verify(mockW3CJsonLD).createCredential(templateParamsCaptor.capture(), anyString());
         Map<String, Object> usedParams = templateParamsCaptor.getValue();
         assertFalse(usedParams.containsKey("claim_169_values"));
+    }
+
+    @Test
+    public void getCredential_ErrorSigningQRData_ThrowsCertifyException() throws Exception {
+        request = createValidCredentialRequest(DEFAULT_FORMAT_LDP);
+
+        when(parsedAccessToken.isActive()).thenReturn(true);
+        when(parsedAccessToken.getClaims()).thenReturn(claimsFromAccessToken);
+        when(vciCacheService.getVCITransaction(TEST_ACCESS_TOKEN_HASH)).thenReturn(transaction);
+        when(proofValidatorFactory.getProofValidator(anyString())).thenReturn(proofValidator);
+        when(proofValidator.getKeyMaterial(any(CredentialProof.class))).thenReturn("");
+        when(proofValidator.validate(anyString(), anyString(), any(CredentialProof.class), any())).thenReturn(true);
+        when(dataProviderPlugin.fetchData(claimsFromAccessToken)).thenReturn(new JSONObject().put("subjectKey", "subjectValue"));
+
+        // Mock credential and QR data
+        W3CJsonLD mockW3CJsonLD = mock(W3CJsonLD.class);
+        when(credentialFactory.getCredential(DEFAULT_FORMAT_LDP)).thenReturn(Optional.of(mockW3CJsonLD));
+
+        // Prepare a non-empty QR data array
+        JSONArray qrData = new JSONArray();
+        JSONObject qrData1 = new JSONObject().put("qr", "data1");
+        qrData.put(qrData1);
+        when(mockW3CJsonLD.createQRData(anyMap(), anyString())).thenReturn(qrData);
+
+        when(pixelPass.getMappedData(eq(qrData1), anyMap(), anyMap(), eq(true))).thenThrow(new RuntimeException("Error during signing QR data"));
+
+        CertifyException ex = assertThrows(CertifyException.class, () -> issuanceService.getCredential(request));
+        assertEquals("error_signing_qr_data", ex.getErrorCode());
+        assertEquals("Error during signing QR data", ex.getMessage());
     }
 
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling around QR data signing to surface clearer error codes and preserve original exceptions where appropriate.

* **Chores**
  * Updated farmer credential configuration to point to a new logo resource location.
  * Added a new standardized error code for QR signing failures.

* **Tests**
  * Added and adjusted unit tests to cover QR signing error scenarios and updated expected error codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->