### PR TITLE
[MOSIP-44618] removed artifactory from certify deployment script

### DIFF
--- a/.github/workflows/chart-lint-publish.yml
+++ b/.github/workflows/chart-lint-publish.yml
@@ -48,8 +48,8 @@ jobs:
     uses: mosip/kattu/.github/workflows/chart-lint-publish.yml@master
     with:
       CHARTS_DIR: ./helm
-      CHARTS_URL: https://mosip.github.io/mosip-helm
-      REPOSITORY: mosip-helm
+      CHARTS_URL: https://inji.github.io/helm
+      REPOSITORY: helm
       BRANCH: gh-pages
       INCLUDE_ALL_CHARTS: "${{ inputs.INCLUDE_ALL_CHARTS || 'NO' }}"
       IGNORE_CHARTS: "${{ inputs.IGNORE_CHARTS ||'redis' }}"

--- a/deploy/inji-certify/install.sh
+++ b/deploy/inji-certify/install.sh
@@ -13,7 +13,7 @@ echo "Create $SOFTHSM_NS namespace"
 kubectl create ns $SOFTHSM_NS
 
 NS=inji-certify
-CHART_VERSION=0.14.0-develop
+CHART_VERSION=0.14.0
 
 echo "Create $NS namespace"
 kubectl create ns $NS

--- a/helm/inji-certify/Chart.yaml
+++ b/helm/inji-certify/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: inji-certify
 description: A Helm chart for inji certify service
 type: application
-version: 0.14.0-develop
+version: 0.14.0
 appVersion: ""
 dependencies:
   - name: common

--- a/helm/inji-certify/values.yaml
+++ b/helm/inji-certify/values.yaml
@@ -252,7 +252,6 @@ extraEnvVars:
 extraEnvVarsCM:
   - inji-stack-config
   - config-server-share
-  - artifactory-share
   - softhsm-certify-share
 
 ## Secret with extra environment variables


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed an environment configuration reference from a service deployment; one set of environment variables will no longer be sourced.
  * Updated the Helm chart publishing endpoint and repository settings used by the CI/CD chart publishing workflow; no other functional changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->