### PR TITLE
[MOSIP-44618] removed artifactory from certify deployment script

### DIFF
--- a/.github/workflows/chart-lint-publish.yml
+++ b/.github/workflows/chart-lint-publish.yml
@@ -48,7 +48,7 @@ jobs:
     uses: mosip/kattu/.github/workflows/chart-lint-publish.yml@master
     with:
       CHARTS_DIR: ./helm
-      CHARTS_URL: https://mosip.github.io/helm
+      CHARTS_URL: https://inji.github.io/helm
       REPOSITORY: helm
       BRANCH: gh-pages
       INCLUDE_ALL_CHARTS: "${{ inputs.INCLUDE_ALL_CHARTS || 'NO' }}"

--- a/helm/inji-certify/values.yaml
+++ b/helm/inji-certify/values.yaml
@@ -252,7 +252,6 @@ extraEnvVars:
 extraEnvVarsCM:
   - inji-stack-config
   - config-server-share
-  - artifactory-share
   - softhsm-certify-share
 
 ## Secret with extra environment variables


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed one ConfigMap reference from the environment-variable injection list, updating which ConfigMaps are used for pod configuration.
  * Updated the chart lint/publish workflow to point to a different charts repository base URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->