### PR TITLE
[INJICERT-1313] update the docker version to branch develop

### DIFF
--- a/certify-service-with-plugins/Dockerfile
+++ b/certify-service-with-plugins/Dockerfile
@@ -1,4 +1,4 @@
-FROM injistack/inji-certify:0.14.0
+FROM injistackdev/inji-certify:develop
 
 ARG SOURCE
 ARG COMMIT_HASH


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the base Docker image for the certification service, incorporating upstream dependencies and infrastructure improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->