### PR TITLE
[INJICERT-1320] added proper error constant for unsupported signature algorithm in mDoc

### DIFF
--- a/certify-core/src/main/java/io/mosip/certify/core/constants/ErrorConstants.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/constants/ErrorConstants.java
@@ -79,6 +79,7 @@ public class ErrorConstants {
     public static final String INVALID_QR_SIGNING_ALGORITHM = "invalid_qr_signing_algorithm";
     public static final String INVALID_QR_SIGNED_RESULT = "invalid_qr_signed_result";
     public static final String ERROR_SIGNING_QR_ENTRY = "error_signing_qr_entry";
+    public static final String ERROR_SIGNING_QR_DATA = "error_signing_qr_data";
     public static final String QR_CBOR_ENCODING_ERROR = "qr_cbor_encoding_error";
     public static final String INVALID_CREDENTIAL_CONFIGURATION_ID = "invalid_credential_configuration_id";
     public static final String MISSING_MANDATORY_CLAIM = "missing_mandatory_claim";

--- a/certify-service/src/main/java/io/mosip/certify/services/CertifyIssuanceServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/CertifyIssuanceServiceImpl.java
@@ -279,9 +279,20 @@ public class CertifyIssuanceServiceImpl implements VCIssuanceService {
             log.info("QR data JSON generated successfully");
 
             if (qrDataJson != null) {
-                List<String> claim169Values = signQrEntries(cred, qrDataJson, templateName);
-                updatedTemplateParams.put("claim_169_values", claim169Values);
-                log.info("Claim 169 values signed successfully for template");
+                try {
+                    List<String> claim169Values = signQrEntries(cred, qrDataJson, templateName);
+                    updatedTemplateParams.put("claim_169_values", claim169Values);
+                    log.info("Claim 169 values signed successfully for template");
+                } catch (JsonProcessingException e) {
+                    log.error(e.getMessage(), e);
+                    throw new CertifyException(ErrorConstants.JSON_PROCESSING_ERROR, "Invalid JSON data encountered during credential generation. Please check the data provider response and template configurations.");
+                } catch (CertifyException e) {
+                    log.error(e.getMessage(), e);
+                    throw e;
+                } catch (Exception e) {
+                    log.error("Error during signing qr data: {}", e.getMessage());
+                    throw new CertifyException(ErrorConstants.ERROR_SIGNING_QR_DATA, e.getMessage());
+                }
             } else {
                 log.warn("QR code not configured for template: {}. To enable qr code support, update the respective credential configuration.", templateName);
             }
@@ -306,12 +317,12 @@ public class CertifyIssuanceServiceImpl implements VCIssuanceService {
 
         } catch (DataProviderExchangeException e) {
             throw new CertifyException(e.getErrorCode());
-        } catch (JSONException | JsonProcessingException e) {
+        } catch (JSONException e) {
             log.error(e.getMessage(), e);
             throw new CertifyException(ErrorConstants.JSON_PROCESSING_ERROR, "Invalid JSON data encountered during credential generation. Please check the data provider response and template configurations.");
         } catch (CertifyException e) {
-            log.error("Error during signing qr data: {}", e.getMessage());
-            throw new CertifyException("ERROR_SIGNING_QR_DATA", e.getMessage());
+            log.error("CertifyException during credential generation: {}", e.getMessage());
+            throw e;
         }
     }
 


### PR DESCRIPTION
### Bug Fixes

- Fixed error code mismatch in the mock mDL use case where a credential request with an unsupported JWT algorithm (`Ed25519`) was returning `ERROR_SIGNING_QR_DATA` instead of the expected `MDOC_PROOF_FAILED`. The generic `Exception` catch block in the QR signing stage was masking the proof validation failure — added explicit handling to ensure `MDOC_PROOF_FAILED` is thrown correctly before reaching the QR signing logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling for QR code signing operations with improved exception management and more specific error messages when failures occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->