### PR TITLE
[INJICERT-1157] add Sunbird VCI known limitation note in certify-defa…

### DIFF
--- a/docker-compose/docker-compose-injistack/config/certify-default.properties
+++ b/docker-compose/docker-compose-injistack/config/certify-default.properties
@@ -51,11 +51,13 @@ mosip.certify.security.cors-enabled-get-method-urls=/rendering-template/**
 mosip.certify.discovery.issuer-id=${mosip.certify.domain.url}${server.servlet.path}
 mosip.certify.authorization.url=https://esignet-mock.collab.mosip.net
 
+##--------------change this later---------------------------------
+mosip.certify.supported.jwt-proof-alg={'RS256','PS256', 'ES256', 'Ed25519'}
+mosip.certify.plugin-mode=DataProvider
+
 ##--------------Known limitation (Sunbird mode)-------------------
 # Known limitation (Sunbird VCI plugin mode): VC issuance currently uses Ed25519 only; signature_crypto_suite from credential_config is not applied.
 # VC types added via Credential Config API may still require Sunbird supported VC type property updates for template/type mapping.
-mosip.certify.supported.jwt-proof-alg={'RS256','PS256', 'ES256', 'Ed25519'}
-mosip.certify.plugin-mode=DataProvider
 
 
 ##----- These are reference to the oauth resource server providing jwk----------------------------------##

--- a/docker-compose/docker-compose-injistack/config/certify-default.properties
+++ b/docker-compose/docker-compose-injistack/config/certify-default.properties
@@ -51,7 +51,9 @@ mosip.certify.security.cors-enabled-get-method-urls=/rendering-template/**
 mosip.certify.discovery.issuer-id=${mosip.certify.domain.url}${server.servlet.path}
 mosip.certify.authorization.url=https://esignet-mock.collab.mosip.net
 
-##--------------change this later---------------------------------
+##--------------Known limitation (Sunbird mode)-------------------
+# Known limitation (Sunbird VCI plugin mode): VC issuance currently uses Ed25519 only; signature_crypto_suite from credential_config is not applied.
+# VC types added via Credential Config API may still require Sunbird supported VC type property updates for template/type mapping.
 mosip.certify.supported.jwt-proof-alg={'RS256','PS256', 'ES256', 'Ed25519'}
 mosip.certify.plugin-mode=DataProvider
 

--- a/docker-compose/docker-compose-injistack/config/certify-default.properties
+++ b/docker-compose/docker-compose-injistack/config/certify-default.properties
@@ -57,8 +57,7 @@ mosip.certify.plugin-mode=DataProvider
 
 ##--------------Known limitation (Sunbird mode)-------------------
 # Known limitation (Sunbird VCI plugin mode): VC issuance currently uses Ed25519 only; signature_crypto_suite from credential_config is not applied.
-# VC types added via Credential Config API may still require Sunbird supported VC type property updates for template/type mapping.
-
+# VC types added via Credential Config API may still require Sunbird supported VC type property updates for credentialType mapping.
 
 ##----- These are reference to the oauth resource server providing jwk----------------------------------##
 mosip.certify.cnonce-expire-seconds=40

--- a/docs/VCIssuance-vs-DataProvider.md
+++ b/docs/VCIssuance-vs-DataProvider.md
@@ -59,6 +59,11 @@ sequenceDiagram
 - There may be a case, where an integrator might want Certify to deal with fewer aspects of VCIssuance or have a pre-existing VC Issuance stack and may just want a Certify as a OpenID4VCI proxy, in this case the implementors can choose to implement VCIssuancePlugin interface which is supposed to give out a valid VC on it's own or with an external stack.
 - If an integrator doesn't have an existing VCIssuance stack pre-deployed, they can choose to let Certify do all the heavy lifting with a DataProviderPlugin. They can choose to use any of the sample plugins present in [this repo](https://github.com/mosip/digital-credential-plugins/) or choose to implement their own.
 
+## Known Limitation (Sunbird VCI Plugin Mode)
+
+- VC issuance currently supports Ed25519 signing only.
+- The signature_crypto_suite from credential_config is not applied in this flow.
+- VC types added via Credential Config API may still require corresponding updates in Sunbird-supported VC type properties for template/type mapping.
 
 # Doubts?
 

--- a/docs/VCIssuance-vs-DataProvider.md
+++ b/docs/VCIssuance-vs-DataProvider.md
@@ -63,7 +63,7 @@ sequenceDiagram
 
 - VC issuance currently supports Ed25519 signing only.
 - The signature_crypto_suite from credential_config is not applied in this flow.
-- VC types added via Credential Config API may still require corresponding updates in Sunbird-supported VC type properties for template/type mapping.
+- VC types added via Credential Config API may still require corresponding updates in Sunbird-supported VC type properties for credentialType mapping.
 
 # Doubts?
 


### PR DESCRIPTION
Added a known limitation note in certify-default.properties clarifying that Sunbird VCI plugin mode supports Ed25519 signing only and may require VC type property updates even after Credential Config API changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Known Limitation note for Sunbird VCI plugin mode: VC issuance currently uses Ed25519-only signing, configured signature-suite settings from credential configuration are not applied in this flow, and VC types added via the Credential Config API may still require Sunbird-specific property updates for correct credential-type mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->