### PR TITLE
MOSIP-44709: Fixed HealthCheck module mapping by using normalized module name instead of prefixed identifier.

### DIFF
--- a/api-test/src/main/java/io/inji/testrig/apirig/injicertify/testrunner/InjiTestRunner.java
+++ b/api-test/src/main/java/io/inji/testrig/apirig/injicertify/testrunner/InjiTestRunner.java
@@ -90,7 +90,7 @@ public class InjiTestRunner {
 			useCaseToExecute = InjiCertifyConfigManager.getproperty("useCaseToExecute");
 
 			HealthChecker healthcheck = new HealthChecker();
-			healthcheck.setCurrentRunningModule(BaseTestCase.currentModule);
+			healthcheck.setCurrentRunningModule(GlobalConstants.INJICERTIFY);
 			Thread trigger = new Thread(healthcheck);
 			trigger.start();
 


### PR DESCRIPTION
Fixes HealthCheck module mismatch by replacing the prefixed module name (BaseTestCase.currentModule) with a normalized value (GlobalConstants.INJICERTIFY), ensuring correct mapping with healthCheckEndpoint.properties and proper endpoint filtering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected module initialization to ensure proper module identification at startup, improving the accuracy of module tracking and health monitoring systems. This change enhances overall system reliability by ensuring consistent and predictable module-specific behavior throughout the test execution lifecycle, preventing potential inconsistencies in module recognition and operational performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->