### PR TITLE
[INJICERT-675] Implementation of nonce_endpoint for c_nonce generation

### DIFF
--- a/certify-core/src/main/java/io/mosip/certify/core/constants/NonceErrorConstants.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/constants/NonceErrorConstants.java
@@ -1,0 +1,6 @@
+package io.mosip.certify.core.constants;
+
+public class NonceErrorConstants {
+    public static final String NONCE_EXPIRED = "nonce_expired";
+    public static final String CACHE_NOT_AVAILABLE = "cache_not_available";
+}

--- a/certify-core/src/main/java/io/mosip/certify/core/constants/VCIErrorConstants.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/constants/VCIErrorConstants.java
@@ -14,4 +14,5 @@ public class VCIErrorConstants {
     public static final String UNSUPPORTED_CREDENTIAL_TYPE = "unsupported_credential_type";
     public static final String UNSUPPORTED_CREDENTIAL_FORMAT = "unsupported_credential_format";
     public static final String INVALID_PROOF = "invalid_proof";
+    public static final String NONCE_EXPIRED = "nonce_expired";
 }

--- a/certify-core/src/main/java/io/mosip/certify/core/constants/VCIErrorConstants.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/constants/VCIErrorConstants.java
@@ -14,5 +14,4 @@ public class VCIErrorConstants {
     public static final String UNSUPPORTED_CREDENTIAL_TYPE = "unsupported_credential_type";
     public static final String UNSUPPORTED_CREDENTIAL_FORMAT = "unsupported_credential_format";
     public static final String INVALID_PROOF = "invalid_proof";
-    public static final String NONCE_EXPIRED = "nonce_expired";
 }

--- a/certify-core/src/main/java/io/mosip/certify/core/dto/NonceResponse.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/dto/NonceResponse.java
@@ -1,0 +1,8 @@
+package io.mosip.certify.core.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record NonceResponse(
+        @JsonProperty("c_nonce")
+        String cNonce
+) {}

--- a/certify-core/src/main/java/io/mosip/certify/core/dto/NonceTransaction.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/dto/NonceTransaction.java
@@ -1,0 +1,6 @@
+package io.mosip.certify.core.dto;
+
+public record NonceTransaction(
+        String cNonce,
+        long cNonceIssuedEpoch,
+        int cNonceExpireSeconds) {}

--- a/certify-core/src/main/java/io/mosip/certify/core/spi/NonceService.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/spi/NonceService.java
@@ -1,0 +1,7 @@
+package io.mosip.certify.core.spi;
+
+import io.mosip.certify.core.dto.NonceResponse;
+
+public interface NonceService {
+    NonceResponse generateNonce();
+}

--- a/certify-service/src/main/java/io/mosip/certify/controller/NonceController.java
+++ b/certify-service/src/main/java/io/mosip/certify/controller/NonceController.java
@@ -5,6 +5,7 @@ import io.mosip.certify.core.spi.NonceService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,7 +21,7 @@ public class NonceController {
         this.nonceService = nonceService;
     }
 
-    @GetMapping("/nonce")
+    @PostMapping("/nonce")
     public ResponseEntity<NonceResponse> getNonce() {
         NonceResponse nonceResponse = nonceService.generateNonce();
         return ResponseEntity.ok()

--- a/certify-service/src/main/java/io/mosip/certify/controller/NonceController.java
+++ b/certify-service/src/main/java/io/mosip/certify/controller/NonceController.java
@@ -1,0 +1,30 @@
+package io.mosip.certify.controller;
+
+import io.mosip.certify.core.dto.NonceResponse;
+import io.mosip.certify.core.spi.NonceService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/issuance")
+public class NonceController {
+
+
+    private final NonceService nonceService;
+
+    public NonceController(NonceService nonceService) {
+        this.nonceService = nonceService;
+    }
+
+    @GetMapping("/nonce")
+    public ResponseEntity<NonceResponse> getNonce() {
+        NonceResponse nonceResponse = nonceService.generateNonce();
+        return ResponseEntity.ok()
+                .header("Cache-Control", "no-store")
+                .body(nonceResponse);
+    }
+}

--- a/certify-service/src/main/java/io/mosip/certify/proof/JwtProofValidator.java
+++ b/certify-service/src/main/java/io/mosip/certify/proof/JwtProofValidator.java
@@ -88,11 +88,6 @@ public class JwtProofValidator implements ProofValidator {
                 throw new InvalidRequestException(ErrorConstants.PROOF_HEADER_INVALID_KEY);
             }
 
-            if (StringUtils.isEmpty(cNonce) && jwt.getJWTClaimsSet().getClaim("nonce") != null) {
-                log.error("Nonce claim is present in proof JWT but no c_nonce is expected");
-                return false;
-            }
-
             JWTClaimsSet.Builder proofJwtClaimsBuilder = new JWTClaimsSet.Builder()
                     .audience(credentialIdentifier);
             if (!StringUtils.isEmpty(cNonce)) {

--- a/certify-service/src/main/java/io/mosip/certify/services/CertifyIssuanceServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/CertifyIssuanceServiceImpl.java
@@ -93,6 +93,9 @@ public class CertifyIssuanceServiceImpl implements VCIssuanceService {
     private VCICacheService vciCacheService;
 
     @Autowired
+    private NonceCacheService nonceCacheService;
+
+    @Autowired
     private SecurityHelperService securityHelperService;
 
     @Autowired
@@ -167,8 +170,8 @@ public class CertifyIssuanceServiceImpl implements VCIssuanceService {
 
         // 3. Proof Validation
         ProofValidator proofValidator = proofValidatorFactory.getProofValidator(credentialRequest.getProof().getProof_type());
-        String validCNonce = VCIssuanceUtil.validateAndGetClientNonce(vciCacheService, parsedAccessToken,
-                cNonceExpireSeconds, securityHelperService, credentialRequest.getProof(), log);
+        String validCNonce = VCIssuanceUtil.validateAndGetClientNonce(nonceCacheService,
+                cNonceExpireSeconds, credentialRequest.getProof(), log);
         if(!proofValidator.validate((String)parsedAccessToken.getClaims().get(Constants.CLIENT_ID), validCNonce,
                 credentialRequest.getProof(), credentialMetadata.getProofTypesSupported())) {
             throw new CertifyException(VCIErrorConstants.INVALID_PROOF, "Error encountered during proof jwt parsing.");

--- a/certify-service/src/main/java/io/mosip/certify/services/NonceCacheService.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/NonceCacheService.java
@@ -1,6 +1,9 @@
 package io.mosip.certify.services;
 
+import io.mosip.certify.core.constants.NonceErrorConstants;
+import io.mosip.certify.core.constants.VCIErrorConstants;
 import io.mosip.certify.core.dto.NonceTransaction;
+import io.mosip.certify.core.exception.CertifyException;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,7 +51,8 @@ public class NonceCacheService {
         Cache cache = cacheManager.getCache(NONCE_CACHE);
         if (cache == null) {
             log.error("Cache {} not available. Please verify cache configuration.", NONCE_CACHE);
-            return null;
+            throw new CertifyException(NonceErrorConstants.CACHE_NOT_AVAILABLE,
+                    "Nonce cache is not configured. Please verify cache configuration.");
         }
         return cache.get("txn:" + cNonce, NonceTransaction.class);
     }

--- a/certify-service/src/main/java/io/mosip/certify/services/NonceCacheService.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/NonceCacheService.java
@@ -1,0 +1,56 @@
+package io.mosip.certify.services;
+
+import io.mosip.certify.core.dto.NonceTransaction;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class NonceCacheService {
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @Value("${spring.cache.type:simple}")
+    private String cacheType;
+
+    private static final String NONCE_CACHE = "nonce";
+    
+    @PostConstruct
+    public void validateCacheConfiguration() {
+        log.info("Cache type configured: {}", cacheType);
+
+        if ("simple".equalsIgnoreCase(cacheType)) {
+            log.warn("CRITICAL WARNING: Simple cache configured for production deployment " +
+                    "'simple' cache uses in-memory storage isolated to each pod, " +
+                    "Multi-pod deployments will experience cache inconsistencies and MAY BREAK FUNCTIONALLY, " +
+                    "Current configuration: spring.cache.type=simple (in-memory, non-distributed), " +
+                    "Switch to Redis cache for multi-pod deployments, Set spring.cache.type=redis in your configuration ");
+        } else if ("redis".equalsIgnoreCase(cacheType)) {
+            log.info("Redis cache is configured - suitable for multi-pod deployment");
+        } else {
+            log.warn("Unknown cache type configured: {}. Please verify configuration.", cacheType);
+        }
+    }
+
+    @CachePut(value = NONCE_CACHE, key = "'txn:' + #cNonce")
+    public NonceTransaction setNonceTransaction(String cNonce,  NonceTransaction nonceTransaction) {
+        return nonceTransaction;
+    }
+
+    public NonceTransaction getNonceTransaction(String cNonce) {
+        Cache cache = cacheManager.getCache(NONCE_CACHE);
+        if (cache == null) {
+            log.error("Cache {} not available. Please verify cache configuration.", NONCE_CACHE);
+            return null;
+        }
+        return cache.get("txn:" + cNonce, NonceTransaction.class);
+    }
+    
+}

--- a/certify-service/src/main/java/io/mosip/certify/services/NonceServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/NonceServiceImpl.java
@@ -1,0 +1,40 @@
+package io.mosip.certify.services;
+
+import io.mosip.certify.core.dto.NonceResponse;
+import io.mosip.certify.core.dto.NonceTransaction;
+import io.mosip.certify.core.spi.NonceService;
+import io.mosip.certify.utils.AccessTokenJwtUtil;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+
+@Component
+public class NonceServiceImpl implements NonceService {
+
+    private final AccessTokenJwtUtil accessTokenJwtUtil;
+
+    private NonceCacheService nonceCacheService;
+
+    @Value("${mosip.certify.cnonce-expire-seconds:300}")
+    private int cNonceExpiresInSeconds;
+
+    public NonceServiceImpl(AccessTokenJwtUtil accessTokenJwtUtil,
+                            NonceCacheService nonceCacheService) {
+        this.accessTokenJwtUtil = accessTokenJwtUtil;
+        this.nonceCacheService = nonceCacheService;
+    }
+
+    @Override
+    public NonceResponse generateNonce() {
+        String cNonce = accessTokenJwtUtil.generateCNonce();
+        NonceTransaction nonceTransaction = createNonceTransaction(cNonce);
+        return new NonceResponse(cNonce);
+    }
+
+    private NonceTransaction createNonceTransaction(String cNonce) {
+        Instant now = Instant.now();
+        NonceTransaction nonceTransaction = new NonceTransaction(cNonce, now.getEpochSecond(), cNonceExpiresInSeconds);
+                return nonceCacheService.setNonceTransaction(cNonce,nonceTransaction);
+    }
+}

--- a/certify-service/src/main/java/io/mosip/certify/services/VCIssuanceServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/VCIssuanceServiceImpl.java
@@ -71,6 +71,9 @@ public class VCIssuanceServiceImpl implements VCIssuanceService {
     @Autowired
     private CredentialConfigurationService credentialConfigurationService;
 
+    @Autowired
+    private NonceCacheService nonceCacheService;
+
     @Override
     public CredentialResponse getCredential(CredentialRequest credentialRequest) {
         boolean isValidCredentialRequest = CredentialRequestValidator.isValid(credentialRequest);
@@ -97,8 +100,8 @@ public class VCIssuanceServiceImpl implements VCIssuanceService {
         }
 
         ProofValidator proofValidator = proofValidatorFactory.getProofValidator(credentialRequest.getProof().getProof_type());
-        String validCNonce = VCIssuanceUtil.validateAndGetClientNonce(vciCacheService, parsedAccessToken,
-                cNonceExpireSeconds, securityHelperService, credentialRequest.getProof(), log);
+        String validCNonce = VCIssuanceUtil.validateAndGetClientNonce(nonceCacheService,
+                cNonceExpireSeconds, credentialRequest.getProof(), log);
         if(!proofValidator.validate((String)parsedAccessToken.getClaims().get(Constants.CLIENT_ID), validCNonce,
                 credentialRequest.getProof(), credentialMetadata.getProofTypesSupported())) {
             throw new CertifyException(VCIErrorConstants.INVALID_PROOF, "Error encountered during proof jwt parsing.");

--- a/certify-service/src/main/java/io/mosip/certify/utils/VCIssuanceUtil.java
+++ b/certify-service/src/main/java/io/mosip/certify/utils/VCIssuanceUtil.java
@@ -11,6 +11,7 @@ import io.mosip.certify.core.exception.CertifyException;
 import io.mosip.certify.core.exception.InvalidRequestException;
 import io.mosip.certify.core.util.SecurityHelperService;
 import io.mosip.certify.exception.InvalidNonceException;
+import io.mosip.certify.services.NonceCacheService;
 import io.mosip.certify.services.VCICacheService;
 import io.mosip.certify.api.dto.VCResult;
 
@@ -150,26 +151,12 @@ public class VCIssuanceUtil {
         return transformedConfig;
     }
 
-    public static String validateAndGetClientNonce(VCICacheService vciCacheService, ParsedAccessToken parsedAccessToken,
-                                             int configuredCNonceExpireSeconds, SecurityHelperService securityHelperService,
+    public static String validateAndGetClientNonce(NonceCacheService nonceCacheService,
+                                                   int configuredCNonceExpireSeconds,
                                                    CredentialProof credentialProof, Logger log) {
-        String accessTokenHash = parsedAccessToken.getAccessTokenHash();
-        VCIssuanceTransaction transaction = vciCacheService.getVCITransaction(accessTokenHash);
-        String authZServerNonce = (transaction == null) ?
-                Optional.ofNullable(parsedAccessToken.getClaims().get(Constants.C_NONCE)).map(Object::toString).orElse("") :
-                transaction.getCNonce();
-
-        int cNonceExpire;
-        if (transaction == null) {
-            int tokenExpiry = determineCNonceExpiry(parsedAccessToken.getClaims().get(Constants.C_NONCE_EXPIRES_IN));
-            cNonceExpire = tokenExpiry > 0 ? tokenExpiry : configuredCNonceExpireSeconds;
-        } else {
-            cNonceExpire = transaction.getCNonceExpireSeconds();
-        }
-
         String proofJwtNonce = null;
         boolean proofJwtHasNonceClaim = false;
-        if (credentialProof.getJwt() != null && !credentialProof.getJwt().isBlank()) {
+        if (StringUtils.isNotBlank(credentialProof.getJwt())) {
             try {
                 SignedJWT proofJwt = SignedJWT.parse(credentialProof.getJwt());
                 Map<String, Object> proofClaims = proofJwt.getJWTClaimsSet().getClaims();
@@ -181,60 +168,42 @@ public class VCIssuanceUtil {
                         throw new CertifyException(VCIErrorConstants.INVALID_PROOF, "Nonce claim must not be empty.");
                     }
                 }
+                else {
+                    log.error("Nonce claim is not present in proof JWT");
+                    throw new CertifyException(VCIErrorConstants.INVALID_PROOF, "Nonce claim must be present in proof JWT.");
+                }
             } catch (ParseException e) {
                 // check iff specific error exists for invalid holderKey
                 throw new CertifyException(VCIErrorConstants.INVALID_PROOF, "Error encountered during proof jwt parsing.");
             }
-        } else if (!StringUtils.isEmpty(authZServerNonce)) {
-            // Access token has nonce but no JWT provided to extract proof nonce from
-            log.error("JWT proof is required but not provided in credential proof");
-            throw new CertifyException(VCIErrorConstants.INVALID_PROOF, "JWT proof is required when nonce is present in access token.");
         }
 
-        if (StringUtils.isEmpty(authZServerNonce) && !proofJwtHasNonceClaim) {
-            return null;
-        }
+        NonceTransaction transaction = nonceCacheService.getNonceTransaction(proofJwtNonce);
 
-        if (StringUtils.isEmpty(authZServerNonce) && proofJwtHasNonceClaim) {
-            log.error("Nonce present in proof JWT but missing in access token");
-            throw new CertifyException(VCIErrorConstants.INVALID_PROOF, "Nonce must not be present in the proof JWT.");
-        }
+        int cNonceExpire;
 
-        long issuedEpoch;
         if (transaction == null) {
-            Object iatClaimValue = parsedAccessToken.getClaims().get(JwtClaimNames.IAT);
-            issuedEpoch = switch (iatClaimValue) {
-                case null -> Instant.MIN.getEpochSecond();
-                case Instant instant -> instant.getEpochSecond();
-                case Number number -> number.longValue();
-                default ->
-                        throw new IllegalStateException("IAT claim is of an unexpected type: " + iatClaimValue.getClass().getName());
-            };
+            log.error("Nonce Transaction could not be found");
+            throw new InvalidNonceException(proofJwtNonce, configuredCNonceExpireSeconds);
         } else {
-            issuedEpoch = transaction.getCNonceIssuedEpoch();
+            cNonceExpire = transaction.cNonceExpireSeconds();
         }
 
-        boolean nonceExpired = !StringUtils.isEmpty(authZServerNonce) &&
-                (cNonceExpire <= 0 ||
+        String cachedNonce = transaction.cNonce();
+
+        long issuedEpoch = transaction.cNonceIssuedEpoch();
+
+        boolean nonceExpired = (cNonceExpire <= 0 ||
                         (issuedEpoch + cNonceExpire) < LocalDateTime.now(ZoneOffset.UTC).toEpochSecond(ZoneOffset.UTC));
 
         if (nonceExpired) {
-            log.error("Client Nonce expired in the access token, generate new authZServerNonce for accessTokenHash: {}",
-                    accessTokenHash != null ? accessTokenHash.substring(0, Math.min(accessTokenHash.length(), 10)) + "..." : "null");
-            VCIssuanceTransaction newTransaction = createOrUpdateVCITransaction(
-                    securityHelperService, configuredCNonceExpireSeconds, vciCacheService, accessTokenHash, transaction);
-            authZServerNonce = newTransaction.getCNonce();
-            cNonceExpire = newTransaction.getCNonceExpireSeconds();
-        }
-        if (!StringUtils.isEmpty(authZServerNonce) && StringUtils.isEmpty(proofJwtNonce)) {
-            log.error("Nonce missing in the proof JWT but present in access token");
-            throw new InvalidNonceException(authZServerNonce, cNonceExpire);
+            throw new CertifyException(VCIErrorConstants.NONCE_EXPIRED, "c_nonce is expired.");
         }
 
-        if (authZServerNonce.equals(proofJwtNonce)) {
-            return authZServerNonce;
+        if (cachedNonce.equals(proofJwtNonce)) {
+            return cachedNonce;
         } else {
-            throw new InvalidNonceException(authZServerNonce, cNonceExpire);
+            throw new InvalidNonceException(cachedNonce, cNonceExpire);
         }
     }
 

--- a/certify-service/src/main/java/io/mosip/certify/utils/VCIssuanceUtil.java
+++ b/certify-service/src/main/java/io/mosip/certify/utils/VCIssuanceUtil.java
@@ -2,10 +2,7 @@ package io.mosip.certify.utils;
 
 import com.nimbusds.jwt.SignedJWT;
 import foundation.identity.jsonld.JsonLDObject;
-import io.mosip.certify.core.constants.Constants;
-import io.mosip.certify.core.constants.ErrorConstants;
-import io.mosip.certify.core.constants.VCFormats;
-import io.mosip.certify.core.constants.VCIErrorConstants;
+import io.mosip.certify.core.constants.*;
 import io.mosip.certify.core.dto.*;
 import io.mosip.certify.core.exception.CertifyException;
 import io.mosip.certify.core.exception.InvalidRequestException;
@@ -156,26 +153,29 @@ public class VCIssuanceUtil {
                                                    CredentialProof credentialProof, Logger log) {
         String proofJwtNonce = null;
         boolean proofJwtHasNonceClaim = false;
-        if (StringUtils.isNotBlank(credentialProof.getJwt())) {
-            try {
-                SignedJWT proofJwt = SignedJWT.parse(credentialProof.getJwt());
-                Map<String, Object> proofClaims = proofJwt.getJWTClaimsSet().getClaims();
-                proofJwtHasNonceClaim = proofClaims.containsKey("nonce");
-                if (proofJwtHasNonceClaim) {
-                    proofJwtNonce = proofJwt.getJWTClaimsSet().getStringClaim("nonce");
-                    if (StringUtils.isBlank(proofJwtNonce)) {
-                        log.error("Nonce claim is present in proof JWT but is blank");
-                        throw new CertifyException(VCIErrorConstants.INVALID_PROOF, "Nonce claim must not be empty.");
-                    }
+        if (credentialProof == null || StringUtils.isBlank(credentialProof.getJwt())) {
+            log.error("Credential proof JWT is required but was blank or missing");
+            throw new CertifyException(VCIErrorConstants.INVALID_PROOF, "Proof JWT is required.");
+       }
+        try {
+            SignedJWT proofJwt = SignedJWT.parse(credentialProof.getJwt());
+            Map<String, Object> proofClaims = proofJwt.getJWTClaimsSet().getClaims();
+            proofJwtHasNonceClaim = proofClaims.containsKey("nonce");
+            if (proofJwtHasNonceClaim) {
+                proofJwtNonce = proofJwt.getJWTClaimsSet().getStringClaim("nonce");
+                if (StringUtils.isBlank(proofJwtNonce)) {
+                    log.error("Nonce claim is present in proof JWT but is blank");
+                    throw new CertifyException(VCIErrorConstants.INVALID_PROOF, "Nonce claim must not be empty.");
                 }
-                else {
-                    log.error("Nonce claim is not present in proof JWT");
-                    throw new CertifyException(VCIErrorConstants.INVALID_PROOF, "Nonce claim must be present in proof JWT.");
-                }
-            } catch (ParseException e) {
-                // check iff specific error exists for invalid holderKey
-                throw new CertifyException(VCIErrorConstants.INVALID_PROOF, "Error encountered during proof jwt parsing.");
             }
+            else {
+                log.error("Nonce claim is not present in proof JWT");
+                throw new CertifyException(VCIErrorConstants.INVALID_PROOF, "Nonce claim must be present in proof JWT.");
+            }
+        }
+        catch (ParseException e) {
+            // check iff specific error exists for invalid holderKey
+            throw new CertifyException(VCIErrorConstants.INVALID_PROOF, "Error encountered during proof jwt parsing.");
         }
 
         NonceTransaction transaction = nonceCacheService.getNonceTransaction(proofJwtNonce);
@@ -197,10 +197,10 @@ public class VCIssuanceUtil {
                         (issuedEpoch + cNonceExpire) < LocalDateTime.now(ZoneOffset.UTC).toEpochSecond(ZoneOffset.UTC));
 
         if (nonceExpired) {
-            throw new CertifyException(VCIErrorConstants.NONCE_EXPIRED, "c_nonce is expired.");
+            throw new CertifyException(NonceErrorConstants.NONCE_EXPIRED, "c_nonce is expired.");
         }
 
-        if (cachedNonce.equals(proofJwtNonce)) {
+        if (Objects.equals(cachedNonce, proofJwtNonce)) {
             return cachedNonce;
         } else {
             throw new InvalidNonceException(cachedNonce, cNonceExpire);

--- a/certify-service/src/main/resources/application-local.properties
+++ b/certify-service/src/main/resources/application-local.properties
@@ -136,7 +136,7 @@ mosip.certify.mock.authenticator.get-identity-url=http://localhost:8082/v1/mock-
 
 # details of VC issuer's public key & controller for DataProvider plugin
 mosip.certify.data-provider-plugin.issuer-public-key-uri=https://vharsh.github.io/DID/mock-rsa.json
-mosip.certify.data-provider-plugin.did-url=did:web:jainhitesh9998.github.io:tempfiles:vc-local-ed25519
+mosip.certify.data-provider-plugin.did-url=did:web:mosip.github.io:inji-config:vc-local-ed25519
 
 ## ---------------------------------------- Cache configuration --------------------------------------------------------
 
@@ -151,7 +151,7 @@ mosip.certify.cache.security.algorithm-name=AES/ECB/PKCS5Padding
 #spring.data.redis.password=redis
 
 spring.cache.type=simple
-mosip.certify.cache.names=userinfo,vcissuance,templatecache,certificatedatacache,credentialConfig,renderTemplate,jwks,preAuthCodeCache,credentialOfferCache,issuerMetadataCache
+mosip.certify.cache.names=userinfo,vcissuance,templatecache,certificatedatacache,credentialConfig,renderTemplate,jwks,preAuthCodeCache,credentialOfferCache,issuerMetadataCache,nonce
 spring.cache.cache-names=${mosip.certify.cache.names}
 management.health.redis.enabled=false
 
@@ -169,10 +169,10 @@ mosip.certify.common.cache-expire-seconds=3600
 mosip.certify.jwks-cache-expire-seconds=300
 # Cache size setup is applicable only for 'simple' cache type.
 # Cache size configuration will not be considered with 'Redis' cache type
-mosip.certify.cache.size={'userinfo': 200, 'vcissuance' : 2000, 'templatecache': 20, 'jwks': 1, 'preAuthCodeCache': 1000, 'credentialOfferCache': 1000, 'issuerMetadataCache': 10}
+mosip.certify.cache.size={'userinfo': 200, 'vcissuance' : 2000, 'templatecache': 20, 'jwks': 1, 'preAuthCodeCache': 1000, 'credentialOfferCache': 1000, 'issuerMetadataCache': 10, 'nonce': 1000}
 
 # Cache expire in seconds is applicable for both 'simple' and 'Redis' cache type
-mosip.certify.cache.expire-in-seconds={'userinfo': ${mosip.certify.access-token-expire-seconds}, 'vcissuance': ${mosip.certify.access-token-expire-seconds}, 'templatecache': ${mosip.certify.templatecache-expire-seconds}, 'certificatedatacache': ${mosip.certify.certificatedatacache-expire-seconds}, 'credentialConfig': ${mosip.certify.common.cache-expire-seconds}, 'renderTemplate': ${mosip.certify.common.cache-expire-seconds}, 'jwks': ${mosip.certify.jwks-cache-expire-seconds}, 'preAuthCodeCache': ${mosip.certify.pre-auth.cache-expire-seconds}, 'credentialOfferCache': ${mosip.certify.credential-offer.cache-expire-seconds}, 'issuerMetadataCache': ${mosip.certify.metadata.cache-expire-seconds}}
+mosip.certify.cache.expire-in-seconds={'userinfo': ${mosip.certify.access-token-expire-seconds}, 'vcissuance': ${mosip.certify.access-token-expire-seconds}, 'templatecache': ${mosip.certify.templatecache-expire-seconds}, 'certificatedatacache': ${mosip.certify.certificatedatacache-expire-seconds}, 'credentialConfig': ${mosip.certify.common.cache-expire-seconds}, 'renderTemplate': ${mosip.certify.common.cache-expire-seconds}, 'jwks': ${mosip.certify.jwks-cache-expire-seconds}, 'preAuthCodeCache': ${mosip.certify.pre-auth.cache-expire-seconds}, 'credentialOfferCache': ${mosip.certify.credential-offer.cache-expire-seconds}, 'issuerMetadataCache': ${mosip.certify.metadata.cache-expire-seconds}, 'nonce': ${mosip.certify.metadata.cache-expire-seconds}}
 
 ##-----------------------------VCI related demo configuration---------------------------------------------##
 

--- a/certify-service/src/main/resources/application-local.properties
+++ b/certify-service/src/main/resources/application-local.properties
@@ -162,6 +162,7 @@ mosip.certify.templatecache-expire-seconds=43200
 mosip.certify.pre-auth.cache-expire-seconds=600
 mosip.certify.credential-offer.cache-expire-seconds=600
 mosip.certify.metadata.cache-expire-seconds=3600
+mosip.certfy.cnonce.cache-expire-seconds=300
 
 mosip.certify.certificatedatacache-expire-seconds=3600
 mosip.certify.common.cache-expire-seconds=3600
@@ -172,7 +173,7 @@ mosip.certify.jwks-cache-expire-seconds=300
 mosip.certify.cache.size={'userinfo': 200, 'vcissuance' : 2000, 'templatecache': 20, 'jwks': 1, 'preAuthCodeCache': 1000, 'credentialOfferCache': 1000, 'issuerMetadataCache': 10, 'nonce': 1000}
 
 # Cache expire in seconds is applicable for both 'simple' and 'Redis' cache type
-mosip.certify.cache.expire-in-seconds={'userinfo': ${mosip.certify.access-token-expire-seconds}, 'vcissuance': ${mosip.certify.access-token-expire-seconds}, 'templatecache': ${mosip.certify.templatecache-expire-seconds}, 'certificatedatacache': ${mosip.certify.certificatedatacache-expire-seconds}, 'credentialConfig': ${mosip.certify.common.cache-expire-seconds}, 'renderTemplate': ${mosip.certify.common.cache-expire-seconds}, 'jwks': ${mosip.certify.jwks-cache-expire-seconds}, 'preAuthCodeCache': ${mosip.certify.pre-auth.cache-expire-seconds}, 'credentialOfferCache': ${mosip.certify.credential-offer.cache-expire-seconds}, 'issuerMetadataCache': ${mosip.certify.metadata.cache-expire-seconds}, 'nonce': ${mosip.certify.metadata.cache-expire-seconds}}
+mosip.certify.cache.expire-in-seconds={'userinfo': ${mosip.certify.access-token-expire-seconds}, 'vcissuance': ${mosip.certify.access-token-expire-seconds}, 'templatecache': ${mosip.certify.templatecache-expire-seconds}, 'certificatedatacache': ${mosip.certify.certificatedatacache-expire-seconds}, 'credentialConfig': ${mosip.certify.common.cache-expire-seconds}, 'renderTemplate': ${mosip.certify.common.cache-expire-seconds}, 'jwks': ${mosip.certify.jwks-cache-expire-seconds}, 'preAuthCodeCache': ${mosip.certify.pre-auth.cache-expire-seconds}, 'credentialOfferCache': ${mosip.certify.credential-offer.cache-expire-seconds}, 'issuerMetadataCache': ${mosip.certify.metadata.cache-expire-seconds}, 'nonce': ${mosip.certfy.cnonce.cache-expire-seconds}}
 
 ##-----------------------------VCI related demo configuration---------------------------------------------##
 

--- a/certify-service/src/test/java/io/mosip/certify/services/CertifyIssuanceServiceImplTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/CertifyIssuanceServiceImplTest.java
@@ -73,6 +73,8 @@ public class CertifyIssuanceServiceImplTest {
     @Mock
     private VCICacheService vciCacheService;
     @Mock
+    private NonceCacheService nonceCacheService;
+    @Mock
     private SecurityHelperService securityHelperService;
     @Mock
     private AuditPlugin auditWrapper;
@@ -109,6 +111,7 @@ public class CertifyIssuanceServiceImplTest {
     CredentialRequest request;
     Map<String, Object> claimsFromAccessToken; // Renamed for clarity
     VCIssuanceTransaction transaction;
+    NonceTransaction nonceTransaction;
     CredentialIssuerMetadataVD13DTO mockGlobalCredentialIssuerMetadataDTO;
 
 
@@ -153,6 +156,7 @@ public class CertifyIssuanceServiceImplTest {
         transaction.setCNonceExpireSeconds(300);
         transaction.setCNonceIssuedEpoch(LocalDateTime.now(ZoneOffset.UTC).toEpochSecond(ZoneOffset.UTC));
 
+        nonceTransaction = new NonceTransaction(TEST_CNONCE,  LocalDateTime.now(ZoneOffset.UTC).toEpochSecond(ZoneOffset.UTC), 300);
 
         mockGlobalCredentialIssuerMetadataDTO = new CredentialIssuerMetadataVD13DTO();
         mockGlobalCredentialIssuerMetadataDTO.setCredentialIssuer("https://test.issuer.com");
@@ -267,7 +271,7 @@ public class CertifyIssuanceServiceImplTest {
 
         when(parsedAccessToken.isActive()).thenReturn(true);
         when(parsedAccessToken.getClaims()).thenReturn(claimsFromAccessToken);
-        when(vciCacheService.getVCITransaction(TEST_ACCESS_TOKEN_HASH)).thenReturn(transaction);
+        when(nonceCacheService.getNonceTransaction(anyString())).thenReturn(nonceTransaction);
         when(proofValidatorFactory.getProofValidator(anyString())).thenReturn(proofValidator);
 
         // Stub getKeyMaterial, its result is used in templateParams for createCredential
@@ -317,7 +321,7 @@ public class CertifyIssuanceServiceImplTest {
         request = createValidCredentialRequest(DEFAULT_FORMAT_LDP);
         when(parsedAccessToken.isActive()).thenReturn(true);
         when(parsedAccessToken.getClaims()).thenReturn(claimsFromAccessToken);
-        when(vciCacheService.getVCITransaction(TEST_ACCESS_TOKEN_HASH)).thenReturn(transaction);
+        when(nonceCacheService.getNonceTransaction(anyString())).thenReturn(nonceTransaction);
         when(proofValidatorFactory.getProofValidator(anyString())).thenReturn(proofValidator);
         when(proofValidator.validate(anyString(), anyString(), any(CredentialProof.class),any())).thenReturn(true);
         when(dataProviderPlugin.fetchData(anyMap())).thenReturn(new JSONObject());
@@ -332,7 +336,7 @@ public class CertifyIssuanceServiceImplTest {
         request = createValidCredentialRequest(DEFAULT_FORMAT_LDP);
         when(parsedAccessToken.isActive()).thenReturn(true);
         when(parsedAccessToken.getClaims()).thenReturn(claimsFromAccessToken);
-        when(vciCacheService.getVCITransaction(TEST_ACCESS_TOKEN_HASH)).thenReturn(transaction);
+        when(nonceCacheService.getNonceTransaction(anyString())).thenReturn(nonceTransaction);
         when(proofValidatorFactory.getProofValidator(anyString())).thenReturn(proofValidator);
         when(proofValidator.validate(anyString(), anyString(), any(CredentialProof.class),any())).thenReturn(true);
         DataProviderExchangeException e = new DataProviderExchangeException("DP_FETCH_FAILED", "Failed to fetch data");
@@ -350,21 +354,15 @@ public class CertifyIssuanceServiceImplTest {
         proof.setJwt(createValidJWT("expired-cnonce"));
         request.setProof(proof);
 
-        VCIssuanceTransaction expiredTransaction = new VCIssuanceTransaction();
-        expiredTransaction.setCNonce("expired-cnonce");
-        expiredTransaction.setCNonceExpireSeconds(10);
-        expiredTransaction.setCNonceIssuedEpoch(LocalDateTime.now(ZoneOffset.UTC).minusSeconds(20).toEpochSecond(ZoneOffset.UTC));
+        NonceTransaction expiredTransaction = new NonceTransaction("expired-cnonce",LocalDateTime.now(ZoneOffset.UTC).minusSeconds(20).toEpochSecond(ZoneOffset.UTC), 10);
 
         when(parsedAccessToken.isActive()).thenReturn(true);
         when(parsedAccessToken.getClaims()).thenReturn(claimsFromAccessToken);
-        when(vciCacheService.getVCITransaction(TEST_ACCESS_TOKEN_HASH)).thenReturn(expiredTransaction);
+        when(nonceCacheService.getNonceTransaction(anyString())).thenReturn(expiredTransaction);
         when(securityHelperService.generateSecureRandomString(anyInt())).thenReturn("new-generated-cnonce");
-        when(vciCacheService.setVCITransaction(eq(TEST_ACCESS_TOKEN_HASH), any(VCIssuanceTransaction.class)))
-                .thenAnswer(invocation -> invocation.getArgument(1));
 
-        InvalidNonceException invalidNonceException = assertThrows(InvalidNonceException.class, () -> issuanceService.getCredential(request));
-        assertEquals("new-generated-cnonce", invalidNonceException.getClientNonce());
-        assertEquals("invalid_proof", invalidNonceException.getErrorCode());
+        CertifyException ex = assertThrows(CertifyException.class, () -> issuanceService.getCredential(request));
+        assertEquals("nonce_expired", ex.getErrorCode());
     }
 
     @Test
@@ -410,7 +408,7 @@ public class CertifyIssuanceServiceImplTest {
         request = createValidCredentialRequest(DEFAULT_FORMAT_LDP);
         when(parsedAccessToken.isActive()).thenReturn(true);
         when(parsedAccessToken.getClaims()).thenReturn(claimsFromAccessToken);
-        when(vciCacheService.getVCITransaction(TEST_ACCESS_TOKEN_HASH)).thenReturn(transaction);
+        when(nonceCacheService.getNonceTransaction(anyString())).thenReturn(nonceTransaction);
         when(proofValidatorFactory.getProofValidator(anyString())).thenReturn(proofValidator);
         when(proofValidator.validate(anyString(), anyString(), any(CredentialProof.class),any())).thenReturn(false);
 
@@ -431,7 +429,7 @@ public class CertifyIssuanceServiceImplTest {
 
         when(parsedAccessToken.isActive()).thenReturn(true);
         when(parsedAccessToken.getClaims()).thenReturn(claimsFromAccessToken);
-        when(vciCacheService.getVCITransaction(TEST_ACCESS_TOKEN_HASH)).thenReturn(transaction);
+        when(nonceCacheService.getNonceTransaction(anyString())).thenReturn(nonceTransaction);
         when(proofValidatorFactory.getProofValidator(anyString())).thenReturn(proofValidator);
 
         // Crucial: Stub getKeyMaterial to return "" to match the addProof mock
@@ -488,7 +486,7 @@ public class CertifyIssuanceServiceImplTest {
         // Mock credentialFactory and W3CJsonLD
         when(parsedAccessToken.isActive()).thenReturn(true);
         when(parsedAccessToken.getClaims()).thenReturn(claimsFromAccessToken);
-        when(vciCacheService.getVCITransaction(TEST_ACCESS_TOKEN_HASH)).thenReturn(transaction);
+        when(nonceCacheService.getNonceTransaction(anyString())).thenReturn(nonceTransaction);
         when(proofValidatorFactory.getProofValidator(anyString())).thenReturn(proofValidator);
 
         // Stub getKeyMaterial, its result is used in templateParams for createCredential
@@ -550,7 +548,7 @@ public class CertifyIssuanceServiceImplTest {
         // Mock credentialFactory and W3CJsonLD
         when(parsedAccessToken.isActive()).thenReturn(true);
         when(parsedAccessToken.getClaims()).thenReturn(claimsFromAccessToken);
-        when(vciCacheService.getVCITransaction(TEST_ACCESS_TOKEN_HASH)).thenReturn(transaction);
+        when(nonceCacheService.getNonceTransaction(anyString())).thenReturn(nonceTransaction);
         when(proofValidatorFactory.getProofValidator(anyString())).thenReturn(proofValidator);
 
         // Stub getKeyMaterial, its result is used in templateParams for createCredential
@@ -616,7 +614,7 @@ public class CertifyIssuanceServiceImplTest {
 
             when(parsedAccessToken.isActive()).thenReturn(true);
             when(parsedAccessToken.getClaims()).thenReturn(claimsFromAccessToken);
-            when(vciCacheService.getVCITransaction(TEST_ACCESS_TOKEN_HASH)).thenReturn(transaction);
+            when(nonceCacheService.getNonceTransaction(anyString())).thenReturn(nonceTransaction);
             when(proofValidatorFactory.getProofValidator(anyString())).thenReturn(proofValidator);
 
             // Stub getKeyMaterial to return ""
@@ -667,7 +665,7 @@ public class CertifyIssuanceServiceImplTest {
 
         when(parsedAccessToken.isActive()).thenReturn(true);
         when(parsedAccessToken.getClaims()).thenReturn(claimsFromAccessToken);
-        when(vciCacheService.getVCITransaction(TEST_ACCESS_TOKEN_HASH)).thenReturn(transaction);
+        when(nonceCacheService.getNonceTransaction(anyString())).thenReturn(nonceTransaction);
         when(proofValidatorFactory.getProofValidator(anyString())).thenReturn(proofValidator);
         when(proofValidator.getKeyMaterial(any(CredentialProof.class))).thenReturn("");
         when(proofValidator.validate(anyString(), anyString(), any(CredentialProof.class), any())).thenReturn(true);
@@ -734,7 +732,7 @@ public class CertifyIssuanceServiceImplTest {
 
         when(parsedAccessToken.isActive()).thenReturn(true);
         when(parsedAccessToken.getClaims()).thenReturn(claimsFromAccessToken);
-        when(vciCacheService.getVCITransaction(TEST_ACCESS_TOKEN_HASH)).thenReturn(transaction);
+        when(nonceCacheService.getNonceTransaction(anyString())).thenReturn(nonceTransaction);
         when(proofValidatorFactory.getProofValidator(anyString())).thenReturn(proofValidator);
         when(proofValidator.getKeyMaterial(any(CredentialProof.class))).thenReturn("");
         when(proofValidator.validate(anyString(), anyString(), any(CredentialProof.class), any())).thenReturn(true);
@@ -777,7 +775,7 @@ public class CertifyIssuanceServiceImplTest {
 
         when(parsedAccessToken.isActive()).thenReturn(true);
         when(parsedAccessToken.getClaims()).thenReturn(claimsFromAccessToken);
-        when(vciCacheService.getVCITransaction(TEST_ACCESS_TOKEN_HASH)).thenReturn(transaction);
+        when(nonceCacheService.getNonceTransaction(anyString())).thenReturn(nonceTransaction);
         when(proofValidatorFactory.getProofValidator(anyString())).thenReturn(proofValidator);
         when(proofValidator.getKeyMaterial(any(CredentialProof.class))).thenReturn("");
         when(proofValidator.validate(anyString(), anyString(), any(CredentialProof.class), any())).thenReturn(true);

--- a/certify-service/src/test/java/io/mosip/certify/services/CertifyIssuanceServiceImplTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/CertifyIssuanceServiceImplTest.java
@@ -359,7 +359,6 @@ public class CertifyIssuanceServiceImplTest {
         when(parsedAccessToken.isActive()).thenReturn(true);
         when(parsedAccessToken.getClaims()).thenReturn(claimsFromAccessToken);
         when(nonceCacheService.getNonceTransaction(anyString())).thenReturn(expiredTransaction);
-        when(securityHelperService.generateSecureRandomString(anyInt())).thenReturn("new-generated-cnonce");
 
         CertifyException ex = assertThrows(CertifyException.class, () -> issuanceService.getCredential(request));
         assertEquals("nonce_expired", ex.getErrorCode());

--- a/certify-service/src/test/java/io/mosip/certify/services/VCIssuanceServiceImplTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/VCIssuanceServiceImplTest.java
@@ -62,6 +62,8 @@ public class VCIssuanceServiceImplTest {
     @Mock
     private VCICacheService vciCacheService;
     @Mock
+    private NonceCacheService nonceCacheService;
+    @Mock
     private SecurityHelperService securityHelperService;
     @Mock
     private AuditPlugin auditWrapper;
@@ -83,6 +85,7 @@ public class VCIssuanceServiceImplTest {
     Map<String, Object> claimsFromAccessToken;
     VCIssuanceTransaction transaction;
     CredentialIssuerMetadataVD13DTO mockGlobalCredentialIssuerMetadataDTO;
+    NonceTransaction nonceTransaction;
 
 
     @Before
@@ -103,6 +106,8 @@ public class VCIssuanceServiceImplTest {
         latestMetadataConfig.put("credential_issuer", "https://localhost:9090");
         latestMetadataConfig.put("credential_endpoint", "https://localhost:9090/v1/certify/issuance/credential");
         testIssuerMetadataMap.put("latest", latestMetadataConfig);
+
+        nonceTransaction = new NonceTransaction(TEST_CNONCE,  LocalDateTime.now(ZoneOffset.UTC).toEpochSecond(ZoneOffset.UTC),300);
 
         ReflectionTestUtils.setField(issuanceService, "cNonceExpireSeconds", 300);
 
@@ -227,7 +232,7 @@ public class VCIssuanceServiceImplTest {
         request = createValidCredentialRequest(VCFormats.LDP_VC);
         when(parsedAccessToken.isActive()).thenReturn(true);
         when(parsedAccessToken.getClaims()).thenReturn(claimsFromAccessToken);
-        when(vciCacheService.getVCITransaction(TEST_ACCESS_TOKEN_HASH)).thenReturn(transaction);
+        when(nonceCacheService.getNonceTransaction(anyString())).thenReturn(nonceTransaction);
         when(proofValidatorFactory.getProofValidator(anyString())).thenReturn(proofValidator);
         when(proofValidator.validate(eq("test-client"), eq(TEST_CNONCE), any(CredentialProof.class), any())).thenReturn(true);
         when(proofValidator.getKeyMaterial(any(CredentialProof.class))).thenReturn(HOLDER_ID);
@@ -252,21 +257,15 @@ public class VCIssuanceServiceImplTest {
         proof.setJwt(createValidJWT("expired-cnonce", true));
         request.setProof(proof);
 
-        VCIssuanceTransaction expiredTransaction = new VCIssuanceTransaction();
-        expiredTransaction.setCNonce("expired-cnonce");
-        expiredTransaction.setCNonceExpireSeconds(10);
-        expiredTransaction.setCNonceIssuedEpoch(LocalDateTime.now(ZoneOffset.UTC).minusSeconds(20).toEpochSecond(ZoneOffset.UTC));
+        NonceTransaction expiredTransaction = new NonceTransaction("expired-cnonce",LocalDateTime.now(ZoneOffset.UTC).minusSeconds(20).toEpochSecond(ZoneOffset.UTC), 10);
+        when(nonceCacheService.getNonceTransaction(anyString())).thenReturn(expiredTransaction);
 
         when(parsedAccessToken.isActive()).thenReturn(true);
         when(parsedAccessToken.getClaims()).thenReturn(claimsFromAccessToken);
-        when(vciCacheService.getVCITransaction(TEST_ACCESS_TOKEN_HASH)).thenReturn(expiredTransaction);
-        when(securityHelperService.generateSecureRandomString(anyInt())).thenReturn("new-generated-cnonce");
-        when(vciCacheService.setVCITransaction(eq(TEST_ACCESS_TOKEN_HASH), any(VCIssuanceTransaction.class)))
-                .thenAnswer(invocation -> invocation.getArgument(1));
+        when(nonceCacheService.getNonceTransaction(anyString())).thenReturn(nonceTransaction);
 
-        InvalidNonceException invalidNonceException = assertThrows(InvalidNonceException.class, () -> issuanceService.getCredential(request));
-        assertEquals("new-generated-cnonce", invalidNonceException.getClientNonce());
-        assertEquals("invalid_proof", invalidNonceException.getErrorCode());
+        CertifyException certifyException = assertThrows(CertifyException.class, () -> issuanceService.getCredential(request));
+        assertEquals("invalid_proof", certifyException.getErrorCode());
     }
 
     @Test
@@ -281,11 +280,9 @@ public class VCIssuanceServiceImplTest {
         claimsFromAccessToken.put("iat", LocalDateTime.now(ZoneOffset.UTC).toEpochSecond(ZoneOffset.UTC));
         when(parsedAccessToken.isActive()).thenReturn(true);
         when(parsedAccessToken.getClaims()).thenReturn(claimsFromAccessToken);
+        CertifyException certifyException = assertThrows(CertifyException.class, () -> issuanceService.getCredential(request));
 
-        InvalidNonceException invalidNonceException = assertThrows(InvalidNonceException.class, () -> issuanceService.getCredential(request));
-
-        assertEquals("test-cnonce", invalidNonceException.getClientNonce());
-        assertEquals("invalid_proof", invalidNonceException.getErrorCode());
+        assertEquals("invalid_proof", certifyException.getErrorCode());
     }
 
     @Test
@@ -300,7 +297,6 @@ public class VCIssuanceServiceImplTest {
         claimsFromAccessToken.put("iat", LocalDateTime.now(ZoneOffset.UTC).toEpochSecond(ZoneOffset.UTC));
         when(parsedAccessToken.isActive()).thenReturn(true);
         when(parsedAccessToken.getClaims()).thenReturn(claimsFromAccessToken);
-
         CertifyException certifyException = assertThrows(CertifyException.class, () -> issuanceService.getCredential(request));
 
         assertEquals("invalid_proof", certifyException.getErrorCode());
@@ -319,6 +315,8 @@ public class VCIssuanceServiceImplTest {
         when(parsedAccessToken.isActive()).thenReturn(true);
         when(parsedAccessToken.getClaims()).thenReturn(claimsFromAccessToken);
 
+        when(nonceCacheService.getNonceTransaction(anyString())).thenReturn(nonceTransaction);
+
         InvalidNonceException invalidNonceException = assertThrows(InvalidNonceException.class, () -> issuanceService.getCredential(request));
 
         assertEquals("test-cnonce", invalidNonceException.getClientNonce());
@@ -326,25 +324,11 @@ public class VCIssuanceServiceImplTest {
     }
 
     @Test
-    public void getCredential_NonceInProofJwtButNotInAccessToken_ThrowsCertifyException() throws Exception {
-        request = createValidCredentialRequest(VCFormats.LDP_VC);
-        Map<String, Object> claimsWithoutCNonce = new HashMap<>(claimsFromAccessToken);
-        claimsWithoutCNonce.remove(Constants.C_NONCE);
-        claimsWithoutCNonce.remove(Constants.C_NONCE_EXPIRES_IN);
-
-        when(parsedAccessToken.isActive()).thenReturn(true);
-        when(parsedAccessToken.getClaims()).thenReturn(claimsWithoutCNonce);
-
-        CertifyException ex = assertThrows(CertifyException.class, () -> issuanceService.getCredential(request));
-        assertEquals(VCIErrorConstants.INVALID_PROOF, ex.getErrorCode());
-    }
-
-    @Test
     public void getCredential_LDP_PluginReturnsNullVCResult_Fail() throws Exception {
         request = createValidCredentialRequest(VCFormats.LDP_VC);
         when(parsedAccessToken.isActive()).thenReturn(true);
         when(parsedAccessToken.getClaims()).thenReturn(claimsFromAccessToken);
-        when(vciCacheService.getVCITransaction(TEST_ACCESS_TOKEN_HASH)).thenReturn(transaction);
+        when(nonceCacheService.getNonceTransaction(anyString())).thenReturn(nonceTransaction);
         when(proofValidatorFactory.getProofValidator(anyString())).thenReturn(proofValidator);
         when(proofValidator.validate(anyString(), anyString(), any(CredentialProof.class),any())).thenReturn(true);
         when(proofValidator.getKeyMaterial(any(CredentialProof.class))).thenReturn(HOLDER_ID);
@@ -360,7 +344,7 @@ public class VCIssuanceServiceImplTest {
         request = createValidCredentialRequest(VCFormats.LDP_VC);
         when(parsedAccessToken.isActive()).thenReturn(true);
         when(parsedAccessToken.getClaims()).thenReturn(claimsFromAccessToken);
-        when(vciCacheService.getVCITransaction(TEST_ACCESS_TOKEN_HASH)).thenReturn(transaction);
+        when(nonceCacheService.getNonceTransaction(anyString())).thenReturn(nonceTransaction);
         when(proofValidatorFactory.getProofValidator(anyString())).thenReturn(proofValidator);
         when(proofValidator.validate(anyString(), anyString(), any(CredentialProof.class),any())).thenReturn(true);
         when(proofValidator.getKeyMaterial(any(CredentialProof.class))).thenReturn(HOLDER_ID);
@@ -382,7 +366,7 @@ public class VCIssuanceServiceImplTest {
 
         when(parsedAccessToken.isActive()).thenReturn(true);
         when(parsedAccessToken.getClaims()).thenReturn(claimsFromAccessToken);
-        when(vciCacheService.getVCITransaction(TEST_ACCESS_TOKEN_HASH)).thenReturn(transaction);
+        when(nonceCacheService.getNonceTransaction(anyString())).thenReturn(nonceTransaction);
         when(proofValidatorFactory.getProofValidator(anyString())).thenReturn(proofValidator);
         when(proofValidator.validate(anyString(), anyString(), any(CredentialProof.class),any())).thenReturn(true);
         when(proofValidator.getKeyMaterial(any(CredentialProof.class))).thenReturn(HOLDER_ID);
@@ -427,7 +411,7 @@ public class VCIssuanceServiceImplTest {
         request = createValidCredentialRequest(VCFormats.LDP_VC);
         when(parsedAccessToken.isActive()).thenReturn(true);
         when(parsedAccessToken.getClaims()).thenReturn(claimsFromAccessToken);
-        when(vciCacheService.getVCITransaction(TEST_ACCESS_TOKEN_HASH)).thenReturn(transaction);
+        when(nonceCacheService.getNonceTransaction(anyString())).thenReturn(nonceTransaction);
         when(proofValidatorFactory.getProofValidator(anyString())).thenReturn(proofValidator);
         when(proofValidator.validate(anyString(), anyString(), any(CredentialProof.class), any())).thenReturn(false); // Proof fails
 
@@ -462,7 +446,7 @@ public class VCIssuanceServiceImplTest {
         request = createValidCredentialRequest(VCFormats.LDP_VC);
         when(parsedAccessToken.isActive()).thenReturn(true);
         when(parsedAccessToken.getClaims()).thenReturn(claimsFromAccessToken);
-        when(vciCacheService.getVCITransaction(TEST_ACCESS_TOKEN_HASH)).thenReturn(transaction);
+        when(nonceCacheService.getNonceTransaction(anyString())).thenReturn(nonceTransaction);
         when(proofValidatorFactory.getProofValidator(anyString())).thenReturn(proofValidator);
         when(proofValidator.validate(eq("test-client"), eq(TEST_CNONCE), any(CredentialProof.class), any())).thenReturn(true);
         when(proofValidator.getKeyMaterial(any(CredentialProof.class))).thenReturn(HOLDER_ID);
@@ -497,7 +481,7 @@ public class VCIssuanceServiceImplTest {
                     anyString(), anyString(), any(), any(CredentialRequest.class)
             )).thenReturn(Optional.of(mockMetadata));
             utilMock.when(() -> VCIssuanceUtil.validateAndGetClientNonce(
-                    any(VCICacheService.class), eq(parsedAccessToken), anyInt(), any(SecurityHelperService.class),
+                    any(NonceCacheService.class), anyInt(),
                     any(CredentialProof.class), any()
             )).thenReturn(TEST_CNONCE);
 
@@ -553,7 +537,7 @@ public class VCIssuanceServiceImplTest {
                     anyString(), anyString(), any(), any(CredentialRequest.class)
             )).thenReturn(Optional.of(mockMetadata));
             utilMock.when(() -> VCIssuanceUtil.validateAndGetClientNonce(
-                    any(VCICacheService.class), eq(parsedAccessToken), anyInt(), any(SecurityHelperService.class),
+                    any(NonceCacheService.class), anyInt(),
                     any(CredentialProof.class), any()
             )).thenReturn(TEST_CNONCE);
 

--- a/docs/postman-collections/Inji Certify - Presentation During Issuance VCI.postman_collection.json
+++ b/docs/postman-collections/Inji Certify - Presentation During Issuance VCI.postman_collection.json
@@ -272,10 +272,6 @@
 									"    pm.collectionVariables.set('access_token', accessToken);",
 									"    // pm.environment.set('access_token', accessToken);",
 									"    console.log(\"✅ Access token saved successfully\");",
-									"    const cNonce = jsonData.c_nonce;",
-									"    const cNonceExpiresIn = jsonData.c_nonce_expires_in;",
-									"    pm.collectionVariables.set('c_nonce', cNonce);",
-									"    pm.collectionVariables.set('c_nonce_expires_in', cNonceExpiresIn);",
 									"});"
 								],
 								"type": "text/javascript"
@@ -328,10 +324,41 @@
 			]
 		},
 		{
-			"name": "5. Credential download",
+			"name": "5. Nonce endpoint",
 			"item": [
 				{
-					"name": "5.1 Get Credential",
+					"name": "5.1 Get Nonce",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"var response = pm.response.json();",
+									"pm.environment.set(\"c_nonce\", response.c_nonce);"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{nonce_endpoint}}",
+							"host": [
+								"{{nonce_endpoint}}"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "6. Credential download",
+			"item": [
+				{
+					"name": "6.1 Get Credential",
 					"event": [
 						{
 							"listen": "prerequest",

--- a/docs/postman-collections/inji-certify-with-mock-identity.postman_collection.json
+++ b/docs/postman-collections/inji-certify-with-mock-identity.postman_collection.json
@@ -1,7 +1,7 @@
 {
 	"info": {
 		"_postman_id": "edd685ae-f66f-425a-8859-ef319d8d5443",
-		"name": "certify- Mock IDA",
+		"name": "certify- Mock IDA - 2",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "1282483"
 	},
@@ -667,11 +667,6 @@
 									"    pm.expect(jsonData.access_token).not.equals(null);",
 									"    pm.environment.set(\"access_token\", jsonData.access_token);",
 									"",
-									"    pm.expect(jsonData.c_nonce).not.equals(null);",
-									"    pm.environment.set(\"c_nonce\", jsonData.c_nonce);",
-									"    // var jwt_parts = pm.environment.get('access_token').split('.'); // header.payload.signature",
-									"    // var jwt_payload = JSON.parse(atob(jwt_parts[1]));",
-									"    // pm.environment.set(\"c_nonce\", jwt_payload.c_nonce);",
 									"});"
 								],
 								"type": "text/javascript"
@@ -730,6 +725,36 @@
 								"oauth",
 								"v2",
 								"token"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Nonce Endpoint",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var response = pm.response.json();",
+									"pm.environment.set(\"c_nonce\", response.c_nonce);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{certifyUrl}}/issuance/nonce",
+							"host": [
+								"{{certifyUrl}}"
+							],
+							"path": [
+								"issuance",
+								"nonce"
 							]
 						}
 					},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a POST /issuance/nonce endpoint for generating client nonces with server-side caching and configurable expiry (default 300s). Responses include Cache-Control: no-store.

* **Bug Fixes**
  * Proof validation now requires a nonce and enforces cache-based expiry, returning clearer nonce-related errors.

* **Tests**
  * Updated tests to align with nonce caching and validation changes.

* **Documentation**
  * Postman collections updated to fetch and store the nonce via the new endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->