### PR TITLE
feat(nonce): #675 Implementation of nonce_endpoint for c_nonce generation

### DIFF
--- a/certify-core/src/main/java/io/mosip/certify/core/constants/NonceErrorConstants.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/constants/NonceErrorConstants.java
@@ -1,0 +1,6 @@
+package io.mosip.certify.core.constants;
+
+public class NonceErrorConstants {
+    public static final String NONCE_EXPIRED = "nonce_expired";
+    public static final String CACHE_NOT_AVAILABLE = "cache_not_available";
+}

--- a/certify-core/src/main/java/io/mosip/certify/core/dto/NonceResponse.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/dto/NonceResponse.java
@@ -1,0 +1,8 @@
+package io.mosip.certify.core.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record NonceResponse(
+        @JsonProperty("c_nonce")
+        String cNonce
+) {}

--- a/certify-core/src/main/java/io/mosip/certify/core/dto/NonceTransaction.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/dto/NonceTransaction.java
@@ -1,0 +1,6 @@
+package io.mosip.certify.core.dto;
+
+public record NonceTransaction(
+        String cNonce,
+        long cNonceIssuedEpoch,
+        int cNonceExpireSeconds) {}

--- a/certify-core/src/main/java/io/mosip/certify/core/dto/NonceTransaction.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/dto/NonceTransaction.java
@@ -1,6 +1,0 @@
-package io.mosip.certify.core.dto;
-
-public record NonceTransaction(
-        String cNonce,
-        long cNonceIssuedEpoch,
-        int cNonceExpireSeconds) {}

--- a/certify-core/src/main/java/io/mosip/certify/core/spi/NonceService.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/spi/NonceService.java
@@ -1,0 +1,7 @@
+package io.mosip.certify.core.spi;
+
+import io.mosip.certify.core.dto.NonceResponse;
+
+public interface NonceService {
+    NonceResponse generateNonce();
+}

--- a/certify-service/src/main/java/io/mosip/certify/controller/NonceController.java
+++ b/certify-service/src/main/java/io/mosip/certify/controller/NonceController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
-@RequestMapping("/issuance")
 public class NonceController {
 
 

--- a/certify-service/src/main/java/io/mosip/certify/controller/NonceController.java
+++ b/certify-service/src/main/java/io/mosip/certify/controller/NonceController.java
@@ -1,0 +1,31 @@
+package io.mosip.certify.controller;
+
+import io.mosip.certify.core.dto.NonceResponse;
+import io.mosip.certify.core.spi.NonceService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/issuance")
+public class NonceController {
+
+
+    private final NonceService nonceService;
+
+    public NonceController(NonceService nonceService) {
+        this.nonceService = nonceService;
+    }
+
+    @PostMapping("/nonce")
+    public ResponseEntity<NonceResponse> getNonce() {
+        NonceResponse nonceResponse = nonceService.generateNonce();
+        return ResponseEntity.ok()
+                .header("Cache-Control", "no-store")
+                .body(nonceResponse);
+    }
+}

--- a/certify-service/src/main/java/io/mosip/certify/services/NonceCacheService.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/NonceCacheService.java
@@ -1,11 +1,10 @@
 package io.mosip.certify.services;
 
 import io.mosip.certify.core.constants.NonceErrorConstants;
-import io.mosip.certify.core.dto.NonceTransaction;
+import io.mosip.certify.core.dto.VCIssuanceTransaction;
 import io.mosip.certify.core.exception.CertifyException;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
@@ -16,13 +15,16 @@ import org.springframework.stereotype.Service;
 @Service
 public class NonceCacheService {
 
-    @Autowired
     private CacheManager cacheManager;
 
     @Value("${spring.cache.type:simple}")
     private String cacheType;
 
     private static final String NONCE_CACHE = "nonce";
+
+    public NonceCacheService(CacheManager cacheManager) {
+        this.cacheManager = cacheManager;
+    }
     
     @PostConstruct
     public void validateCacheConfiguration() {
@@ -42,18 +44,18 @@ public class NonceCacheService {
     }
 
     @CachePut(value = NONCE_CACHE, key = "'txn:' + #cNonce")
-    public NonceTransaction setNonceTransaction(String cNonce,  NonceTransaction nonceTransaction) {
-        return nonceTransaction;
+    public VCIssuanceTransaction setNonceTransaction(String cNonce, VCIssuanceTransaction transaction) {
+        return transaction;
     }
 
-    public NonceTransaction getNonceTransaction(String cNonce) {
+    public VCIssuanceTransaction getNonceTransaction(String cNonce) {
         Cache cache = cacheManager.getCache(NONCE_CACHE);
         if (cache == null) {
             log.error("Cache {} not available. Please verify cache configuration.", NONCE_CACHE);
             throw new CertifyException(NonceErrorConstants.CACHE_NOT_AVAILABLE,
                     "Nonce cache is not configured. Please verify cache configuration.");
         }
-        return cache.get("txn:" + cNonce, NonceTransaction.class);
+        return cache.get("txn:" + cNonce, VCIssuanceTransaction.class);
     }
     
 }

--- a/certify-service/src/main/java/io/mosip/certify/services/NonceCacheService.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/NonceCacheService.java
@@ -1,0 +1,59 @@
+package io.mosip.certify.services;
+
+import io.mosip.certify.core.constants.NonceErrorConstants;
+import io.mosip.certify.core.dto.NonceTransaction;
+import io.mosip.certify.core.exception.CertifyException;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class NonceCacheService {
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @Value("${spring.cache.type:simple}")
+    private String cacheType;
+
+    private static final String NONCE_CACHE = "nonce";
+    
+    @PostConstruct
+    public void validateCacheConfiguration() {
+        log.info("Cache type configured: {}", cacheType);
+
+        if ("simple".equalsIgnoreCase(cacheType)) {
+            log.warn("CRITICAL WARNING: Simple cache configured for production deployment " +
+                    "'simple' cache uses in-memory storage isolated to each pod, " +
+                    "Multi-pod deployments will experience cache inconsistencies and MAY BREAK FUNCTIONALLY, " +
+                    "Current configuration: spring.cache.type=simple (in-memory, non-distributed), " +
+                    "Switch to Redis cache for multi-pod deployments, Set spring.cache.type=redis in your configuration ");
+        } else if ("redis".equalsIgnoreCase(cacheType)) {
+            log.info("Redis cache is configured - suitable for multi-pod deployment");
+        } else {
+            log.warn("Unknown cache type configured: {}. Please verify configuration.", cacheType);
+        }
+    }
+
+    @CachePut(value = NONCE_CACHE, key = "'txn:' + #cNonce")
+    public NonceTransaction setNonceTransaction(String cNonce,  NonceTransaction nonceTransaction) {
+        return nonceTransaction;
+    }
+
+    public NonceTransaction getNonceTransaction(String cNonce) {
+        Cache cache = cacheManager.getCache(NONCE_CACHE);
+        if (cache == null) {
+            log.error("Cache {} not available. Please verify cache configuration.", NONCE_CACHE);
+            throw new CertifyException(NonceErrorConstants.CACHE_NOT_AVAILABLE,
+                    "Nonce cache is not configured. Please verify cache configuration.");
+        }
+        return cache.get("txn:" + cNonce, NonceTransaction.class);
+    }
+    
+}

--- a/certify-service/src/main/java/io/mosip/certify/services/NonceServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/NonceServiceImpl.java
@@ -1,0 +1,45 @@
+package io.mosip.certify.services;
+
+import io.mosip.certify.core.dto.NonceResponse;
+import io.mosip.certify.core.dto.NonceTransaction;
+import io.mosip.certify.core.exception.CertifyException;
+import io.mosip.certify.core.spi.NonceService;
+import io.mosip.certify.utils.AccessTokenJwtUtil;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+
+@Component
+public class NonceServiceImpl implements NonceService {
+
+    private final AccessTokenJwtUtil accessTokenJwtUtil;
+
+    private NonceCacheService nonceCacheService;
+
+    @Value("${mosip.certify.cnonce-expire-seconds:300}")
+    private int cNonceExpiresInSeconds;
+
+    public NonceServiceImpl(AccessTokenJwtUtil accessTokenJwtUtil,
+                            NonceCacheService nonceCacheService) {
+        this.accessTokenJwtUtil = accessTokenJwtUtil;
+        this.nonceCacheService = nonceCacheService;
+    }
+
+    @Override
+    public NonceResponse generateNonce() {
+        String cNonce = accessTokenJwtUtil.generateCNonce();
+        NonceTransaction nonceTransaction = createNonceTransaction(cNonce);
+        return new NonceResponse(cNonce);
+    }
+
+    private NonceTransaction createNonceTransaction(String cNonce) {
+        try {
+            Instant now = Instant.now();
+            NonceTransaction nonceTransaction = new NonceTransaction(cNonce, now.getEpochSecond(), cNonceExpiresInSeconds);
+            return nonceCacheService.setNonceTransaction(cNonce,nonceTransaction);
+        } catch (CertifyException e) {
+            throw e;
+        }
+    }
+}

--- a/certify-service/src/main/java/io/mosip/certify/services/NonceServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/NonceServiceImpl.java
@@ -1,16 +1,16 @@
 package io.mosip.certify.services;
 
 import io.mosip.certify.core.dto.NonceResponse;
-import io.mosip.certify.core.dto.NonceTransaction;
+import io.mosip.certify.core.dto.VCIssuanceTransaction;
 import io.mosip.certify.core.exception.CertifyException;
 import io.mosip.certify.core.spi.NonceService;
 import io.mosip.certify.utils.AccessTokenJwtUtil;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 
-import java.time.Instant;
-
-@Component
+@Service
 public class NonceServiceImpl implements NonceService {
 
     private final AccessTokenJwtUtil accessTokenJwtUtil;
@@ -29,15 +29,18 @@ public class NonceServiceImpl implements NonceService {
     @Override
     public NonceResponse generateNonce() {
         String cNonce = accessTokenJwtUtil.generateCNonce();
-        NonceTransaction nonceTransaction = createNonceTransaction(cNonce);
+        VCIssuanceTransaction transaction = createNonceTransaction(cNonce);
         return new NonceResponse(cNonce);
     }
 
-    private NonceTransaction createNonceTransaction(String cNonce) {
+    private VCIssuanceTransaction createNonceTransaction(String cNonce) {
         try {
-            Instant now = Instant.now();
-            NonceTransaction nonceTransaction = new NonceTransaction(cNonce, now.getEpochSecond(), cNonceExpiresInSeconds);
-            return nonceCacheService.setNonceTransaction(cNonce,nonceTransaction);
+            Long cNonceIssuedTime = LocalDateTime.now(ZoneOffset.UTC).toEpochSecond(ZoneOffset.UTC);
+            VCIssuanceTransaction transaction = new VCIssuanceTransaction();
+            transaction.setCNonce(cNonce);
+            transaction.setCNonceIssuedEpoch(cNonceIssuedTime);
+            transaction.setCNonceExpireSeconds(cNonceExpiresInSeconds);
+            return nonceCacheService.setNonceTransaction(cNonce, transaction);
         } catch (CertifyException e) {
             throw e;
         }

--- a/certify-service/src/main/java/io/mosip/certify/services/NonceServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/NonceServiceImpl.java
@@ -4,7 +4,6 @@ import io.mosip.certify.core.dto.NonceResponse;
 import io.mosip.certify.core.dto.VCIssuanceTransaction;
 import io.mosip.certify.core.exception.CertifyException;
 import io.mosip.certify.core.spi.NonceService;
-import io.mosip.certify.utils.AccessTokenJwtUtil;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
@@ -13,24 +12,26 @@ import java.time.ZoneOffset;
 @Service
 public class NonceServiceImpl implements NonceService {
 
-    private final AccessTokenJwtUtil accessTokenJwtUtil;
-
     private NonceCacheService nonceCacheService;
 
     @Value("${mosip.certify.cnonce-expire-seconds:300}")
     private int cNonceExpiresInSeconds;
 
-    public NonceServiceImpl(AccessTokenJwtUtil accessTokenJwtUtil,
+    public NonceServiceImpl(
                             NonceCacheService nonceCacheService) {
-        this.accessTokenJwtUtil = accessTokenJwtUtil;
         this.nonceCacheService = nonceCacheService;
     }
 
     @Override
     public NonceResponse generateNonce() {
-        String cNonce = accessTokenJwtUtil.generateCNonce();
+        String cNonce = generateCNonce();
         VCIssuanceTransaction transaction = createNonceTransaction(cNonce);
         return new NonceResponse(cNonce);
+    }
+
+    public String generateCNonce() {
+        String cNonce = java.util.UUID.randomUUID().toString();
+        return cNonce;
     }
 
     private VCIssuanceTransaction createNonceTransaction(String cNonce) {

--- a/certify-service/src/main/resources/application-local.properties
+++ b/certify-service/src/main/resources/application-local.properties
@@ -136,7 +136,7 @@ mosip.certify.mock.authenticator.get-identity-url=http://localhost:8082/v1/mock-
 
 # details of VC issuer's public key & controller for DataProvider plugin
 mosip.certify.data-provider-plugin.issuer-public-key-uri=https://vharsh.github.io/DID/mock-rsa.json
-mosip.certify.data-provider-plugin.did-url=did:web:bleep-rinsing-judgingly.ngrok-free.dev
+mosip.certify.data-provider-plugin.did-url=did:web:jainhitesh9998.github.io:tempfiles:vc-local-ed25519
 
 ## ---------------------------------------- Cache configuration --------------------------------------------------------
 

--- a/certify-service/src/main/resources/application-local.properties
+++ b/certify-service/src/main/resources/application-local.properties
@@ -162,7 +162,7 @@ mosip.certify.templatecache-expire-seconds=43200
 mosip.certify.pre-auth.cache-expire-seconds=600
 mosip.certify.credential-offer.cache-expire-seconds=600
 mosip.certify.metadata.cache-expire-seconds=3600
-mosip.certfy.cnonce.cache-expire-seconds=300
+mosip.certify.cnonce.cache-expire-seconds=300
 
 mosip.certify.certificatedatacache-expire-seconds=3600
 mosip.certify.common.cache-expire-seconds=3600
@@ -173,7 +173,7 @@ mosip.certify.jwks-cache-expire-seconds=300
 mosip.certify.cache.size={'userinfo': 200, 'vcissuance' : 2000, 'templatecache': 20, 'jwks': 1, 'preAuthCodeCache': 1000, 'credentialOfferCache': 1000, 'issuerMetadataCache': 10, 'nonce': 1000}
 
 # Cache expire in seconds is applicable for both 'simple' and 'Redis' cache type
-mosip.certify.cache.expire-in-seconds={'userinfo': ${mosip.certify.access-token-expire-seconds}, 'vcissuance': ${mosip.certify.access-token-expire-seconds}, 'templatecache': ${mosip.certify.templatecache-expire-seconds}, 'certificatedatacache': ${mosip.certify.certificatedatacache-expire-seconds}, 'credentialConfig': ${mosip.certify.common.cache-expire-seconds}, 'renderTemplate': ${mosip.certify.common.cache-expire-seconds}, 'jwks': ${mosip.certify.jwks-cache-expire-seconds}, 'preAuthCodeCache': ${mosip.certify.pre-auth.cache-expire-seconds}, 'credentialOfferCache': ${mosip.certify.credential-offer.cache-expire-seconds}, 'issuerMetadataCache': ${mosip.certify.metadata.cache-expire-seconds}, 'nonce': ${mosip.certfy.cnonce.cache-expire-seconds}}
+mosip.certify.cache.expire-in-seconds={'userinfo': ${mosip.certify.access-token-expire-seconds}, 'vcissuance': ${mosip.certify.access-token-expire-seconds}, 'templatecache': ${mosip.certify.templatecache-expire-seconds}, 'certificatedatacache': ${mosip.certify.certificatedatacache-expire-seconds}, 'credentialConfig': ${mosip.certify.common.cache-expire-seconds}, 'renderTemplate': ${mosip.certify.common.cache-expire-seconds}, 'jwks': ${mosip.certify.jwks-cache-expire-seconds}, 'preAuthCodeCache': ${mosip.certify.pre-auth.cache-expire-seconds}, 'credentialOfferCache': ${mosip.certify.credential-offer.cache-expire-seconds}, 'issuerMetadataCache': ${mosip.certify.metadata.cache-expire-seconds}, 'nonce': ${mosip.certify.cnonce.cache-expire-seconds}}
 
 ##-----------------------------VCI related demo configuration---------------------------------------------##
 

--- a/certify-service/src/main/resources/application-local.properties
+++ b/certify-service/src/main/resources/application-local.properties
@@ -136,7 +136,7 @@ mosip.certify.mock.authenticator.get-identity-url=http://localhost:8082/v1/mock-
 
 # details of VC issuer's public key & controller for DataProvider plugin
 mosip.certify.data-provider-plugin.issuer-public-key-uri=https://vharsh.github.io/DID/mock-rsa.json
-mosip.certify.data-provider-plugin.did-url=did:web:mosip.github.io:inji-config:vc-local-ed25519
+mosip.certify.data-provider-plugin.did-url=did:web:mosip.github.io:inji-config:local
 
 ## ---------------------------------------- Cache configuration --------------------------------------------------------
 

--- a/certify-service/src/main/resources/application-local.properties
+++ b/certify-service/src/main/resources/application-local.properties
@@ -136,7 +136,7 @@ mosip.certify.mock.authenticator.get-identity-url=http://localhost:8082/v1/mock-
 
 # details of VC issuer's public key & controller for DataProvider plugin
 mosip.certify.data-provider-plugin.issuer-public-key-uri=https://vharsh.github.io/DID/mock-rsa.json
-mosip.certify.data-provider-plugin.did-url=did:web:mosip.github.io:inji-config:local
+mosip.certify.data-provider-plugin.did-url=did:web:bleep-rinsing-judgingly.ngrok-free.dev
 
 ## ---------------------------------------- Cache configuration --------------------------------------------------------
 

--- a/certify-service/src/main/resources/application-local.properties
+++ b/certify-service/src/main/resources/application-local.properties
@@ -11,7 +11,7 @@ mosip.certify.security.ignore-csrf-urls=**/actuator/**,/favicon.ico,**/error,\
 
 mosip.certify.security.ignore-auth-urls=/actuator/**,**/error,**/swagger-ui/**,\
   **/v3/api-docs/**, **/issuance/**,/system-info/**,/rendering-template/**,**/credential-configurations/**,\
-  **/.well-known/**,**/ledger-search/**,**/credentials/**,**/oauth/**,**/credential-offer-data/**,**/pre-authorized-data/**
+  **/.well-known/**,**/ledger-search/**,**/credentials/**,**/oauth/**,**/credential-offer-data/**,**/pre-authorized-data/**,**/nonce/**
 
 # This property specifies URL patterns for which CORS (Cross-Origin Resource Sharing) is enabled for HTTP GET requests. It allows the application to accept cross-origin GET requests on the specified endpoints, improving security and flexibility for frontend integrations.
 # For example, /rendering-template/** enables CORS for all GET requests matching this pattern.
@@ -136,7 +136,7 @@ mosip.certify.mock.authenticator.get-identity-url=http://localhost:8082/v1/mock-
 
 # details of VC issuer's public key & controller for DataProvider plugin
 mosip.certify.data-provider-plugin.issuer-public-key-uri=https://vharsh.github.io/DID/mock-rsa.json
-mosip.certify.data-provider-plugin.did-url=did:web:jainhitesh9998.github.io:tempfiles:vc-local-ed25519
+mosip.certify.data-provider-plugin.did-url=did:web:mosip.github.io:inji-config:vc-local-ed25519
 
 ## ---------------------------------------- Cache configuration --------------------------------------------------------
 
@@ -162,6 +162,7 @@ mosip.certify.templatecache-expire-seconds=43200
 mosip.certify.pre-auth.cache-expire-seconds=600
 mosip.certify.credential-offer.cache-expire-seconds=600
 mosip.certify.metadata.cache-expire-seconds=3600
+mosip.certfy.cnonce.cache-expire-seconds=300
 
 mosip.certify.certificatedatacache-expire-seconds=3600
 mosip.certify.common.cache-expire-seconds=3600
@@ -172,7 +173,7 @@ mosip.certify.jwks-cache-expire-seconds=300
 mosip.certify.cache.size={'userinfo': 200, 'vcissuance' : 2000, 'templatecache': 20, 'jwks': 1, 'preAuthCodeCache': 1000, 'credentialOfferCache': 1000, 'issuerMetadataCache': 10, 'nonce': 1000}
 
 # Cache expire in seconds is applicable for both 'simple' and 'Redis' cache type
-mosip.certify.cache.expire-in-seconds={'userinfo': ${mosip.certify.access-token-expire-seconds}, 'vcissuance': ${mosip.certify.access-token-expire-seconds}, 'templatecache': ${mosip.certify.templatecache-expire-seconds}, 'certificatedatacache': ${mosip.certify.certificatedatacache-expire-seconds}, 'credentialConfig': ${mosip.certify.common.cache-expire-seconds}, 'renderTemplate': ${mosip.certify.common.cache-expire-seconds}, 'jwks': ${mosip.certify.jwks-cache-expire-seconds}, 'preAuthCodeCache': ${mosip.certify.pre-auth.cache-expire-seconds}, 'credentialOfferCache': ${mosip.certify.credential-offer.cache-expire-seconds}, 'issuerMetadataCache': ${mosip.certify.metadata.cache-expire-seconds}, 'nonce': ${mosip.certify.metadata.cache-expire-seconds}}
+mosip.certify.cache.expire-in-seconds={'userinfo': ${mosip.certify.access-token-expire-seconds}, 'vcissuance': ${mosip.certify.access-token-expire-seconds}, 'templatecache': ${mosip.certify.templatecache-expire-seconds}, 'certificatedatacache': ${mosip.certify.certificatedatacache-expire-seconds}, 'credentialConfig': ${mosip.certify.common.cache-expire-seconds}, 'renderTemplate': ${mosip.certify.common.cache-expire-seconds}, 'jwks': ${mosip.certify.jwks-cache-expire-seconds}, 'preAuthCodeCache': ${mosip.certify.pre-auth.cache-expire-seconds}, 'credentialOfferCache': ${mosip.certify.credential-offer.cache-expire-seconds}, 'issuerMetadataCache': ${mosip.certify.metadata.cache-expire-seconds}, 'nonce': ${mosip.certfy.cnonce.cache-expire-seconds}}
 
 ##-----------------------------VCI related demo configuration---------------------------------------------##
 

--- a/certify-service/src/main/resources/application-local.properties
+++ b/certify-service/src/main/resources/application-local.properties
@@ -151,7 +151,7 @@ mosip.certify.cache.security.algorithm-name=AES/ECB/PKCS5Padding
 #spring.data.redis.password=redis
 
 spring.cache.type=simple
-mosip.certify.cache.names=userinfo,vcissuance,templatecache,certificatedatacache,credentialConfig,renderTemplate,jwks,preAuthCodeCache,credentialOfferCache,issuerMetadataCache
+mosip.certify.cache.names=userinfo,vcissuance,templatecache,certificatedatacache,credentialConfig,renderTemplate,jwks,preAuthCodeCache,credentialOfferCache,issuerMetadataCache,nonce
 spring.cache.cache-names=${mosip.certify.cache.names}
 management.health.redis.enabled=false
 
@@ -169,10 +169,10 @@ mosip.certify.common.cache-expire-seconds=3600
 mosip.certify.jwks-cache-expire-seconds=300
 # Cache size setup is applicable only for 'simple' cache type.
 # Cache size configuration will not be considered with 'Redis' cache type
-mosip.certify.cache.size={'userinfo': 200, 'vcissuance' : 2000, 'templatecache': 20, 'jwks': 1, 'preAuthCodeCache': 1000, 'credentialOfferCache': 1000, 'issuerMetadataCache': 10}
+mosip.certify.cache.size={'userinfo': 200, 'vcissuance' : 2000, 'templatecache': 20, 'jwks': 1, 'preAuthCodeCache': 1000, 'credentialOfferCache': 1000, 'issuerMetadataCache': 10, 'nonce': 1000}
 
 # Cache expire in seconds is applicable for both 'simple' and 'Redis' cache type
-mosip.certify.cache.expire-in-seconds={'userinfo': ${mosip.certify.access-token-expire-seconds}, 'vcissuance': ${mosip.certify.access-token-expire-seconds}, 'templatecache': ${mosip.certify.templatecache-expire-seconds}, 'certificatedatacache': ${mosip.certify.certificatedatacache-expire-seconds}, 'credentialConfig': ${mosip.certify.common.cache-expire-seconds}, 'renderTemplate': ${mosip.certify.common.cache-expire-seconds}, 'jwks': ${mosip.certify.jwks-cache-expire-seconds}, 'preAuthCodeCache': ${mosip.certify.pre-auth.cache-expire-seconds}, 'credentialOfferCache': ${mosip.certify.credential-offer.cache-expire-seconds}, 'issuerMetadataCache': ${mosip.certify.metadata.cache-expire-seconds}}
+mosip.certify.cache.expire-in-seconds={'userinfo': ${mosip.certify.access-token-expire-seconds}, 'vcissuance': ${mosip.certify.access-token-expire-seconds}, 'templatecache': ${mosip.certify.templatecache-expire-seconds}, 'certificatedatacache': ${mosip.certify.certificatedatacache-expire-seconds}, 'credentialConfig': ${mosip.certify.common.cache-expire-seconds}, 'renderTemplate': ${mosip.certify.common.cache-expire-seconds}, 'jwks': ${mosip.certify.jwks-cache-expire-seconds}, 'preAuthCodeCache': ${mosip.certify.pre-auth.cache-expire-seconds}, 'credentialOfferCache': ${mosip.certify.credential-offer.cache-expire-seconds}, 'issuerMetadataCache': ${mosip.certify.metadata.cache-expire-seconds}, 'nonce': ${mosip.certify.metadata.cache-expire-seconds}}
 
 ##-----------------------------VCI related demo configuration---------------------------------------------##
 

--- a/certify-service/src/test/java/io/mosip/certify/controller/NonceControllerTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/controller/NonceControllerTest.java
@@ -2,6 +2,7 @@ package io.mosip.certify.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.mosip.certify.core.dto.NonceResponse;
+import io.mosip.certify.core.dto.ParsedAccessToken;
 import io.mosip.certify.core.spi.NonceService;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,6 +32,8 @@ public class NonceControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
+    @MockBean
+    ParsedAccessToken parsedAccessToken;
     @Test
     public void testGetNonce_success() throws Exception {
 
@@ -44,6 +47,6 @@ public class NonceControllerTest {
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(header().string("Cache-Control", "no-store"))
-                .andExpect(jsonPath("$.nonce").value("test-nonce-123"));
+                .andExpect(jsonPath("$.c_nonce").value("test-nonce-123"));
     }
 }

--- a/certify-service/src/test/java/io/mosip/certify/controller/NonceControllerTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/controller/NonceControllerTest.java
@@ -1,0 +1,49 @@
+package io.mosip.certify.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.mosip.certify.core.dto.NonceResponse;
+import io.mosip.certify.core.spi.NonceService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(NonceController.class)
+public class NonceControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private NonceService nonceService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    public void testGetNonce_success() throws Exception {
+
+        // Arrange
+        NonceResponse mockResponse = new NonceResponse("test-nonce-123");
+
+        Mockito.when(nonceService.generateNonce()).thenReturn(mockResponse);
+
+        // Act & Assert
+        mockMvc.perform(post("/issuance/nonce")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Cache-Control", "no-store"))
+                .andExpect(jsonPath("$.nonce").value("test-nonce-123"));
+    }
+}

--- a/certify-service/src/test/java/io/mosip/certify/controller/NonceControllerTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/controller/NonceControllerTest.java
@@ -9,6 +9,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
@@ -29,6 +30,9 @@ public class NonceControllerTest {
     @MockBean
     private NonceService nonceService;
 
+    @MockBean
+    ParsedAccessToken parsedAccessToken;
+
     @Test
     public void testGetNonce_success() throws Exception {
 
@@ -38,7 +42,7 @@ public class NonceControllerTest {
         Mockito.when(nonceService.generateNonce()).thenReturn(mockResponse);
 
         // Act & Assert
-        mockMvc.perform(post("/issuance/nonce")
+        mockMvc.perform(post("/nonce")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(header().string("Cache-Control", "no-store"))

--- a/certify-service/src/test/java/io/mosip/certify/controller/NonceControllerTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/controller/NonceControllerTest.java
@@ -29,11 +29,6 @@ public class NonceControllerTest {
     @MockBean
     private NonceService nonceService;
 
-    @Autowired
-    private ObjectMapper objectMapper;
-
-    @MockBean
-    ParsedAccessToken parsedAccessToken;
     @Test
     public void testGetNonce_success() throws Exception {
 

--- a/certify-service/src/test/java/io/mosip/certify/services/NonceServiceImplTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/NonceServiceImplTest.java
@@ -1,0 +1,75 @@
+package io.mosip.certify.services;
+
+import io.mosip.certify.core.dto.NonceResponse;
+import io.mosip.certify.core.dto.NonceTransaction;
+import io.mosip.certify.core.exception.CertifyException;
+import io.mosip.certify.utils.AccessTokenJwtUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.lang.reflect.Field;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NonceServiceImplTest {
+
+    @Mock
+    private AccessTokenJwtUtil accessTokenJwtUtil;
+
+    @Mock
+    private NonceCacheService nonceCacheService;
+
+    @InjectMocks
+    private NonceServiceImpl nonceService;
+
+    @Before
+    public void setup() throws Exception {
+        // Inject @Value field manually
+        Field field = NonceServiceImpl.class.getDeclaredField("cNonceExpiresInSeconds");
+        field.setAccessible(true);
+        field.set(nonceService, 300);
+    }
+
+    @Test
+    public void testGenerateNonce_success() {
+
+        String mockNonce = "test-cnonce-123";
+
+        when(accessTokenJwtUtil.generateCNonce()).thenReturn(mockNonce);
+
+
+        when(nonceCacheService.setNonceTransaction(anyString(), any(NonceTransaction.class)))
+                .thenAnswer(invocation -> invocation.getArgument(1));
+
+
+        NonceResponse response = nonceService.generateNonce();
+
+
+        assertNotNull(response);
+        assertEquals(mockNonce, response.cNonce());
+
+        verify(accessTokenJwtUtil, times(1)).generateCNonce();
+        verify(nonceCacheService, times(1))
+                .setNonceTransaction(eq(mockNonce), any(NonceTransaction.class));
+    }
+
+
+    @Test(expected = CertifyException.class)
+    public void testGenerateNonce_whenCacheFails_shouldThrowException() {
+
+        String mockNonce = "test-nonce-123";
+
+        when(accessTokenJwtUtil.generateCNonce()).thenReturn(mockNonce);
+        when(nonceCacheService.setNonceTransaction(anyString(), any(NonceTransaction.class)))
+                .thenThrow(new CertifyException("CACHE_ERROR", "Cache failure"));
+
+        nonceService.generateNonce();
+    }
+}

--- a/certify-service/src/test/java/io/mosip/certify/services/NonceServiceImplTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/NonceServiceImplTest.java
@@ -1,19 +1,15 @@
 package io.mosip.certify.services;
 
 import io.mosip.certify.core.dto.NonceResponse;
-import io.mosip.certify.core.dto.NonceTransaction;
+import io.mosip.certify.core.dto.VCIssuanceTransaction;
 import io.mosip.certify.core.exception.CertifyException;
 import io.mosip.certify.utils.AccessTokenJwtUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
-
 import java.lang.reflect.Field;
-
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
@@ -26,11 +22,12 @@ public class NonceServiceImplTest {
     @Mock
     private NonceCacheService nonceCacheService;
 
-    @InjectMocks
     private NonceServiceImpl nonceService;
 
     @Before
     public void setup() throws Exception {
+
+        nonceService = new NonceServiceImpl(accessTokenJwtUtil, nonceCacheService);
         // Inject @Value field manually
         Field field = NonceServiceImpl.class.getDeclaredField("cNonceExpiresInSeconds");
         field.setAccessible(true);
@@ -45,8 +42,7 @@ public class NonceServiceImplTest {
         when(accessTokenJwtUtil.generateCNonce()).thenReturn(mockNonce);
 
 
-        when(nonceCacheService.setNonceTransaction(anyString(), any(NonceTransaction.class)))
-                .thenAnswer(invocation -> invocation.getArgument(1));
+        when(accessTokenJwtUtil.generateCNonce()).thenReturn(mockNonce);
 
 
         NonceResponse response = nonceService.generateNonce();
@@ -57,19 +53,24 @@ public class NonceServiceImplTest {
 
         verify(accessTokenJwtUtil, times(1)).generateCNonce();
         verify(nonceCacheService, times(1))
-                .setNonceTransaction(eq(mockNonce), any(NonceTransaction.class));
+                .setNonceTransaction(eq(mockNonce), any(VCIssuanceTransaction.class));
     }
 
 
-    @Test(expected = CertifyException.class)
+    @Test
     public void testGenerateNonce_whenCacheFails_shouldThrowException() {
 
         String mockNonce = "test-nonce-123";
 
         when(accessTokenJwtUtil.generateCNonce()).thenReturn(mockNonce);
-        when(nonceCacheService.setNonceTransaction(anyString(), any(NonceTransaction.class)))
+        when(nonceCacheService.setNonceTransaction(anyString(), any(VCIssuanceTransaction.class)))
                 .thenThrow(new CertifyException("CACHE_ERROR", "Cache failure"));
 
-        nonceService.generateNonce();
+        CertifyException ex = assertThrows(CertifyException.class, () -> {
+            nonceService.generateNonce();
+        });
+
+        assertEquals("CACHE_ERROR", ex.getErrorCode());
+        assertEquals("Cache failure", ex.getMessage());
     }
 }

--- a/certify-service/src/test/java/io/mosip/certify/services/NonceServiceImplTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/NonceServiceImplTest.java
@@ -3,7 +3,6 @@ package io.mosip.certify.services;
 import io.mosip.certify.core.dto.NonceResponse;
 import io.mosip.certify.core.dto.VCIssuanceTransaction;
 import io.mosip.certify.core.exception.CertifyException;
-import io.mosip.certify.utils.AccessTokenJwtUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -17,9 +16,6 @@ import static org.mockito.Mockito.*;
 public class NonceServiceImplTest {
 
     @Mock
-    private AccessTokenJwtUtil accessTokenJwtUtil;
-
-    @Mock
     private NonceCacheService nonceCacheService;
 
     private NonceServiceImpl nonceService;
@@ -27,7 +23,7 @@ public class NonceServiceImplTest {
     @Before
     public void setup() throws Exception {
 
-        nonceService = new NonceServiceImpl(accessTokenJwtUtil, nonceCacheService);
+        nonceService = new NonceServiceImpl(nonceCacheService);
         // Inject @Value field manually
         Field field = NonceServiceImpl.class.getDeclaredField("cNonceExpiresInSeconds");
         field.setAccessible(true);
@@ -36,33 +32,18 @@ public class NonceServiceImplTest {
 
     @Test
     public void testGenerateNonce_success() {
-
-        String mockNonce = "test-cnonce-123";
-
-        when(accessTokenJwtUtil.generateCNonce()).thenReturn(mockNonce);
-
-
-        when(accessTokenJwtUtil.generateCNonce()).thenReturn(mockNonce);
-
-
         NonceResponse response = nonceService.generateNonce();
 
-
         assertNotNull(response);
-        assertEquals(mockNonce, response.cNonce());
+        assertNotNull(response.cNonce());
 
-        verify(accessTokenJwtUtil, times(1)).generateCNonce();
         verify(nonceCacheService, times(1))
-                .setNonceTransaction(eq(mockNonce), any(VCIssuanceTransaction.class));
+                .setNonceTransaction(eq(response.cNonce()), any(VCIssuanceTransaction.class));
     }
 
 
     @Test
     public void testGenerateNonce_whenCacheFails_shouldThrowException() {
-
-        String mockNonce = "test-nonce-123";
-
-        when(accessTokenJwtUtil.generateCNonce()).thenReturn(mockNonce);
         when(nonceCacheService.setNonceTransaction(anyString(), any(VCIssuanceTransaction.class)))
                 .thenThrow(new CertifyException("CACHE_ERROR", "Cache failure"));
 

--- a/docs/inji-certify-openapi.yaml
+++ b/docs/inji-certify-openapi.yaml
@@ -464,6 +464,12 @@ paths:
       responses:
         '200':
           description: Nonce generated successfully.
+          headers:
+            Cache-Control:
+              description: Prevents caching of nonce responses.
+              schema:
+                type: string
+                example: no-store
           content:
             application/json:
               schema:

--- a/docs/inji-certify-openapi.yaml
+++ b/docs/inji-certify-openapi.yaml
@@ -454,7 +454,29 @@ paths:
       servers:
         - url: 'http://localhost:8090/v1/certify'
           description: Generated server url
-
+  /issuance/nonce:
+    post:
+      tags:
+        - 'Nonce Controller'
+      summary: Generate Nonce
+      description: 'Generates a c_nonce value to be used in credential issuance flow as per OpenID4VCI specification.'
+      operationId: getNonce
+      responses:
+        '200':
+          description: Nonce generated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NonceResponse'
+              examples:
+                Example 1:
+                  value:
+                    c_nonce: "abc123xyz"
+        '500':
+          description: Internal server error while generating nonce.
+      servers:
+        - url: 'http://localhost:8090/v1/certify'
+          description: Generated server url
   /issuance/vd12/credential:
     post:
       tags:
@@ -3110,3 +3132,12 @@ components:
           type: string
         issuer_state:
           type: string
+    NonceResponse:
+      type: object
+      properties:
+        c_nonce:
+          type: string
+          description: One-time nonce value used for proof validation
+          example: "abc123xyz"
+      required:
+        - c_nonce

--- a/docs/postman-collections/Inji Certify - Pre Auth Code.postman_collection.json
+++ b/docs/postman-collections/Inji Certify - Pre Auth Code.postman_collection.json
@@ -364,7 +364,7 @@
 							"script": {
 								"exec": [
 									"var response = pm.response.json();",
-									"pm.environment.set(\"c_nonce\", response.c_nonce);"
+									"pm.collectionVariables.set(\"c_nonce\", response.c_nonce);"
 								],
 								"type": "text/javascript"
 							}
@@ -374,9 +374,9 @@
 						"method": "POST",
 						"header": [],
 						"url": {
-							"raw": "{{certifyUrl}}/issuance/nonce",
+							"raw": "{{certifyurl}}/issuance/nonce",
 							"host": [
-								"{{certifyUrl}}"
+								"{{certifyurl}}"
 							],
 							"path": [
 								"issuance",

--- a/docs/postman-collections/Inji Certify - Pre Auth Code.postman_collection.json
+++ b/docs/postman-collections/Inji Certify - Pre Auth Code.postman_collection.json
@@ -374,12 +374,11 @@
 						"method": "POST",
 						"header": [],
 						"url": {
-							"raw": "{{certifyurl}}/issuance/nonce",
+							"raw": "{{certifyurl}}/nonce",
 							"host": [
 								"{{certifyurl}}"
 							],
 							"path": [
-								"issuance",
 								"nonce"
 							]
 						}

--- a/docs/postman-collections/Inji Certify - Pre Auth Code.postman_collection.json
+++ b/docs/postman-collections/Inji Certify - Pre Auth Code.postman_collection.json
@@ -303,18 +303,12 @@
 									"    pm.expect(jsonData).to.have.property('access_token');",
 									"    pm.expect(jsonData).to.have.property('token_type');",
 									"    pm.expect(jsonData).to.have.property('expires_in');",
-									"    pm.expect(jsonData).to.have.property('c_nonce');",
-									"    pm.expect(jsonData).to.have.property('c_nonce_expires_in');",
 									"",
 									"    const accessToken = jsonData.access_token;",
 									"    // Store access token",
 									"    console.log(\"access_token:\", accessToken);",
 									"    pm.collectionVariables.set('access_token', accessToken);",
-									"    console.log(\"✅ Access token saved successfully\");",
-									"    const cNonce = jsonData.c_nonce;",
-									"    const cNonceExpiresIn = jsonData.c_nonce_expires_in;",
-									"    pm.collectionVariables.set('c_nonce', cNonce);",
-									"    pm.collectionVariables.set('c_nonce_expires_in', cNonceExpiresIn);",
+									"    console.log(\"✅ Access token saved successfully\");"
 									"});"
 								],
 								"type": "text/javascript"
@@ -363,7 +357,37 @@
 					"response": []
 				},
 				{
-					"name": "4. Get Credential with Pre-Auth Token",
+					"name": "4. Nonce Endpoint",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var response = pm.response.json();",
+									"pm.environment.set(\"c_nonce\", response.c_nonce);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{certifyUrl}}/issuance/nonce",
+							"host": [
+								"{{certifyUrl}}"
+							],
+							"path": [
+								"issuance",
+								"nonce"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "5. Get Credential with Pre-Auth Token",
 					"event": [
 						{
 							"listen": "test",

--- a/docs/postman-collections/Inji Certify - Presentation During Issuance VCI.postman_collection.json
+++ b/docs/postman-collections/Inji Certify - Presentation During Issuance VCI.postman_collection.json
@@ -335,7 +335,7 @@
 								"type": "text/javascript",
 								"exec": [
 									"var response = pm.response.json();",
-									"pm.environment.set(\"c_nonce\", response.c_nonce);"
+									"pm.collectionVariables.set(\"c_nonce\", response.c_nonce);"
 								]
 							}
 						}

--- a/docs/postman-collections/Inji Certify - Presentation During Issuance VCI.postman_collection.json
+++ b/docs/postman-collections/Inji Certify - Presentation During Issuance VCI.postman_collection.json
@@ -272,10 +272,6 @@
 									"    pm.collectionVariables.set('access_token', accessToken);",
 									"    // pm.environment.set('access_token', accessToken);",
 									"    console.log(\"✅ Access token saved successfully\");",
-									"    const cNonce = jsonData.c_nonce;",
-									"    const cNonceExpiresIn = jsonData.c_nonce_expires_in;",
-									"    pm.collectionVariables.set('c_nonce', cNonce);",
-									"    pm.collectionVariables.set('c_nonce_expires_in', cNonceExpiresIn);",
 									"});"
 								],
 								"type": "text/javascript"
@@ -328,10 +324,41 @@
 			]
 		},
 		{
-			"name": "5. Credential download",
+			"name": "5. Nonce endpoint",
 			"item": [
 				{
-					"name": "5.1 Get Credential",
+					"name": "5.1 Get Nonce",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"var response = pm.response.json();",
+									"pm.environment.set(\"c_nonce\", response.c_nonce);"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{nonce_endpoint}}",
+							"host": [
+								"{{nonce_endpoint}}"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "6. Credential download",
+			"item": [
+				{
+					"name": "6.1 Get Credential",
 					"event": [
 						{
 							"listen": "prerequest",

--- a/docs/postman-collections/inji-certify-with-mock-identity.postman_collection.json
+++ b/docs/postman-collections/inji-certify-with-mock-identity.postman_collection.json
@@ -748,12 +748,11 @@
 						"method": "POST",
 						"header": [],
 						"url": {
-							"raw": "{{certifyUrl}}/issuance/nonce",
+							"raw": "{{certifyUrl}}/nonce",
 							"host": [
 								"{{certifyUrl}}"
 							],
 							"path": [
-								"issuance",
 								"nonce"
 							]
 						}

--- a/docs/postman-collections/inji-certify-with-mock-identity.postman_collection.json
+++ b/docs/postman-collections/inji-certify-with-mock-identity.postman_collection.json
@@ -1,7 +1,7 @@
 {
 	"info": {
 		"_postman_id": "edd685ae-f66f-425a-8859-ef319d8d5443",
-		"name": "certify- Mock IDA",
+		"name": "certify- Mock IDA - 2",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "1282483"
 	},
@@ -667,11 +667,6 @@
 									"    pm.expect(jsonData.access_token).not.equals(null);",
 									"    pm.environment.set(\"access_token\", jsonData.access_token);",
 									"",
-									"    pm.expect(jsonData.c_nonce).not.equals(null);",
-									"    pm.environment.set(\"c_nonce\", jsonData.c_nonce);",
-									"    // var jwt_parts = pm.environment.get('access_token').split('.'); // header.payload.signature",
-									"    // var jwt_payload = JSON.parse(atob(jwt_parts[1]));",
-									"    // pm.environment.set(\"c_nonce\", jwt_payload.c_nonce);",
 									"});"
 								],
 								"type": "text/javascript"
@@ -730,6 +725,36 @@
 								"oauth",
 								"v2",
 								"token"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Nonce Endpoint",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var response = pm.response.json();",
+									"pm.environment.set(\"c_nonce\", response.c_nonce);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{certifyUrl}}/issuance/nonce",
+							"host": [
+								"{{certifyUrl}}"
+							],
+							"path": [
+								"issuance",
+								"nonce"
 							]
 						}
 					},

--- a/docs/postman-collections/inji-certify-with-mock-mdoc-vci.postman_collection.json
+++ b/docs/postman-collections/inji-certify-with-mock-mdoc-vci.postman_collection.json
@@ -433,12 +433,11 @@
 						"method": "POST",
 						"header": [],
 						"url": {
-							"raw": "{{certifyUrl}}/issuance/nonce",
+							"raw": "{{certifyUrl}}/nonce",
 							"host": [
 								"{{certifyUrl}}"
 							],
 							"path": [
-								"issuance",
 								"nonce"
 							]
 						}

--- a/docs/postman-collections/inji-certify-with-mock-mdoc-vci.postman_collection.json
+++ b/docs/postman-collections/inji-certify-with-mock-mdoc-vci.postman_collection.json
@@ -349,8 +349,6 @@
 									"    pm.expect(jsonData.access_token).not.equals(null);",
 									"    pm.environment.set(\"access_token\", jsonData.access_token);",
 									"",
-									"    pm.expect(jsonData.c_nonce).not.equals(null);",
-									"    pm.environment.set(\"c_nonce\", jsonData.c_nonce);",
 									"    // var jwt_parts = pm.environment.get('access_token').split('.'); // header.payload.signature",
 									"    // var jwt_payload = JSON.parse(atob(jwt_parts[1]));",
 									"    // pm.environment.set(\"c_nonce\", jwt_payload.c_nonce);",
@@ -412,6 +410,36 @@
 								"oauth",
 								"v2",
 								"token"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Nonce Endpoint",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var response = pm.response.json();",
+									"pm.environment.set(\"c_nonce\", response.c_nonce);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{certifyUrl}}/issuance/nonce",
+							"host": [
+								"{{certifyUrl}}"
+							],
+							"path": [
+								"issuance",
+								"nonce"
 							]
 						}
 					},

--- a/docs/postman-collections/inji-certify-with-sunbird-insurance.postman_collection.json
+++ b/docs/postman-collections/inji-certify-with-sunbird-insurance.postman_collection.json
@@ -825,7 +825,7 @@
 						"method": "POST",
 						"header": [],
 						"url": {
-							"raw": "{{certifyServiceUrll}}/nonce",
+							"raw": "{{certifyServiceUrl}}/nonce",
 							"host": [
 								"{{certifyServiceUrl}}"
 							],

--- a/docs/postman-collections/inji-certify-with-sunbird-insurance.postman_collection.json
+++ b/docs/postman-collections/inji-certify-with-sunbird-insurance.postman_collection.json
@@ -825,9 +825,9 @@
 						"method": "POST",
 						"header": [],
 						"url": {
-							"raw": "{{certifyurl}}/issuance/nonce",
+							"raw": "{{certifyServiceUrll}}/issuance/nonce",
 							"host": [
-								"{{certifyurl}}"
+								"{{certifyServiceUrl}}"
 							],
 							"path": [
 								"issuance",

--- a/docs/postman-collections/inji-certify-with-sunbird-insurance.postman_collection.json
+++ b/docs/postman-collections/inji-certify-with-sunbird-insurance.postman_collection.json
@@ -743,7 +743,6 @@
 									"",
 									"    var jwt_parts = pm.environment.get('access_token').split('.'); // header.payload.signature",
 									"    var jwt_payload = JSON.parse(atob(jwt_parts[1]));",
-									"    pm.environment.set(\"c_nonce\", jwt_payload.c_nonce);",
 									"});"
 								],
 								"type": "text/javascript",
@@ -803,6 +802,36 @@
 								"oauth",
 								"v2",
 								"token"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Nonce Endpoint",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var response = pm.response.json();",
+									"pm.environment.set(\"c_nonce\", response.c_nonce);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{certifyUrl}}/issuance/nonce",
+							"host": [
+								"{{certifyUrl}}"
+							],
+							"path": [
+								"issuance",
+								"nonce"
 							]
 						}
 					},

--- a/docs/postman-collections/inji-certify-with-sunbird-insurance.postman_collection.json
+++ b/docs/postman-collections/inji-certify-with-sunbird-insurance.postman_collection.json
@@ -825,12 +825,11 @@
 						"method": "POST",
 						"header": [],
 						"url": {
-							"raw": "{{certifyServiceUrll}}/issuance/nonce",
+							"raw": "{{certifyServiceUrll}}/nonce",
 							"host": [
 								"{{certifyServiceUrl}}"
 							],
 							"path": [
-								"issuance",
 								"nonce"
 							]
 						}

--- a/docs/postman-collections/inji-certify-with-sunbird-insurance.postman_collection.json
+++ b/docs/postman-collections/inji-certify-with-sunbird-insurance.postman_collection.json
@@ -825,9 +825,9 @@
 						"method": "POST",
 						"header": [],
 						"url": {
-							"raw": "{{certifyUrl}}/issuance/nonce",
+							"raw": "{{certifyurl}}/issuance/nonce",
 							"host": [
-								"{{certifyUrl}}"
+								"{{certifyurl}}"
 							],
 							"path": [
 								"issuance",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Introduced a dedicated nonce generation endpoint that returns a nonce value with configurable expiration and cache-control headers to prevent caching.

## Documentation
* Updated API documentation and Postman collections to reflect the new nonce generation endpoint, moving nonce retrieval from the token exchange step to a dedicated endpoint call.

## Tests
* Added comprehensive test coverage for the new nonce endpoint and generation logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->