### PR TITLE
INJICERT 677 replace credential format from vc+sd-jwt to dc+sd-jwt format

### DIFF
--- a/certify-core/src/main/java/io/mosip/certify/core/constants/ErrorConstants.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/constants/ErrorConstants.java
@@ -63,8 +63,8 @@ public class ErrorConstants {
     public static final String LDP_VC_CONFIG_EXISTS = "ldp_vc_config_exists";
     public static final String MSO_MDOC_MANDATORY_FIELDS_MISSING = "mso_mdoc_mandatory_fields_missing";
     public static final String MSO_MDOC_CONFIG_EXISTS = "mso_mdoc_config_exists";
-    public static final String VC_SD_JWT_MANDATORY_FIELDS_MISSING = "vc_sd_jwt_mandatory_fields_missing";
-    public static final String VC_SD_JWT_CONFIG_EXISTS = "vc_sd_jwt_config_exists";
+    public static final String DC_SD_JWT_MANDATORY_FIELDS_MISSING = "dc_sd_jwt_mandatory_fields_missing";
+    public static final String DC_SD_JWT_CONFIG_EXISTS = "dc_sd_jwt_config_exists";
     public static final String UNSUPPORTED_FORMAT = "unsupported_format";
     public static final String UNSUPPORTED_CRYPTO_SUITE = "unsupported_crypto_suite";
     public static final String UNSUPPORTED_SIGNATURE_ALGO = "unsupported_signature_algo";

--- a/certify-core/src/main/java/io/mosip/certify/core/constants/VCFormats.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/constants/VCFormats.java
@@ -9,8 +9,7 @@ public class VCFormats {
 
     public static final String MSO_MDOC = "mso_mdoc";
     public static final String LDP_VC = "ldp_vc";
-    public static final String SD_JWT = "dc+sd-jwt";
-    public static final String VC_SD_JWT = "vc+sd-jwt";
+    public static final String DC_SD_JWT = "dc+sd-jwt";
     public static final String JWT_VC_JSON = "jwt_vc_json";
     public static final String JWT_VC_JSON_LD = "jwt_vc_json-ld";
 }

--- a/certify-service/src/main/java/io/mosip/certify/credential/SDJWT.java
+++ b/certify-service/src/main/java/io/mosip/certify/credential/SDJWT.java
@@ -52,7 +52,7 @@ public class SDJWT extends Credential{
      */
     @Override
     public boolean canHandle(String format){
-        return "vc+sd-jwt".equals(format);
+        return VCFormats.DC_SD_JWT.equals(format);
     }
 
 
@@ -121,7 +121,7 @@ public class SDJWT extends Credential{
         payload.setDataToSign(jwtPayload.length > 1?jwtPayload[1]:jwtPayload[0]);
         payload.setApplicationId(appID);
         payload.setReferenceId(refID);
-        payload.setAdditionalHeaders(Map.of("typ", VCFormats.VC_SD_JWT));
+        payload.setAdditionalHeaders(Map.of("typ", VCFormats.DC_SD_JWT));
         //TODO: Wait for keymanager fix here.
         payload.setSignAlgorithm(signAlgorithm);
         payload.setIncludePayload(true);

--- a/certify-service/src/main/java/io/mosip/certify/services/CertifyIssuanceServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/CertifyIssuanceServiceImpl.java
@@ -233,7 +233,7 @@ public class CertifyIssuanceServiceImpl implements VCIssuanceService {
 
             // Handle format-specific setup
             switch (format) {
-                case "ldp_vc":
+                case VCFormats.LDP_VC:
                     vcRequestDto.setContext(credentialConfigurationSupported.getContext());
                     vcRequestDto.setType(credentialConfigurationSupported.getTypes());
                     templateName = CredentialUtils.getTemplateName(vcRequestDto);
@@ -250,7 +250,7 @@ public class CertifyIssuanceServiceImpl implements VCIssuanceService {
                     }
                     break;
 
-                case "vc+sd-jwt":
+                case VCFormats.DC_SD_JWT:
                     vcRequestDto.setVct(credentialConfigurationSupported.getVct());
                     templateName = CredentialUtils.getTemplateName(vcRequestDto);
                     templateParams.put(Constants.VCTYPE, vcRequestDto.getVct());
@@ -259,7 +259,7 @@ public class CertifyIssuanceServiceImpl implements VCIssuanceService {
                     jsonObject.put(Constants.TYPE, vcRequestDto.getVct());
                     break;
 
-                case "mso_mdoc":
+                case VCFormats.MSO_MDOC:
                     vcRequestDto.setDoctype(credentialConfigurationSupported.getDocType());
                     templateName = CredentialUtils.getTemplateName(vcRequestDto);
                     templateParams.put("_doctype", vcRequestDto.getDoctype());

--- a/certify-service/src/main/java/io/mosip/certify/services/CredentialConfigurationServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/CredentialConfigurationServiceImpl.java
@@ -128,12 +128,12 @@ public class CredentialConfigurationServiceImpl implements CredentialConfigurati
                     throw new CertifyException(ErrorConstants.MSO_MDOC_CONFIG_EXISTS, "Configuration already exists for the specified doctype.");
                 }
                 break;
-            case VCFormats.VC_SD_JWT:
+            case VCFormats.DC_SD_JWT:
                 if (!SdJwtCredentialConfigValidator.isValidCheck(credentialConfig)) {
-                    throw new CertifyException(ErrorConstants.VC_SD_JWT_MANDATORY_FIELDS_MISSING, "Fields vct and signatureAlgo are mandatory for the vc+sd-jwt format.");
+                    throw new CertifyException(ErrorConstants.DC_SD_JWT_MANDATORY_FIELDS_MISSING, "Fields vct and signatureAlgo are mandatory for the dc+sd-jwt format.");
                 }
                 if(shouldCheckDuplicate && SdJwtCredentialConfigValidator.isConfigAlreadyPresent(credentialConfig, credentialConfigRepository)) {
-                    throw new CertifyException(ErrorConstants.VC_SD_JWT_CONFIG_EXISTS, "Configuration already exists for the specified vct.");
+                    throw new CertifyException(ErrorConstants.DC_SD_JWT_CONFIG_EXISTS, "Configuration already exists for the specified vct.");
                 }
                 break;
             default:
@@ -376,7 +376,7 @@ public class CredentialConfigurationServiceImpl implements CredentialConfigurati
         } else if (VCFormats.MSO_MDOC.equals(credentialConfig.getCredentialFormat())) {
             credentialConfigurationSupported.setDocType(credentialConfig.getDocType());
             credentialMetadataDTO.setClaims(mapMDocClaims(credentialConfig.getMsoMdocClaims()));
-        } else if (VCFormats.VC_SD_JWT.equals(credentialConfig.getCredentialFormat())) {
+        } else if (VCFormats.DC_SD_JWT.equals(credentialConfig.getCredentialFormat())) {
             credentialConfigurationSupported.setVct(credentialConfig.getSdJwtVct());
             credentialMetadataDTO.setClaims(mapStandardClaims(credentialConfig.getSdJwtClaims()));
         }

--- a/certify-service/src/main/java/io/mosip/certify/utils/CredentialCacheKeyGenerator.java
+++ b/certify-service/src/main/java/io/mosip/certify/utils/CredentialCacheKeyGenerator.java
@@ -39,7 +39,7 @@ public class CredentialCacheKeyGenerator {
         if (configOpt.isPresent()) {
            CredentialConfig config = configOpt.get();
 
-           if(config.getCredentialFormat().equals(VCFormats.VC_SD_JWT)){
+           if(config.getCredentialFormat().equals(VCFormats.DC_SD_JWT)){
                 return String.join(DELIMITER,
                           config.getCredentialFormat(),
                           config.getSdJwtVct());

--- a/certify-service/src/main/java/io/mosip/certify/utils/CredentialUtils.java
+++ b/certify-service/src/main/java/io/mosip/certify/utils/CredentialUtils.java
@@ -37,7 +37,7 @@ public class CredentialUtils {
     public static String getTemplateName(VCRequestDto vcRequestDto) {
         //TODO: Cache this entire data so we do not construct all the time.
 
-        if(vcRequestDto.getFormat().equals(VCFormats.VC_SD_JWT)) {
+        if(vcRequestDto.getFormat().equals(VCFormats.DC_SD_JWT)) {
             return String.join(Constants.DELIMITER, vcRequestDto.getFormat(), vcRequestDto.getVct());
         }
         if(vcRequestDto.getFormat().equals(VCFormats.MSO_MDOC)) {

--- a/certify-service/src/main/java/io/mosip/certify/utils/VCIssuanceUtil.java
+++ b/certify-service/src/main/java/io/mosip/certify/utils/VCIssuanceUtil.java
@@ -100,7 +100,7 @@ public class VCIssuanceUtil {
                 ldpVcResponse.setCredentials(ldpVcCredentials);
                 return ldpVcResponse;
 
-            case VCFormats.VC_SD_JWT:
+            case VCFormats.DC_SD_JWT:
             case VCFormats.JWT_VC_JSON:
             case VCFormats.JWT_VC_JSON_LD:
             case VCFormats.MSO_MDOC:
@@ -147,7 +147,7 @@ public class VCIssuanceUtil {
             credentialConfigurationSupported.setContext(credentialConfig.getCredentialDefinition().getContext());
         }
 
-        if(credentialConfig.getFormat().equals(VCFormats.VC_SD_JWT)) {
+        if(credentialConfig.getFormat().equals(VCFormats.DC_SD_JWT)) {
             credentialConfigurationSupported.setVct(credentialConfig.getVct());
         } else if(credentialConfig.getFormat().equals(VCFormats.MSO_MDOC)) {
             credentialConfigurationSupported.setDocType(credentialConfig.getDocType());

--- a/certify-service/src/main/java/io/mosip/certify/vcformatters/VelocityTemplatingEngineImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/vcformatters/VelocityTemplatingEngineImpl.java
@@ -93,7 +93,7 @@ public class VelocityTemplatingEngineImpl implements VCFormatter {
                             log.error("CredentialConfig not found in DB for key: {}", templateKey);
                             return new CertifyException(ErrorConstants.EXPECTED_TEMPLATE_NOT_FOUND, "CredentialConfig not found for key: " + templateKey);
                         });
-            } else if (Objects.equals(credentialFormat, VCFormats.VC_SD_JWT)) {
+            } else if (Objects.equals(credentialFormat, VCFormats.DC_SD_JWT)) {
                 String vct = parts[1];
                 return credentialConfigRepository.findByCredentialFormatAndSdJwtVct(credentialFormat, vct)
                         .orElseThrow(() -> {

--- a/certify-service/src/main/resources/application-local.properties
+++ b/certify-service/src/main/resources/application-local.properties
@@ -29,7 +29,7 @@ mosip.certify.plugin-mode=DataProvider
 mosip.certify.credential-config.cryptographic-binding-methods-supported={\
   'ldp_vc': {'did:jwk','did:web'},\
   'mso_mdoc': {'cose_key'},\
-  'vc+sd-jwt': {'did:jwk','did:web'}\
+  'dc+sd-jwt': {'did:jwk','did:web'}\
 }
 mosip.certify.credential-config.credential-signing-alg-values-supported={\
   'RsaSignature2018': {'RS256'},\

--- a/certify-service/src/test/java/io/mosip/certify/credential/MDocCredentialTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/credential/MDocCredentialTest.java
@@ -65,9 +65,9 @@ public class MDocCredentialTest {
 
     @Test
     public void testCanHandleReturnsFalseForOtherFormat() {
-        assertFalse("Should not handle ldp_vc", mDocCredential.canHandle("ldp_vc"));
-        assertFalse("Should not handle jwt_vc", mDocCredential.canHandle("jwt_vc"));
-        assertFalse("Should not handle vc+sd-jwt", mDocCredential.canHandle("vc+sd-jwt"));
+        assertFalse("Should not handle ldp_vc", mDocCredential.canHandle(VCFormats.LDP_VC));
+        assertFalse("Should not handle jwt_vc", mDocCredential.canHandle(VCFormats.JWT_VC_JSON));
+        assertFalse("Should not handle dc+sd-jwt", mDocCredential.canHandle(VCFormats.DC_SD_JWT));
         assertFalse("Should not handle null", mDocCredential.canHandle(null));
     }
 

--- a/certify-service/src/test/java/io/mosip/certify/credential/SDJWTTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/credential/SDJWTTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.mosip.certify.api.dto.VCResult;
 import io.mosip.certify.core.constants.ErrorConstants;
+import io.mosip.certify.core.constants.VCFormats;
 import io.mosip.certify.core.exception.CertifyException;
 import io.mosip.certify.vcformatters.VCFormatter;
 import io.mosip.kernel.signature.dto.JWSSignatureRequestDtoV2;
@@ -50,12 +51,12 @@ public class SDJWTTest {
 
     @Test
     public void testCanHandle_ShouldReturnTrueForCorrectFormat() {
-        assertTrue(sdjwt.canHandle("vc+sd-jwt"));
+        assertTrue(sdjwt.canHandle(VCFormats.DC_SD_JWT));
     }
 
     @Test
     public void testCanHandle_ShouldReturnFalseForIncorrectFormat() {
-        assertFalse(sdjwt.canHandle("ld+vc"));
+        assertFalse(sdjwt.canHandle(VCFormats.LDP_VC));
     }
 
     @Test

--- a/certify-service/src/test/java/io/mosip/certify/services/CertifyIssuanceServiceImplTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/CertifyIssuanceServiceImplTest.java
@@ -105,7 +105,7 @@ public class CertifyIssuanceServiceImplTest {
     private static final String TEST_CNONCE = "test-cnonce";
     private static final String DEFAULT_SCOPE = "test-scope";
     private static final String DEFAULT_FORMAT_LDP = VCFormats.LDP_VC;
-    private static final String DEFAULT_FORMAT_SDJWT = VCFormats.VC_SD_JWT; // vc+sd-jwt
+    private static final String DEFAULT_FORMAT_SDJWT = VCFormats.DC_SD_JWT; // dc+sd-jwt
     private static final String DEFAULT_FORMAT_MDOC = VCFormats.MSO_MDOC; // mso_mdoc
 
     CredentialRequest request;

--- a/certify-service/src/test/java/io/mosip/certify/services/CredentialConfigurationSupportedServiceImplTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/CredentialConfigurationSupportedServiceImplTest.java
@@ -195,7 +195,7 @@ public class CredentialConfigurationSupportedServiceImplTest {
         mockCredentialConfig.setCredentialConfigKeyId("test-credential");
         mockCredentialConfig.setStatus(expectedStatus);
         mockCredentialConfig.setVcTemplate("some_template");
-        mockCredentialConfig.setCredentialFormat("vc+sd-jwt");
+        mockCredentialConfig.setCredentialFormat("dc+sd-jwt");
         mockCredentialConfig.setSdJwtVct("test-vct");
         mockCredentialConfig.setSignatureAlgo("ES256");
 
@@ -208,7 +208,7 @@ public class CredentialConfigurationSupportedServiceImplTest {
 
         // Create a valid DTO for validation that will be returned by toDto
         CredentialConfigurationDTO validationDto = new CredentialConfigurationDTO();
-        validationDto.setCredentialFormat("vc+sd-jwt");
+        validationDto.setCredentialFormat("dc+sd-jwt");
         validationDto.setVcTemplate("some_template");
         validationDto.setSdJwtVct("test-vct");
         validationDto.setSignatureAlgo("ES256");
@@ -327,14 +327,14 @@ public class CredentialConfigurationSupportedServiceImplTest {
         config.setConfigId(UUID.randomUUID().toString());
         config.setCredentialConfigKeyId("sdjwt-credential");
         config.setStatus("active");
-        config.setCredentialFormat("vc+sd-jwt");
+        config.setCredentialFormat("dc+sd-jwt");
         config.setSignatureCryptoSuite(null); // triggers else branch
         config.setSignatureAlgo("ES256");
         config.setSdJwtVct("test-vct");
 
         when(credentialConfigRepository.findAll()).thenReturn(List.of(config));
         CredentialConfigurationDTO dto = new CredentialConfigurationDTO();
-        dto.setCredentialFormat("vc+sd-jwt");
+        dto.setCredentialFormat("dc+sd-jwt");
         when(credentialConfigMapper.toDto(config)).thenReturn(dto);
 
         CredentialIssuerMetadataDTO result = credentialConfigurationService.fetchCredentialIssuerMetadata();
@@ -406,12 +406,12 @@ public class CredentialConfigurationSupportedServiceImplTest {
         sdJwtConfig.setCredentialConfigKeyId("sdjwt-credential");
         sdJwtConfig.setVcTemplate("sd_jwt_template");
         sdJwtConfig.setStatus("active");
-        sdJwtConfig.setCredentialFormat("vc+sd-jwt");
+        sdJwtConfig.setCredentialFormat("dc+sd-jwt");
         sdJwtConfig.setSdJwtVct("test-vct");
         sdJwtConfig.setSignatureAlgo("ES256");
 
         CredentialConfigurationDTO sdJwtDTO = new CredentialConfigurationDTO();
-        sdJwtDTO.setCredentialFormat("vc+sd-jwt");
+        sdJwtDTO.setCredentialFormat("dc+sd-jwt");
         sdJwtDTO.setCredentialConfigKeyId("sdjwt-credential");
         sdJwtDTO.setVcTemplate("sd_jwt_template");
         sdJwtDTO.setSdJwtVct("test-vct"); // required
@@ -489,21 +489,21 @@ public class CredentialConfigurationSupportedServiceImplTest {
     @Test
     public void validateCredentialConfiguration_SdJwt_Invalid_ThrowsException() {
         CredentialConfigurationDTO dto = new CredentialConfigurationDTO();
-        dto.setCredentialFormat("vc+sd-jwt");
+        dto.setCredentialFormat("dc+sd-jwt");
         dto.setVcTemplate("test_template");
         try (var mocked = org.mockito.Mockito.mockStatic(SdJwtCredentialConfigValidator.class)) {
             mocked.when(() -> SdJwtCredentialConfigValidator.isValidCheck(dto)).thenReturn(false);
             CertifyException ex = assertThrows(CertifyException.class, () ->
                     ReflectionTestUtils.invokeMethod(credentialConfigurationService, "validateCredentialConfiguration", dto, true)
             );
-            assertEquals("Fields vct and signatureAlgo are mandatory for the vc+sd-jwt format.", ex.getMessage());
+            assertEquals("Fields vct and signatureAlgo are mandatory for the dc+sd-jwt format.", ex.getMessage());
         }
     }
 
     @Test
     public void validateCredentialConfiguration_SdJwt_Duplicate_ThrowsException() {
         CredentialConfigurationDTO dto = new CredentialConfigurationDTO();
-        dto.setCredentialFormat("vc+sd-jwt");
+        dto.setCredentialFormat("dc+sd-jwt");
         dto.setVcTemplate("test_template");
         try (var mocked = org.mockito.Mockito.mockStatic(SdJwtCredentialConfigValidator.class)) {
             mocked.when(() -> SdJwtCredentialConfigValidator.isValidCheck(dto)).thenReturn(true);
@@ -867,14 +867,14 @@ public class CredentialConfigurationSupportedServiceImplTest {
     @Test
     public void testmapToSupportedDTO_SdJwt() {
         CredentialConfig config = new CredentialConfig();
-        config.setCredentialFormat(VCFormats.VC_SD_JWT);
+        config.setCredentialFormat(VCFormats.DC_SD_JWT);
         config.setSdJwtVct("https://example.com/vct");
         
         Claims claimsConfig = new Claims(List.of(new Claims.Display("Last Name", "en")),false);
         config.setSdJwtClaims(Map.of("family_name", claimsConfig));
 
         CredentialConfigurationDTO dtoV2 = new CredentialConfigurationDTO();
-        dtoV2.setCredentialFormat(VCFormats.VC_SD_JWT);
+        dtoV2.setCredentialFormat(VCFormats.DC_SD_JWT);
         
         when(credentialConfigMapper.toDto(config)).thenReturn(dtoV2);
 

--- a/certify-service/src/test/java/io/mosip/certify/services/VCIssuanceServiceImplTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/VCIssuanceServiceImplTest.java
@@ -158,7 +158,7 @@ public class VCIssuanceServiceImplTest {
 
     private CredentialRequest createValidCredentialRequest(String format) throws Exception {
         CredentialRequest req = new CredentialRequest();
-        if (VCFormats.VC_SD_JWT.equals(format)) {
+        if (VCFormats.DC_SD_JWT.equals(format)) {
             req.setCredentialConfigId("test-credential-id-sdjwt");
         } else if(VCFormats.LDP_VC.equals(format)) { // LDP
             req.setCredentialConfigId("test-credential-id-ldp");

--- a/certify-service/src/test/java/io/mosip/certify/utils/SDJsonUtilsTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/utils/SDJsonUtilsTest.java
@@ -148,7 +148,7 @@ public class SDJsonUtilsTest extends TestCase {
         //         .build();
         JWSHeader header =
             new JWSHeader.Builder(JWSAlgorithm.ES256)
-                .type(new JOSEObjectType("vc+sd-jwt")).build();
+                .type(new JOSEObjectType("dc+sd-jwt")).build();
         // Create a credential JWT. (not signed yet)
         SignedJWT jwt = new SignedJWT(header, claimsSet);
 

--- a/db_upgrade_script/mosip_certify/sql/0.14.0_to_0.15.0_rollback.sql
+++ b/db_upgrade_script/mosip_certify/sql/0.14.0_to_0.15.0_rollback.sql
@@ -27,3 +27,7 @@ ALTER COLUMN credential_status TYPE credential_status_enum
 ALTER TABLE certify.credential_config
 RENAME COLUMN claims TO credential_subject;
 COMMENT ON COLUMN certify.credential_config.credential_subject IS 'Credential Subject: JSON object containing subject attributes schema.';
+
+UPDATE certify.credential_config
+SET credential_format = 'vc+sd-jwt'
+WHERE credential_format = 'dc+sd-jwt';

--- a/db_upgrade_script/mosip_certify/sql/0.14.0_to_0.15.0_upgrade.sql
+++ b/db_upgrade_script/mosip_certify/sql/0.14.0_to_0.15.0_upgrade.sql
@@ -24,3 +24,7 @@ ALTER COLUMN credential_status TYPE VARCHAR
 ALTER TABLE certify.credential_config
 RENAME COLUMN credential_subject TO claims;
 COMMENT ON COLUMN certify.credential_config.claims IS 'Claims: JSON object containing subject attributes schema.';
+
+UPDATE certify.credential_config
+SET credential_format = 'dc+sd-jwt'
+WHERE credential_format = 'vc+sd-jwt';

--- a/docker-compose/docker-compose-injistack/config/certify-default.properties
+++ b/docker-compose/docker-compose-injistack/config/certify-default.properties
@@ -185,7 +185,7 @@ mosip.certify.cache.expire-in-seconds={'userinfo': ${mosip.certify.access-token-
 mosip.certify.credential-config.cryptographic-binding-methods-supported={\
   'ldp_vc': {'did:jwk','did:key'},\
   'mso_mdoc': {'cose_key'},\
-  'vc+sd-jwt': {'did:jwk','did:key'}\
+  'dc+sd-jwt': {'did:jwk','did:key'}\
 }
 mosip.certify.credential-config.credential-signing-alg-values-supported={\
   'RsaSignature2018': {'RS256'},\


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated SD-JWT credential format identifier from `vc+sd-jwt` to `dc+sd-jwt` throughout the credential handling system
  * Revised error messages and configuration handling for SD-JWT credential validation and configuration
  * Standardized format constant references in credential issuance services and utilities
  * Updated configuration properties and supporting test fixtures to align with new SD-JWT format naming

<!-- end of auto-generated comment: release notes by coderabbit.ai -->