### PR TITLE
feat(nonce): #678 update postman collection and vc types in readme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ In particular, certify focuses on the issuer’s role in and provides the follow
 | Credential Binding with did:.. keys                                 | ✅        |
 | Credential Binding with jwt proof                                   | ✅        |
 | Support for JSON\_LD VC Format                                      | ✅        |
-| Support for IETF SD\_JWT VC Format with support only for vc+sd\_jwt | ✅        |
+| Support for IETF SD\_JWT VC Format with support only for dc+sd\_jwt | ✅        |
 | Revocation support for JSON\_LD                                     | ✅        |
 | Credential Offer with Pre Authorization Code Flow                   | ✅        |
 | Credential Issuance with Interactive Authorization Request          | ✅        |

--- a/docs/Claim-169-QR-Code-Support.md
+++ b/docs/Claim-169-QR-Code-Support.md
@@ -44,7 +44,7 @@ To enable QR code support in your credential configurations, you need to include
 5. Below is an example of how to include `qr_settings` and `qr_signature_algo` in your credential configuration JSON:
 ```json
 {
-  "credentialFormat": "vc+sd-jwt",
+  "credentialFormat": "dc+sd-jwt",
   "qrSettings": [
     {
       "Full Name": "${fullName}",

--- a/docs/Claim-169-QR-Code-Support.md
+++ b/docs/Claim-169-QR-Code-Support.md
@@ -28,7 +28,9 @@ Inji Certify now includes support for generating and embedding QR codes in Verif
         "fullName": "${fullName}",
         "mobileNumber": "${mobileNumber}",
         "dateOfBirth": "${dateOfBirth}",
-        "identityQRCode": $claim_169_values[0]
+        "claim169": {
+              "identityQRCode": "$claim_169_values[0]"
+            }
       }
     }
     ```
@@ -44,7 +46,7 @@ To enable QR code support in your credential configurations, you need to include
 5. Below is an example of how to include `qr_settings` and `qr_signature_algo` in your credential configuration JSON:
 ```json
 {
-  "credentialFormat": "dc+sd-jwt",
+  "credentialFormat": "ldp_vc",
   "qrSettings": [
     {
       "Full Name": "${fullName}",

--- a/docs/Credential-Issuer-Configuration.md
+++ b/docs/Credential-Issuer-Configuration.md
@@ -37,7 +37,7 @@ You can use these endpoints to manage your credential configurations:
 
 ## What Information Do You Need to Provide?
 
-When adding or updating a configuration, you need to send a JSON object with details related to the credential format you are configuring. The required fields depend on the credential format (e.g., `ldp_vc`, `mso_mdoc`, `vc+sd-jwt`). For more details regarding the API fields and examples, refer to the [Inji Certify API docs](https://mosip.stoplight.io/docs/inji-certify).
+When adding or updating a configuration, you need to send a JSON object with details related to the credential format you are configuring. The required fields depend on the credential format (e.g., `ldp_vc`, `mso_mdoc`, `dc+sd-jwt`). For more details regarding the API fields and examples, refer to the [Inji Certify API docs](https://mosip.stoplight.io/docs/inji-certify).
 
 ---
 
@@ -48,7 +48,7 @@ The Inji Certify uses several configuration properties to control how credential
 | Property Name                                                          | Description                                                               | Example Value                                                                                                                                                                                                                                                                                     |
 |------------------------------------------------------------------------|---------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `mosip.certify.data-provider-plugin.credential-status.allowed-status-purposes` | List of supported credential status purposes. Default value 'revocation'. | `["suspension", "revocation"]`                                                                                                                                                                                                                                                                    |
-| `mosip.certify.credential-config.cryptographic-binding-methods-supported` | Supported cryptographic binding methods per credential format.            | `{ 'ldp_vc': {'did:jwk','did:key'}, 'mso_mdoc': {'cose_key'},'vc+sd-jwt': {'did:jwk','did:key'} }`                                                                                                                                                                                                |
+| `mosip.certify.credential-config.cryptographic-binding-methods-supported` | Supported cryptographic binding methods per credential format.            | `{ 'ldp_vc': {'did:jwk','did:key'}, 'mso_mdoc': {'cose_key'},'dc+sd-jwt': {'did:jwk','did:key'} }`                                                                                                                                                                                                |
 | `mosip.certify.credential-config.credential-signing-alg-values-supported` | Supported signing algorithms per crypto suite.                            | `{ 'RsaSignature2018': {'RS256'}, 'Ed25519Signature2018': {'EdDSA'}, 'Ed25519Signature2020': {'EdDSA'}, 'EcdsaKoblitzSignature2016': {'ES256K'}, 'EcdsaSecp256k1Signature2019': {'ES256K'}, 'EcdsaSecp256r1Signature2019': {'ES256'}, 'ecdsa-rdfc-2019': {'ES256'}, 'ecdsa-jcs-2019': {'ES256'}}` |
 | `mosip.certify.credential-config.proof-types-supported`                | Supported proof types for credentials.                                    | `{'jwt': {'proof_signing_alg_values_supported': {'RS256', 'PS256', 'ES256', 'EdDSA'}}}`                                                                                                                                                                                                           |
 | `mosip.certify.signature-algo.key-alias-mapper`                       | Maps signature algorithms to list of key-aliases in key_alias table.      | `{'EdDSA': {{'CERTIFY_VC_SIGN_ED25519', ''}, {'CERTIFY_VC_SIGN_ED25519', 'ED25519_SIGN'}}`                                                                                                                                                                                                        |
@@ -57,7 +57,7 @@ The Inji Certify uses several configuration properties to control how credential
 
 **Note** : 
 In case of VCIssuance plugin mode, `ldp_vc` and `mso_mdoc` formats are supported by credential-configurations endpoints. 
-In case of DataProviderPlugin mode, `ldp_vc` and `vc+sd-jwt` formats are supported by credential-configurations endpoints.
+In case of DataProviderPlugin mode, `ldp_vc` and `dc+sd-jwt` formats are supported by credential-configurations endpoints.
 
 Inji Certify checks your configuration for required fields and possible duplicates:
 
@@ -65,7 +65,7 @@ Inji Certify checks your configuration for required fields and possible duplicat
 - **No duplicate configurations**: You cannot add two configurations with the same key details. For example, 
   - for `ldp_vc` format, combination of context & type should be unique. 
   - for `mso_mdoc` format, docType value should be unique.
-  - for `vc+sd-jwt` format, sdJwtVct value should be unique.
+  - for `dc+sd-jwt` format, sdJwtVct value should be unique.
 - **Validation for `signatureCryptoSuite`, `signatureAlgo`, `keyManagerAppId`, `keyManagerRefId`**.
   - `signatureCryptoSuite` must be one of the supported suites defined in `mosip.certify.credential-config.credential-signing-alg-values-supported`.
   - `signatureAlgo` must be one of the supported algorithms for the chosen `signatureCryptoSuite`.

--- a/docs/PKI-Support-and-Integration-with-SD-JWT-VC.md
+++ b/docs/PKI-Support-and-Integration-with-SD-JWT-VC.md
@@ -1,4 +1,4 @@
-# Support for Public Key Infrastructure (PKI) and Its Integration with SD-JWT(IETF format vc+sd-jwt) Verifiable Credentials
+# Support for Public Key Infrastructure (PKI) and Its Integration with SD-JWT(IETF format dc+sd-jwt) Verifiable Credentials
 Inji Certify allows issuers to integrate their own CA-signed certificates into the credential signing pipeline. This workflow guides you through the complete setup—from generating a CSR to uploading the signed certificate—so that all Verifiable Credentials (VCs) are signed using your institution’s PKI.
 
 ## Overview

--- a/docs/SD-JWT-Support.md
+++ b/docs/SD-JWT-Support.md
@@ -8,7 +8,7 @@ This document explains how to configure and use SD-JWT (Selective Disclosure JWT
 
 To add a new SD-JWT credential configuration, use the `/credential-configurations` endpoint with the following important fields in your JSON payload:
 
-- **credentialFormat**: Must be set to `vc+sd-jwt`
+- **credentialFormat**: Must be set to `dc+sd-jwt`
 - **signatureAlgo**: The signing algorithm (e.g., `ES256K`)
 - **sdJwtVct**: The VCT (Verifiable Credential Type) value for the credential
 
@@ -24,7 +24,7 @@ Add the following properties to your `application.yml` or `application.propertie
 |------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------|
 | `mosip.certify.credential-config.credential-signing-alg-values-supported` | Supported signing algorithms for SD-JWT                                                                                                                                   | `{ 'RsaSignature2018': {'RS256'}, 'Ed25519Signature2018': {'EdDSA'}, 'Ed25519Signature2020': {'EdDSA'}, 'EcdsaKoblitzSignature2016': {'ES256K'}, 'EcdsaSecp256k1Signature2019': {'ES256K'}, 'EcdsaSecp256r1Signature2019': {'ES256'}, 'ecdsa-rdfc-2019': {'ES256'}, 'ecdsa-jcs-2019': {'ES256'}}`              |
 | `mosip.certify.credential-config.proof-types-supported`                | Supported proof types for SD-JWT                                                                                                                                          | `{'jwt': {'proof_signing_alg_values_supported': {'RS256', 'PS256', 'ES256', 'EdDSA'}}}`                     |
-| `mosip.certify.credential-config.cryptographic-binding-methods-supported` | Supported binding methods for SD-JWT                                                                                                                                      | `{ 'ldp_vc': {'did:jwk','did:key'}, 'mso_mdoc': {'cose_key'},'vc+sd-jwt': {'did:jwk','did:key'} }`          |
+| `mosip.certify.credential-config.cryptographic-binding-methods-supported` | Supported binding methods for SD-JWT                                                                                                                                      | `{ 'ldp_vc': {'did:jwk','did:key'}, 'mso_mdoc': {'cose_key'},'dc+sd-jwt': {'did:jwk','did:key'} }`          |
 | `mosip.certify.data-provider-plugin.did-url` | The base Decentralized Identifier document URL used by the data provider plugin to resolve and bind DIDs for credential issuance.                                         | `did:web:someuser.github.io:somerepo:somedirectory` |
 |`mosip.kernel.keymanager.signature.kid.prepend`| The prefix to prepend to the `kid` field in SD-JWT credentials. This is useful for ensuring unique key identifiers across different systems. Default value will be blank. | `#`, `<DOMAIN_NAME>#` or `PAYLOAD_ISSUER`                          |
 ---
@@ -42,7 +42,7 @@ sequenceDiagram
     participant SDJWTCredential as 🔐 SDJWTCredential
     end
 
-    Client->>CredentialAPI: Request VC Issuance (format: vc+sd-jwt)
+    Client->>CredentialAPI: Request VC Issuance (format: dc+sd-jwt)
 
     CredentialAPI->>CredentialConfiguration: Validate VC request & get template
     CredentialConfiguration-->>CredentialAPI: Return validation success & template
@@ -61,9 +61,9 @@ sequenceDiagram
 
     CredentialAPI->>SDJWTCredential: addProof(unsigned credential)
     note right of SDJWTCredential: Signs the JWT and adds the final proof alongwith disclosures.
-    SDJWTCredential-->>CredentialAPI: Return signed vc+sd-jwt
+    SDJWTCredential-->>CredentialAPI: Return signed dc+sd-jwt
 
-    CredentialAPI-->>Client: Return final vc+sd-jwt
+    CredentialAPI-->>Client: Return final dc+sd-jwt
 ```
 
 ## 4. Configuring `kid` and DID Binding

--- a/docs/inji-certify-openapi.yaml
+++ b/docs/inji-certify-openapi.yaml
@@ -884,7 +884,7 @@ paths:
       description: |-
         Creates a new credential configuration. Requires a valid request body as per schema and has some additional validations too based on credential format and plugin configuration.
 
-        **Note** : Incase of VCIssuance plugin mode, only `ldp_vc` and `mso_mdoc` formats are supported by credential-configuration endpoints. `vc+sd-jwt` format is not yet supported currently.
+        **Note** : Incase of VCIssuance plugin mode, only `ldp_vc` and `mso_mdoc` formats are supported by credential-configuration endpoints. `dc+sd-jwt` format is not yet supported currently.
       operationId: addCredentialConfiguration
       requestBody:
         required: true
@@ -1017,7 +1017,7 @@ paths:
                         display:
                           - name: Document Number
                             locale: en
-              vc+sd-jwt example:
+              dc+sd-jwt example:
                 value:
                   credentialConfigKeyId: SD_JWT
                   vcTemplate: ewogICAgICAgICAiQGNvbnRleHQiOiBbCiAgICAgICAgICAgICAgICAgImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsCiAgICAgICAgICAgICAgICAgImh0dHBzOi8vbW9zaXAuZ2l0aHViLmlvL2luamktY29uZmlnL2NvbnRleHRzL2xhbmRyZWdpc3RyeS1zdGF0ZW1lbnQtY29udGV4dC5qc29uIiwKICAgICAgICAgICAgICAgICAiaHR0cHM6Ly93M2lkLm9yZy9zZWN1cml0eS9zdWl0ZXMvZWQyNTUxOS0yMDIwL3YxIgogICAgICAgICBdLAogICAgICAgICAiaXNzdWVyIjogIiR7X2lzc3Vlcn0iLAogICAgICAgICAidHlwZSI6IFsKICAgICAgICAgICAgICJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsCiAgICAgICAgICAgICAiTGFuZFN0YXRlbWVudENyZWRlbnRpYWwiCiAgICAgICAgIF0sCiAgICAgICAgICJ2YWxpZEZyb20iOiAiJHt2YWxpZEZyb219IiwKICAgICAgICAgInZhbGlkVW50aWwiOiAiJHt2YWxpZFVudGlsfSIsCiAgICAgICAgICJjcmVkZW50aWFsU3ViamVjdCI6IHsKICAgICAgICAgICAgImlkIjogIiR7X2hvbGRlcklkfSIsCiAgICAgICAgICAgICJOdW1iZXJPZkNBUiI6ICIke2Nhcl9yZWdpc3RyYXRpb25fbnVtYmVyfSIsCiAgICAgICAgICAgICJSZWdpc3RyYXRpb25EYXRlIjogIiR7cmVnaXN0cmF0aW9uX2RhdGV9IiwKICAgICAgICAgICAgIkxhc3RNb2RpZmljYXRpb25EYXRlIjogIiR7ZGF0ZV9vZl9sYXN0X2FtZW5kbWVudH0iLAogICAgICAgICAgICAiUnVyYWxQcm9wZXJ0eUFyZWEiOiAke3J1cmFsX3Byb3BlcnR5X2FyZWF9LAogICAgICAgICAgICAiTGF0aXR1ZGUiOiAiJHtsYXRpdHVkZX0iLAogICAgICAgICAgICAiTG9uZ2l0dWRlIjogIiR7bG9uZ2l0dWRlfSIsCiAgICAgICAgICAgICJNdW5pY2lwYWxpdHkiOiAiJHttdW5pY2lwYWxpdHl9IiwKICAgICAgICAgICAgIkV4dGVybmFsQ29uZGl0aW9uIjogIiR7ZXh0ZXJuYWxfY29uZGl0aW9ufSIsCiAgICAgICAgICAgICJSZWdpc3RyYXRpb25TdGF0dXMiOiAiJHtyZWdpc3RyYXRpb25fc3RhdHVzfSIsCiAgICAgICAgICAgICJQUkFDb25kaXRpb24iOiAiJHtwcmFfY29uZGl0aW9ufSIsCiAgICAgICAgICAgICJHcm91bmRDb3ZlcmFnZSI6ICIke2xhbmRfY292ZXJ9IiwKICAgICAgICAgICAgIk5hdGl2ZVZlZ2V0YXRpb25SZW1uYW50QXJlYSI6ICR7bmF0aXZlX3ZlZ2V0YXRpb25fcmVtbmFudF9hcmVhfSwKICAgICAgICAgICAgIkNvbnNvbGlkYXRlZFJ1cmFsQXJlYSI6ICR7Y29uc29saWRhdGVkX3J1cmFsX2FyZWF9LAogICAgICAgICAgICAiQWRtaW5pc3RyYXRpdmVFYXNlbWVudEFyZWEiOiAke2FkbWluaXN0cmF0aXZlX2Vhc2VtZW50X2FyZWF9LAogICAgICAgICAgICAiTGVnYWxSZXNlcnZlTG9jYXRpb24iOiAiJHtsb2NhdGlvbl9vZl9sZWdhbF9yZXNlcnZlfSIsCiAgICAgICAgICAgICJSZWdpc3RlcmVkTGVnYWxSZXNlcnZlQXJlYSI6ICR7cmVnaXN0ZXJlZF9sZWdhbF9yZXNlcnZlX2FyZWF9LAogICAgICAgICAgICAiR2VvcmVmZXJlbmNlZExlZ2FsUmVzZXJ2ZUFyZWEiOiAke2dlb3JlZmVyZW5jZWRfbGVnYWxfcmVzZXJ2ZV9hcmVhfSwKICAgICAgICAgICAgIkFwcHJvdmVkVW5yZWdpc3RlcmVkTGVnYWxSZXNlcnZlQXJlYSI6ICR7YXBwcm92ZWRfbGVnYWxfcmVzZXJ2ZV9hcmVhX25vdF9yZWdpc3RlcmVkfSwKICAgICAgICAgICAgIlByb3Bvc2VkTGVnYWxSZXNlcnZlQXJlYSI6ICR7cHJvcG9zZWRfbGVnYWxfcmVzZXJ2ZV9hcmVhfSwKICAgICAgICAgICAgIlRvdGFsRGVjbGFyZWRMZWdhbFJlc2VydmUiOiAke3RvdGFsX2xlZ2FsX3Jlc2VydmVfZGVjbGFyZWR9LAogICAgICAgICAgICAiUGVybWFuZW50UHJlc2VydmF0aW9uQXJlYXMiOiAke3Blcm1hbmVudF9wcmVzZXJ2YXRpb25fYXJlYXNfYXBwfSwKICAgICAgICAgICAgIkFQUEluQ29uc29saWRhdGVkUnVyYWxBcmVhIjogJHthcHBfaW5fY29uc29saWRhdGVkX3J1cmFsX2FyZWF9LAogICAgICAgICAgICAiQVBQSW5OYXRpdmVWZWdldGF0aW9uUmVtbmFudEFyZWEiOiAke2FwcF9pbl9uYXRpdmVfdmVnZXRhdGlvbl9yZW1uYW50X2FyZWF9LAogICAgICAgICAgICAiUmVzdHJpY3RlZFVzZUFyZWFzIjogJHtyZXN0cmljdGVkX3VzZV9hcmVhc30sCiAgICAgICAgICAgICJMZWdhbFJlc2VydmVEZWZpY2l0T3JFeGNlc3MiOiAke2xlZ2FsX3Jlc2VydmVfZGVmaWNpdF9leGNlc3N9LAogICAgICAgICAgICAiTGVnYWxSZXNlcnZlQXJlYVRvQmVSZXN0b3JlZCI6ICR7bGVnYWxfcmVzZXJ2ZV9hcmVhX3RvX3JlY29tcG9zZX0sCiAgICAgICAgICAgICJQZXJtYW5lbnRQcmVzZXJ2YXRpb25BcmVhc1RvQmVSZXN0b3JlZCI6ICR7cGVybWFuZW50X3ByZXNlcnZhdGlvbl9hcmVhc190b19yZWNvbXBvc2V9LAogICAgICAgICAgICAiUmVzdHJpY3RlZFVzZUFyZWFUb0JlUmVzdG9yZWQiOiAke3Jlc3RyaWN0ZWRfdXNlX2FyZWFfdG9fcmVjb21wb3NlfSwKICAgICAgICAgICAgIkVtYmFyZ2dlZEFyZWFEZXNjcmlwdGlvbiI6ICIke2VtYmFyZ29lZF9hcmVhX2Rlc2NyaXB0aW9ufSIsCiAgICAgICAgICAgICJFbWJhcmdnZWRBcmVhUHJvY2Vzc2luZ0RhdGUiOiAiJHtlbWJhcmdvZWRfYXJlYV9wcm9jZXNzaW5nX2RhdGV9IiwKICAgICAgICAgICAgIkVtYmFyZ2dlZEFyZWFPdmVybGFwIjogJHtlbWJhcmdvZWRfYXJlYV9vdmVybGFwfSwKICAgICAgICAgICAgIkVtYmFyZ2dlZEFyZWFPdmVybGFwUGVyY2VudGFnZSI6ICR7ZW1iYXJnb2VkX2FyZWFfb3ZlcmxhcF9wZXJjZW50YWdlfSwKICAgICAgICAgICAgIkNvbnNlcnZhdGlvblVuaXREZXNjcmlwdGlvbiI6ICIke2NvbnNlcnZhdGlvbl91bml0X2Rlc2NyaXB0aW9ufSIsCiAgICAgICAgICAgICJDb25zZXJ2YXRpb25Vbml0UHJvY2Vzc2luZ0RhdGUiOiAiJHtjb25zZXJ2YXRpb25fdW5pdF9wcm9jZXNzaW5nX2RhdGV9IiwKICAgICAgICAgICAgIkNvbnNlcnZhdGlvblVuaXRPdmVybGFwQXJlYSI6ICR7Y29uc2VydmF0aW9uX3VuaXRfb3ZlcmxhcF9hcmVhfSwKICAgICAgICAgICAgIkNvbnNlcnZhdGlvblVuaXRPdmVybGFwUGVyY2VudGFnZSI6ICR7Y29uc2VydmF0aW9uX3VuaXRfb3ZlcmxhcF9wZXJjZW50YWdlfQogICAgICAgICB9CiAgICAgfQ==
@@ -1025,7 +1025,7 @@ paths:
                   keyManagerRefId: ED25519_SIGN
                   signatureAlgo: EdDSA
                   sdJwtVct: SD_JWT
-                  credentialFormat: vc+sd-jwt
+                  credentialFormat: dc+sd-jwt
                   didUrl: 'did:web:likhitharl.github.io:vc:qainji#key-0'
                   metaDataDisplay:
                     - name: STATEMENT OF THE STATUS OF INFORMATION DECLARED IN CAR
@@ -1929,14 +1929,14 @@ components:
             type: string
         sdJwtVct:
           type: string
-          description: Represents the Verifiable Credential Type (VCT) used in Selective Disclosure JWT (SD-JWT) credentials. This field specifies the credential type identifier required for vc+sd-jwt format.
+          description: Represents the Verifiable Credential Type (VCT) used in Selective Disclosure JWT (SD-JWT) credentials. This field specifies the credential type identifier required for dc+sd-jwt format.
         credentialFormat:
-          description: 'Format of the credential. Valid values are ldp_vc, mso_mdoc, vc+sd-jwt.'
+          description: 'Format of the credential. Valid values are ldp_vc, mso_mdoc, dc+sd-jwt.'
           type: string
           enum:
             - ldp_vc
             - mso_mdoc
-            - vc+sd-jwt
+            - dc+sd-jwt
         didUrl:
           type: string
           description: URL of the Decentralized Identifier (DID) document. Mandatory for DataProvider plugin mode.
@@ -1948,7 +1948,7 @@ components:
           description: Reference ID for the key manager. Applicable for DataProvider plugin mode.
         signatureAlgo:
           description: |-
-            Signature or proof algorithm used for credential signing. This field is required for certain credential formats, such as vc+sd-jwt and optionally for ldp_vc when the signatureCryptoSuite is one of DataIntegrityProof suite (e.g. ecdsa-rdfc-2019, ecdsa-jcs-2019, etc). It ensures compatibility between the cryptographic suite and the signing algorithm. Mapping of signatureCryptoSuite and signatureAlgo values for DataIntegrityProof suite scenario :
+            Signature or proof algorithm used for credential signing. This field is required for certain credential formats, such as dc+sd-jwt and optionally for ldp_vc when the signatureCryptoSuite is one of DataIntegrityProof suite (e.g. ecdsa-rdfc-2019, ecdsa-jcs-2019, etc). It ensures compatibility between the cryptographic suite and the signing algorithm. Mapping of signatureCryptoSuite and signatureAlgo values for DataIntegrityProof suite scenario :
 
             signatureCryptoSuite |  signatureAlgo
             ---------|----------
@@ -1962,7 +1962,7 @@ components:
           type: string
         sdClaim:
           type: string
-          description: Comma-separated list for selective disclosure claim configuration. Applicable for vc+sd-jwt credential type.
+          description: Comma-separated list for selective disclosure claim configuration. Applicable for dc+sd-jwt credential type.
         metaDataDisplay:
           type: array
           description: 'To configure the display properties (e.g., logo, name, colors, and localization) for metadata associated with the Verifiable Credential type.'
@@ -1989,7 +1989,7 @@ components:
           additionalProperties:
             $ref: '#/components/schemas/CredentialSubjectParametersDTO'
         msoMdocClaims:
-          description: Claims included in the credential. Applicable for mso_mdoc and vc+sd-jwt credential formats.
+          description: Claims included in the credential. Applicable for mso_mdoc and dc+sd-jwt credential formats.
           type: object
           additionalProperties:
             type: object
@@ -2514,13 +2514,13 @@ components:
       properties:
         format:
           type: string
-          description: 'The credential format supported (e.g., ldp_vc, mso_mdoc, vc+sd-jwt).'
+          description: 'The credential format supported (e.g., ldp_vc, mso_mdoc, dc+sd-jwt).'
         scope:
           type: string
           description: The OAuth2 scope value associated with this credential configuration.
         claims:
           type: object
-          description: Map of claim definitions for the credential (used for mso_mdoc and vc+sd-jwt).
+          description: Map of claim definitions for the credential (used for mso_mdoc and dc+sd-jwt).
           additionalProperties:
             type: object
         display:

--- a/docs/postman-collections/Inji Certify - Pre Auth Code.postman_collection.json
+++ b/docs/postman-collections/Inji Certify - Pre Auth Code.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "710a0e17-88d9-4686-8332-05dd6045c363",
+		"_postman_id": "6e03a109-6aea-423e-8ebb-45e8bb5ad85a",
 		"name": "Inji Certify - Pre Auth Code",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "1282483"
+		"_exporter_id": "41350892"
 	},
 	"item": [
 		{
@@ -402,7 +402,9 @@
 									"    console.log('Credential received successfully');",
 									"});"
 								],
-								"type": "text/javascript"
+								"type": "text/javascript",
+								"packages": {},
+								"requests": {}
 							}
 						},
 						{
@@ -437,7 +439,9 @@
 									"",
 									"pm.collectionVariables.set(\"proof_jwt\",signed_jwt);"
 								],
-								"type": "text/javascript"
+								"type": "text/javascript",
+								"packages": {},
+								"requests": {}
 							}
 						}
 					],
@@ -461,7 +465,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"format\": \"ldp_vc\",\n    \"credential_definition\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"type\": [\n            \"VerifiableCredential\",\n            \"FarmerCredential\"\n        ]\n    },\n    \"proof\": {\n        \"proof_type\": \"jwt\",\n        \"jwt\": \"{{proof_jwt}}\"\n    }\n}"
+							"raw": "{\n    \"credential_configuration_id\":\"FarmerCredential\",\n    \"proofs\": {\n        \"jwt\": [\"{{proof_jwt}}\"]\n    }\n}"
 						},
 						"url": {
 							"raw": "{{certifyurl}}/issuance/credential",

--- a/docs/postman-collections/Inji Certify - Presentation During Issuance VCI.postman_collection.json
+++ b/docs/postman-collections/Inji Certify - Presentation During Issuance VCI.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "fd7002a2-0db6-4eab-bc4f-f312d90dbe43",
+		"_postman_id": "acff4e4d-2fad-4f4e-98fe-86f452e747db",
 		"name": "Inji Certify - Presentation During Issuance VCI",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "1282483"
+		"_exporter_id": "41350892"
 	},
 	"item": [
 		{
@@ -395,7 +395,9 @@
 									"",
 									"pm.collectionVariables.set(\"proof_jwt\",signed_jwt);"
 								],
-								"type": "text/javascript"
+								"type": "text/javascript",
+								"packages": {},
+								"requests": {}
 							}
 						},
 						{
@@ -404,7 +406,9 @@
 								"exec": [
 									""
 								],
-								"type": "text/javascript"
+								"type": "text/javascript",
+								"packages": {},
+								"requests": {}
 							}
 						}
 					],
@@ -423,7 +427,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"format\": \"ldp_vc\",\n    \"credential_definition\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"type\": [\n            \"VerifiableCredential\",\n            \"FarmerCredential\"\n        ]\n    },\n    \"proof\": {\n        \"proof_type\": \"jwt\",\n        \"jwt\": \"{{proof_jwt}}\"\n    }\n}",
+							"raw": "{\n    \"credential_configuration_id\":\"FarmerCredential\",\n    \"proofs\": {\n        \"jwt\": [\"{{proof_jwt}}\"]\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/docs/postman-collections/Inji Certify - Presentation During Issuance VCI.postman_collection.json
+++ b/docs/postman-collections/Inji Certify - Presentation During Issuance VCI.postman_collection.json
@@ -25,9 +25,11 @@
 									"    pm.expect(jsonData).to.have.property('credential_issuer');",
 									"    pm.expect(jsonData).to.have.property('authorization_servers');",
 									"    pm.expect(jsonData).to.have.property('credential_endpoint');",
+									"    pm.expect(jsonData).to.have.property('nonce_endpoint');",
 									"",
 									"    pm.collectionVariables.set('authorization_server', jsonData.authorization_servers[0]);",
 									"    pm.collectionVariables.set('credential_endpoint', jsonData.credential_endpoint);",
+									"    pm.collectionVariables.set('nonce_endpoint', jsonData.nonce_endpoint);",
 									"});"
 								],
 								"type": "text/javascript"
@@ -621,6 +623,10 @@
 		},
 		{
 			"key": "credential_endpoint",
+			"value": ""
+		},
+		{
+			"key": "nonce_endpoint",
 			"value": ""
 		}
 	]

--- a/docs/postman-collections/inji-certify-with-mock-identity.postman_collection.json
+++ b/docs/postman-collections/inji-certify-with-mock-identity.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "edd685ae-f66f-425a-8859-ef319d8d5443",
+		"_postman_id": "73d9e832-fc1b-4156-83ff-29f9f7d7f1e9",
 		"name": "certify- Mock IDA",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "1282483"
+		"_exporter_id": "41350892"
 	},
 	"item": [
 		{
@@ -795,7 +795,9 @@
 									"pm.collectionVariables.set(\"proof_jwt\",signed_jwt);",
 									""
 								],
-								"type": "text/javascript"
+								"type": "text/javascript",
+								"packages": {},
+								"requests": {}
 							}
 						},
 						{
@@ -810,7 +812,9 @@
 									"    }    ",
 									"});"
 								],
-								"type": "text/javascript"
+								"type": "text/javascript",
+								"packages": {},
+								"requests": {}
 							}
 						}
 					],
@@ -829,7 +833,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"format\": \"ldp_vc\",\n    \"credential_definition\" : \n    { \n        \"type\" : [\"VerifiableCredential\", \"FarmerCredential\"], \n    \"@context\" : [\"https://www.w3.org/2018/credentials/v1\"]\n    },\n    \"proof\": {\n        \"proof_type\":\"jwt\",\n        \"jwt\": \"{{proof_jwt}}\"\n    }\n}",
+							"raw": "{\n    \"credential_configuration_id\":\"FarmerCredential\",\n    \"proofs\": {\n        \"jwt\": [\"{{proof_jwt}}\"]\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/docs/postman-collections/inji-certify-with-mock-mdoc-vci.postman_collection.json
+++ b/docs/postman-collections/inji-certify-with-mock-mdoc-vci.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "37eb73f6-3f54-4fee-a226-49aa46665379",
+		"_postman_id": "dc5253d4-a6a8-4da3-9271-a358e097bb9e",
 		"name": "Inji Certify Mock MDL VCI",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "1282483"
+		"_exporter_id": "41350892"
 	},
 	"item": [
 		{
@@ -485,7 +485,9 @@
 									"pm.collectionVariables.set(\"proof_jwt\",signed_jwt);",
 									""
 								],
-								"type": "text/javascript"
+								"type": "text/javascript",
+								"packages": {},
+								"requests": {}
 							}
 						},
 						{
@@ -500,7 +502,9 @@
 									"    }    ",
 									"});"
 								],
-								"type": "text/javascript"
+								"type": "text/javascript",
+								"packages": {},
+								"requests": {}
 							}
 						}
 					],
@@ -519,7 +523,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"format\": \"mso_mdoc\",\n    \"doctype\": \"org.iso.18013.5.1.mDL\",\n    \"proof\": {\n        \"proof_type\": \"jwt\",\n        \"jwt\": \"{{proof_jwt}}\"\n    }\n}",
+							"raw": "{\n    \"credential_configuration_id\":\"DrivingLicenseCredential\",\n    \"proofs\": {\n        \"jwt\": [\"{{proof_jwt}}\"]\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/docs/postman-collections/inji-certify-with-sunbird-insurance.postman_collection.json
+++ b/docs/postman-collections/inji-certify-with-sunbird-insurance.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "9476e7a3-a298-4086-82a8-de2e0ac60766",
+		"_postman_id": "41ef526b-5ab3-47ca-9774-090f5d92bcca",
 		"name": "eSignet with Sunbird RC",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "46457899"
+		"_exporter_id": "41350892"
 	},
 	"item": [
 		{
@@ -873,7 +873,8 @@
 									""
 								],
 								"type": "text/javascript",
-								"packages": {}
+								"packages": {},
+								"requests": {}
 							}
 						},
 						{
@@ -889,7 +890,8 @@
 									"});"
 								],
 								"type": "text/javascript",
-								"packages": {}
+								"packages": {},
+								"requests": {}
 							}
 						}
 					],
@@ -908,7 +910,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"format\": \"ldp_vc\",\n    \"credential_definition\": {\n        \"type\": [\n            \"VerifiableCredential\",\n            \"LifeInsuranceCredential\"\n        ],\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ]\n    },\n    \"proof\": {\n        \"proof_type\": \"jwt\",\n         \"jwt\": \"{{proof_jwt}}\"\n    }\n}",
+							"raw": "{\n    \"credential_configuration_id\":\"LifeInsuranceCredential\",\n    \"proofs\": {\n        \"jwt\": [\"{{proof_jwt}}\"]\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced legacy credential format references with the updated format across multiple guides; adjusted QR and credential examples and updated a sample credential to nest the identity QR code under the new claim object.

* **Tests**
  * Updated Postman collections: refreshed collection metadata, added script metadata fields, and changed credential issuance examples to use configuration-based identifiers with proofs provided as arrays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->