### PR TITLE
MOSIP-44954 Replaced vc+sd-jwt to dc+sd-jwt to support 1.0 VCI Spec

### DIFF
--- a/api-test/src/main/resources/injicertify/CSRCertificate/AddCredentialConfigCSRCertificate/AddCredentialConfigForCSRCertificate.yml
+++ b/api-test/src/main/resources/injicertify/CSRCertificate/AddCredentialConfigCSRCertificate/AddCredentialConfigForCSRCertificate.yml
@@ -369,7 +369,7 @@ AddCredentialConfigForCSRCertificate:
         "keyManagerAppId": "CERTIFY_VC_SIGN_EC_R1",
         "keyManagerRefId": "EC_SECP256R1_SIGN",
         "signatureAlgo": "ES256",
-        "credentialFormat": "vc+sd-jwt",
+        "credentialFormat": "dc+sd-jwt",
         "display_name": "Sd_jwt",
         "displayOrder": [
           {"displayOrder_values": "NumberOfCAR"},

--- a/api-test/src/main/resources/injicertify/CSRCertificate/GetCredentialForCSRCertificate/GetCredentialForCSRCertificate.yml
+++ b/api-test/src/main/resources/injicertify/CSRCertificate/GetCredentialForCSRCertificate/GetCredentialForCSRCertificate.yml
@@ -99,7 +99,7 @@ GetCredentialForCsrCertificate:
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2_For_LandRegistry2_all_Valid_Smoke_sid_clientId$",
         "idpAccessToken": "$ID:ESignet_GenerateToken_ForLandRegistry_Cred2_Valid_Smoke_For_CSRCertificate_sid_access_token$",
-        "format": "vc+sd-jwt",
+        "format": "dc+sd-jwt",
         "vct": "Sd_jwt_landstatement_csrCertificate",        
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT$",

--- a/api-test/src/main/resources/injicertify/Sd_Jwt/AddCredentialConfigSd_Jwt/AddCredentialConfigurationSd_Jwt.yml
+++ b/api-test/src/main/resources/injicertify/Sd_Jwt/AddCredentialConfigSd_Jwt/AddCredentialConfigurationSd_Jwt.yml
@@ -85,7 +85,7 @@ AddCredentialConfig:
         "keyManagerAppId": "CERTIFY_VC_SIGN_EC_R1",
         "keyManagerRefId": "EC_SECP256R1_SIGN",
         "signatureAlgo": "ES256",
-        "credentialFormat": "vc+sd-jwt",
+        "credentialFormat": "dc+sd-jwt",
         "display_name": "Sd_jwt",
         "displayOrder": [
           {"displayOrder_values": "NumberOfCAR"},
@@ -155,7 +155,7 @@ AddCredentialConfig:
         "keyManagerAppId": "CERTIFY_VC_SIGN_EC_R1",
         "keyManagerRefId": "EC_SECP256R1_SIGN",
         "signatureAlgo": "ES256",
-        "credentialFormat": "vc+sd-jwt",
+        "credentialFormat": "dc+sd-jwt",
         "display_name": "Sd_jwt",
         "displayOrder": [
           {"displayOrder_values": "PermanentPreservationAreas"},
@@ -209,7 +209,7 @@ AddCredentialConfig:
         "keyManagerAppId": "CERTIFY_VC_SIGN_EC_R1",
         "keyManagerRefId": "EC_SECP256R1_SIGN",
         "signatureAlgo": "ES256",
-        "credentialFormat": "vc+sd-jwt",
+        "credentialFormat": "dc+sd-jwt",
         "display_name": "Sd_jwt",
         "displayOrder": [
           {"displayOrder_values": "PermanentPreservationAreas"},
@@ -285,7 +285,7 @@ AddCredentialConfig:
         "keyManagerAppId": "CERTIFY_VC_SIGN_EC_R1",
         "keyManagerRefId": "EC_SECP256R1_SIGN",
         "signatureAlgo": "ES256",
-        "credentialFormat": "vc+sd-jwt",
+        "credentialFormat": "dc+sd-jwt",
         "display_name": "Sd_jwt",
         "displayOrder": [
           {"displayOrder_values": "NumberOfCAR"},
@@ -360,7 +360,7 @@ AddCredentialConfig:
         "keyManagerAppId": "CERTIFY_VC_SIGN_EC_R1",
         "keyManagerRefId": "EC_SECP256R1_SIGN",
         "signatureAlgo": "ES256",
-        "credentialFormat": "vc+sd-jwt",
+        "credentialFormat": "dc+sd-jwt",
         "display_name": "Sd_jwt",
         "displayOrder": [
           {"displayOrder_values": "NumberOfCAR"},
@@ -474,7 +474,7 @@ AddCredentialConfig:
         "keyManagerAppId": "CERTIFY_VC_SIGN_ED25519",
         "keyManagerRefId": "ED25519_SIGN",
         "signatureAlgo": "EdDSA",
-        "credentialFormat": "vc+sd-jwt",
+        "credentialFormat": "dc+sd-jwt",
         "display_name": "Sd_jwt",
         "displayOrder": [
           {"displayOrder_values": "NumberOfCAR"},
@@ -598,7 +598,7 @@ AddCredentialConfig:
         "keyManagerAppId": "CERTIFY_VC_SIGN_EC_R1",
         "keyManagerRefId": "EC_SECP256R1_SIGN",
         "signatureAlgo": "ES256",
-        "credentialFormat": "vc+sd-jwt",
+        "credentialFormat": "dc+sd-jwt",
         "display_name": "Sd_jwt",
         "displayOrder": [
           {"displayOrder_values": "NumberOfCAR"},
@@ -721,7 +721,7 @@ AddCredentialConfig:
         "didUrl": "did:web:inji.github.io:inji-config:qa-inji1:landregistry",
         "keyManagerAppId": "CERTIFY_VC_SIGN_EC_R1",
         "keyManagerRefId": "EC_SECP256R1_SIGN",
-        "credentialFormat": "vc+sd-jwt",
+        "credentialFormat": "dc+sd-jwt",
         "display_name": "Sd_jwt",
         "displayOrder": [
           {"displayOrder_values": "NumberOfCAR"},
@@ -849,7 +849,7 @@ AddCredentialConfig:
         "keyManagerAppId": "CERTIFY_VC_SIGN_EC_R1",
         "keyManagerRefId": "EC_SECP256R1_SIGN",
         "signatureAlgo": "ES256",
-        "credentialFormat": "vc+sd-jwt",
+        "credentialFormat": "dc+sd-jwt",
         "display_name": "Sd_jwt",
         "displayOrder": [
           { "displayOrder_values": "NumberOfCAR" },

--- a/api-test/src/main/resources/injicertify/Sd_Jwt/GetCredentialForSd_Jwt/GetCredentialForSd_Jwt.yml
+++ b/api-test/src/main/resources/injicertify/Sd_Jwt/GetCredentialForSd_Jwt/GetCredentialForSd_Jwt.yml
@@ -13,7 +13,7 @@ GetCredentialForSd_jwt:
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2_For_LandRegistry2_all_Valid_Smoke_sid_clientId$",
         "idpAccessToken": "$ID:ESignet_GenerateToken_ForLandRegistry_Cred1_Sd_Jwt_Valid_Smoke_sid_access_token$",
-        "format": "vc+sd-jwt",
+        "format": "dc+sd-jwt",
         "vct": "Sd_jwt_landstatement",        
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT$",
@@ -36,7 +36,7 @@ GetCredentialForSd_jwt:
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2_For_LandRegistry2_all_Valid_Smoke_sid_clientId$",
         "idpAccessToken": "$ID:ESignet_GenerateToken_ForLandRegistry_Cred1_Sd_Jwt_Valid_Smoke_sid_access_token$",
-        "format": "vc+sd-jwt",
+        "format": "dc+sd-jwt",
         "vct": "Sd_jwt_landstatement",        
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT$",
@@ -58,7 +58,7 @@ GetCredentialForSd_jwt:
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2_For_LandRegistry2_all_Valid_Smoke_sid_clientId$",
         "idpAccessToken": "$ID:ESignet_GenerateToken_ForLandRegistry_Cred1_Sd_Jwt_Valid_Smoke_sid_access_token$",
-        "format": "vc+sd-jwt",
+        "format": "dc+sd-jwt",
         "vct": "Sd_jwt_landstatement",        
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",
@@ -79,7 +79,7 @@ GetCredentialForSd_jwt:
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2_For_LandRegistry2_all_Valid_Smoke_sid_clientId$",
         "idpAccessToken": "$ID:ESignet_GenerateToken_ForLandRegistry_Cred1_Sd_Jwt_Valid_Smoke_sid_access_token$",
-        "format": "vc+sd-jwt",
+        "format": "dc+sd-jwt",
         "vct": "Sd_jwt_landstatement",        
       	"proof_type": "jwt",
         "proof_jwt": "null",
@@ -103,7 +103,7 @@ GetCredentialForSd_jwt:
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2_For_LandRegistry2_all_Valid_Smoke_sid_clientId$",
         "idpAccessToken": "$ID:ESignet_GenerateToken_ForLandRegistry_Cred2_Sd_Jwt_Valid_Smoke_sid_access_token$",
-        "format": "vc+sd-jwt",
+        "format": "dc+sd-jwt",
         "vct": "Sd_jwt_landregistry",        
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",
@@ -124,7 +124,7 @@ GetCredentialForSd_jwt:
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2_For_LandRegistry2_all_Valid_Smoke_sid_clientId$",
         "idpAccessToken": "$ID:ESignet_GenerateToken_ForLandRegistry_Cred2_Sd_Jwt_Valid_Smoke_sid_access_token$",
-        "format": "vc+sd-jwt",
+        "format": "dc+sd-jwt",
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",
         "signatureSupported": "Ed25519"
@@ -166,7 +166,7 @@ GetCredentialForSd_jwt:
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2_For_LandRegistry2_all_Valid_Smoke_sid_clientId$",
         "idpAccessToken": "$ID:ESignet_GenerateToken_ForLandRegistry_Cred1_Sd_Jwt_Valid_Smoke_sid_access_token$",
-        "format": "vc+sd-jwt",
+        "format": "dc+sd-jwt",
         "vct": "invalid",        
       	"proof_type": "jwt",
         "proof_jwt": "null",
@@ -189,7 +189,7 @@ GetCredentialForSd_jwt:
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2_For_LandRegistry2_all_Valid_Smoke_sid_clientId$",
         "idpAccessToken": "$ID:ESignet_GenerateToken_ForLandRegistry_Cred1_Sd_Jwt_Valid_Smoke_sid_access_token$",
-        "format": "vc+sd-jwt",
+        "format": "dc+sd-jwt",
         "vct": "Sd_jwt_sdClaims",        
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT$",
@@ -232,7 +232,7 @@ GetCredentialForSd_jwt:
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2_For_LandRegistry2_all_Valid_Smoke_sid_clientId$",
         "idpAccessToken": "$ID:ESignet_GenerateToken_ForLandRegistry_Cred1_Sd_Jwt_Valid_Smoke_sid_access_token$",
-        "format": "vc+sd-jwt",
+        "format": "dc+sd-jwt",
         "vct": "Sd_jwt_random_claims",       
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT$",
@@ -253,7 +253,7 @@ GetCredentialForSd_jwt:
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2_For_LandRegistry2_all_Valid_Smoke_sid_clientId$",
         "idpAccessToken": "$ID:ESignet_GenerateToken_ForLandRegistry_Cred1_Sd_Jwt_Valid_Smoke_sid_access_token$",
-        "format": "vc+sd-jwt",
+        "format": "dc+sd-jwt",
         "vct": "Sd_jwt_differtntstructures",        
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_3$",

--- a/api-test/src/main/resources/injicertify/Sd_Jwt/GetCredentialForSd_Jwt/GetCredentialForSd_JwtVd11.yml
+++ b/api-test/src/main/resources/injicertify/Sd_Jwt/GetCredentialForSd_Jwt/GetCredentialForSd_JwtVd11.yml
@@ -13,7 +13,7 @@ GetCredentialForSd_jwtForVd11:
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2_For_LandRegistry2_all_Valid_Smoke_sid_clientId$",
         "idpAccessToken": "$ID:ESignet_GenerateToken_ForLandRegistry_Cred1_Sd_Jwt_Valid_Smoke_sid_access_token$",
-        "format": "vc+sd-jwt",
+        "format": "dc+sd-jwt",
         "vct": "Sd_jwt_landstatement",        
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT$",
@@ -36,7 +36,7 @@ GetCredentialForSd_jwtForVd11:
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2_For_LandRegistry2_all_Valid_Smoke_sid_clientId$",
         "idpAccessToken": "$ID:ESignet_GenerateToken_ForLandRegistry_Cred2_Sd_Jwt_Valid_Smoke_sid_access_token$",
-        "format": "vc+sd-jwt",
+        "format": "dc+sd-jwt",
         "vct": "Sd_jwt_landregistry",        
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",

--- a/api-test/src/main/resources/injicertify/Sd_Jwt/GetCredentialForSd_Jwt/GetCredentialForSd_JwtVd12.yml
+++ b/api-test/src/main/resources/injicertify/Sd_Jwt/GetCredentialForSd_Jwt/GetCredentialForSd_JwtVd12.yml
@@ -13,7 +13,7 @@ GetCredentialForSd_jwtVd12:
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2_For_LandRegistry2_all_Valid_Smoke_sid_clientId$",
         "idpAccessToken": "$ID:ESignet_GenerateToken_ForLandRegistry_Cred1_Sd_Jwt_Valid_Smoke_sid_access_token$",
-        "format": "vc+sd-jwt",
+        "format": "dc+sd-jwt",
         "vct": "Sd_jwt_landstatement",        
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ES256$",
@@ -36,7 +36,7 @@ GetCredentialForSd_jwtVd12:
       input: '{
       	"client_id": "$ID:ESignet_CreateOIDCClientV2_For_LandRegistry2_all_Valid_Smoke_sid_clientId$",
         "idpAccessToken": "$ID:ESignet_GenerateToken_ForLandRegistry_Cred2_Sd_Jwt_Valid_Smoke_sid_access_token$",
-        "format": "vc+sd-jwt",
+        "format": "dc+sd-jwt",
         "vct": "Sd_jwt_landregistry",        
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT$",


### PR DESCRIPTION
1. Replace format from vc+sd-jwt to dc+sd-jwt to suuport OpenID4VCI 1.0 spec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configurations for SD-JWT credential issuance across multiple test scenarios, including CSR certificate and VD1.1/VD1.2 variants, to use updated credential format specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->