### PR TITLE
fix(preauth): check expiry before claim

### DIFF
--- a/certify-service/src/main/java/io/mosip/certify/services/PreAuthorizedCodeService.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/PreAuthorizedCodeService.java
@@ -357,18 +357,24 @@ public class PreAuthorizedCodeService {
             throw new CertifyException(ErrorConstants.UNSUPPORTED_GRANT_TYPE, "Grant type not supported");
         }
 
-        // Atomically claim the pre-authorized code
-        boolean claimed = vciCacheService.claimPreAuthCode(request.getPre_authorized_code());
-        if (!claimed) {
-            log.error("Pre-authorized code already used or invalid");
-            throw new CertifyException(ErrorConstants.INVALID_GRANT, "Pre-authorized code has already been used  or invalid");
+        // Reject unknown codes immediately before any expiry or claim check
+        if (codeData == null) {
+            log.error("Pre-authorized code not found: {}", request.getPre_authorized_code());
+            throw new CertifyException(ErrorConstants.INVALID_GRANT, "Pre-authorized code not found");
         }
 
-        // Check expiry
+        // Check expiry before claiming so expired codes are never consumed
         long currentTime = System.currentTimeMillis();
         if (codeData.getExpiresAt() < currentTime) {
             log.error("Pre-authorized code expired. Expiry: {}, Current: {}", codeData.getExpiresAt(), currentTime);
             throw new CertifyException("pre_auth_code_expired", "Pre-authorized code has expired");
+        }
+
+        // Atomically claim the pre-authorized code (single-use enforcement)
+        boolean claimed = vciCacheService.claimPreAuthCode(request.getPre_authorized_code());
+        if (!claimed) {
+            log.error("Pre-authorized code already used or invalid");
+            throw new CertifyException(ErrorConstants.INVALID_GRANT, "Pre-authorized code has already been used  or invalid");
         }
 
         // Validate transaction code if required

--- a/certify-service/src/main/java/io/mosip/certify/services/PreAuthorizedCodeService.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/PreAuthorizedCodeService.java
@@ -363,16 +363,15 @@ public class PreAuthorizedCodeService {
             throw new CertifyException(ErrorConstants.INVALID_GRANT, "Pre-authorized code not found");
         }
 
-        // Check expiry before claiming so expired codes are never consumed
+        // Atomically validate expiry and claim to avoid TOCTOU around expiry boundary
         long currentTime = System.currentTimeMillis();
-        if (codeData.getExpiresAt() < currentTime) {
+        VCICacheService.PreAuthCodeClaimResult claimResult =
+                vciCacheService.claimPreAuthCodeIfUnexpired(request.getPre_authorized_code(), currentTime);
+        if (claimResult == VCICacheService.PreAuthCodeClaimResult.EXPIRED) {
             log.error("Pre-authorized code expired. Expiry: {}, Current: {}", codeData.getExpiresAt(), currentTime);
             throw new CertifyException("pre_auth_code_expired", "Pre-authorized code has expired");
         }
-
-        // Atomically claim the pre-authorized code (single-use enforcement)
-        boolean claimed = vciCacheService.claimPreAuthCode(request.getPre_authorized_code());
-        if (!claimed) {
+        if (claimResult == VCICacheService.PreAuthCodeClaimResult.INVALID_OR_USED) {
             log.error("Pre-authorized code already used or invalid");
             throw new CertifyException(ErrorConstants.INVALID_GRANT, "Pre-authorized code has already been used  or invalid");
         }

--- a/certify-service/src/main/java/io/mosip/certify/services/VCICacheService.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/VCICacheService.java
@@ -16,6 +16,12 @@ import org.springframework.stereotype.Service;
 @Service
 public class VCICacheService {
 
+    public enum PreAuthCodeClaimResult {
+        CLAIMED,
+        EXPIRED,
+        INVALID_OR_USED
+    }
+
     @Autowired
     private CacheManager cacheManager;
 
@@ -119,6 +125,22 @@ public class VCICacheService {
             }
             markPreAuthCodeAsUsed(preAuthCode);
             return true;
+        }
+    }
+
+    public PreAuthCodeClaimResult claimPreAuthCodeIfUnexpired(String preAuthCode, long currentTime) {
+        synchronized (this) {
+            PreAuthCodeData codeData = getPreAuthCodeData(preAuthCode);
+            if (codeData == null || isPreAuthCodeUsed(preAuthCode)) {
+                return PreAuthCodeClaimResult.INVALID_OR_USED;
+            }
+
+            if (codeData.getExpiresAt() < currentTime) {
+                return PreAuthCodeClaimResult.EXPIRED;
+            }
+
+            markPreAuthCodeAsUsed(preAuthCode);
+            return PreAuthCodeClaimResult.CLAIMED;
         }
     }
 

--- a/certify-service/src/test/java/io/mosip/certify/services/PreAuthorizedCodeServiceTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/PreAuthorizedCodeServiceTest.java
@@ -305,7 +305,8 @@ public class PreAuthorizedCodeServiceTest {
                 .build();
 
         when(vciCacheService.getPreAuthCodeData(preAuthCode)).thenReturn(codeData);
-        when(vciCacheService.claimPreAuthCode(preAuthCode)).thenReturn(true);
+        when(vciCacheService.claimPreAuthCodeIfUnexpired(eq(preAuthCode), anyLong()))
+                .thenReturn(VCICacheService.PreAuthCodeClaimResult.CLAIMED);
         when(vciCacheService.setVCITransaction(anyString(), any(VCIssuanceTransaction.class))).thenReturn(null);
         when(accessTokenJwtUtil.generateCNonce()).thenReturn("test-cnonce");
         when(accessTokenJwtUtil.generateSignedJwt(anyString(), anyString(), anyString(), anyString(), anyString(), anyInt(), anyString()))
@@ -322,7 +323,7 @@ public class PreAuthorizedCodeServiceTest {
         Assert.assertEquals(Integer.valueOf(300), response.getCNonceExpiresIn());
 
         verify(vciCacheService).getPreAuthCodeData(preAuthCode);
-        verify(vciCacheService).claimPreAuthCode(preAuthCode);
+        verify(vciCacheService).claimPreAuthCodeIfUnexpired(eq(preAuthCode), anyLong());
         verify(vciCacheService).setVCITransaction(anyString(), any(VCIssuanceTransaction.class));
     }
 
@@ -347,7 +348,8 @@ public class PreAuthorizedCodeServiceTest {
                 .build();
 
         when(vciCacheService.getPreAuthCodeData(preAuthCode)).thenReturn(codeData);
-        when(vciCacheService.claimPreAuthCode(preAuthCode)).thenReturn(true);
+        when(vciCacheService.claimPreAuthCodeIfUnexpired(eq(preAuthCode), anyLong()))
+                .thenReturn(VCICacheService.PreAuthCodeClaimResult.CLAIMED);
         when(vciCacheService.setVCITransaction(anyString(), any(VCIssuanceTransaction.class))).thenReturn(null);
         when(accessTokenJwtUtil.generateCNonce()).thenReturn("test-cnonce");
         when(accessTokenJwtUtil.generateSignedJwt(anyString(), anyString(), anyString(), anyString(), anyString(), anyInt(), anyString()))
@@ -357,7 +359,7 @@ public class PreAuthorizedCodeServiceTest {
 
         Assert.assertNotNull(response);
         Assert.assertNotNull(response.getAccessToken());
-        verify(vciCacheService).claimPreAuthCode(preAuthCode);
+        verify(vciCacheService).claimPreAuthCodeIfUnexpired(eq(preAuthCode), anyLong());
     }
 
     @Test
@@ -408,13 +410,15 @@ public class PreAuthorizedCodeServiceTest {
                 .build();
 
         when(vciCacheService.getPreAuthCodeData(preAuthCode)).thenReturn(codeData);
+        when(vciCacheService.claimPreAuthCodeIfUnexpired(eq(preAuthCode), anyLong()))
+                .thenReturn(VCICacheService.PreAuthCodeClaimResult.EXPIRED);
 
         CertifyException exception = assertThrows(CertifyException.class,
                 () -> preAuthorizedCodeService.exchangePreAuthorizedCode(tokenRequest));
 
         Assert.assertEquals("pre_auth_code_expired", exception.getErrorCode());
-        // Expired codes must never be consumed — claiming would corrupt single-use semantics
-        verify(vciCacheService, never()).claimPreAuthCode(preAuthCode);
+        // Expiry and claim are validated atomically in cache layer
+        verify(vciCacheService).claimPreAuthCodeIfUnexpired(eq(preAuthCode), anyLong());
     }
 
     @Test
@@ -431,7 +435,8 @@ public class PreAuthorizedCodeServiceTest {
                 .build();
 
         when(vciCacheService.getPreAuthCodeData(preAuthCode)).thenReturn(codeData);
-        when(vciCacheService.claimPreAuthCode(preAuthCode)).thenReturn(false);
+        when(vciCacheService.claimPreAuthCodeIfUnexpired(eq(preAuthCode), anyLong()))
+                .thenReturn(VCICacheService.PreAuthCodeClaimResult.INVALID_OR_USED);
 
         CertifyException exception = assertThrows(CertifyException.class,
                 () -> preAuthorizedCodeService.exchangePreAuthorizedCode(tokenRequest));
@@ -454,7 +459,8 @@ public class PreAuthorizedCodeServiceTest {
                 .build();
 
         when(vciCacheService.getPreAuthCodeData(preAuthCode)).thenReturn(codeData);
-        when(vciCacheService.claimPreAuthCode(preAuthCode)).thenReturn(true);
+        when(vciCacheService.claimPreAuthCodeIfUnexpired(eq(preAuthCode), anyLong()))
+                .thenReturn(VCICacheService.PreAuthCodeClaimResult.CLAIMED);
 
         CertifyException exception = assertThrows(CertifyException.class,
                 () -> preAuthorizedCodeService.exchangePreAuthorizedCode(tokenRequest));
@@ -478,7 +484,8 @@ public class PreAuthorizedCodeServiceTest {
                 .build();
 
         when(vciCacheService.getPreAuthCodeData(preAuthCode)).thenReturn(codeData);
-        when(vciCacheService.claimPreAuthCode(preAuthCode)).thenReturn(true);
+        when(vciCacheService.claimPreAuthCodeIfUnexpired(eq(preAuthCode), anyLong()))
+                .thenReturn(VCICacheService.PreAuthCodeClaimResult.CLAIMED);
 
         CertifyException exception = assertThrows(CertifyException.class,
                 () -> preAuthorizedCodeService.exchangePreAuthorizedCode(tokenRequest));

--- a/certify-service/src/test/java/io/mosip/certify/services/PreAuthorizedCodeServiceTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/PreAuthorizedCodeServiceTest.java
@@ -408,12 +408,13 @@ public class PreAuthorizedCodeServiceTest {
                 .build();
 
         when(vciCacheService.getPreAuthCodeData(preAuthCode)).thenReturn(codeData);
-        when(vciCacheService.claimPreAuthCode(preAuthCode)).thenReturn(true);
 
         CertifyException exception = assertThrows(CertifyException.class,
                 () -> preAuthorizedCodeService.exchangePreAuthorizedCode(tokenRequest));
 
         Assert.assertEquals("pre_auth_code_expired", exception.getErrorCode());
+        // Expired codes must never be consumed — claiming would corrupt single-use semantics
+        verify(vciCacheService, never()).claimPreAuthCode(preAuthCode);
     }
 
     @Test


### PR DESCRIPTION
This PR fixes validation order in pre-auth token exchange by checking expiry before claiming the code as used.

### Impact
- Prevents expired pre-auth codes from being consumed
- Returns the correct expiry behavior instead of treating it like reuse
- Improves reliability of the student QR scan flow

### Issue
Closes #869

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation flow for pre-authorized codes to properly reject expired codes without consuming them.
  * Enhanced security by enforcing strict single-use semantics for pre-authorized codes and preventing unnecessary consumption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->