### PR TITLE
Fix access token validation by enabling b64 jws header

### DIFF
--- a/certify-service/src/main/java/io/mosip/certify/utils/AccessTokenJwtUtil.java
+++ b/certify-service/src/main/java/io/mosip/certify/utils/AccessTokenJwtUtil.java
@@ -118,8 +118,8 @@ public class AccessTokenJwtUtil {
             signatureRequest.setIncludePayload(true);
             signatureRequest.setIncludeCertificate(false);
             signatureRequest.setIncludeCertHash(false);
-            signatureRequest.setValidateJson(false);
-            signatureRequest.setB64JWSHeaderParam(false);
+            signatureRequest.setValidateJson(true);
+            signatureRequest.setB64JWSHeaderParam(true);
             signatureRequest.setSignAlgorithm("RS256");
 
             // Sign using keymanager service


### PR DESCRIPTION
### Description

- setValidateJson value to true in signatureRequest
- setB64JWSHeaderParam value to true in signatureRequest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated JWT token generation to improve validation and encoding standards compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->