### PR TITLE
fix: map c_nonce parse error to invalid_request instead of unknown_error

### DIFF
--- a/certify-core/src/main/java/io/mosip/certify/core/dto/CredentialRequest.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/dto/CredentialRequest.java
@@ -62,9 +62,4 @@ public class CredentialRequest {
      * a proof of possession of key material
      */
     private String c_nonce;
-
-    /**
-     * JSON integer denoting the lifetime in seconds of the c_nonce
-     */
-    private Integer c_nonce_expires_in;
 }

--- a/certify-core/src/main/java/io/mosip/certify/core/dto/CredentialRequest.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/dto/CredentialRequest.java
@@ -10,6 +10,7 @@ import io.mosip.certify.core.constants.VCIErrorConstants;
 import jakarta.validation.Valid;
 import lombok.Data;
 import java.util.List;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -17,6 +18,7 @@ import jakarta.validation.constraints.NotNull;
 import java.util.Map;
 
 @Data
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class CredentialRequest {
 
     /**
@@ -54,4 +56,15 @@ public class CredentialRequest {
     private Map<String,Object> claims;
 
     String vct;
+
+    /**
+     * JSON string containing a nonce to be used to create
+     * a proof of possession of key material
+     */
+    private String c_nonce;
+
+    /**
+     * JSON integer denoting the lifetime in seconds of the c_nonce
+     */
+    private Integer c_nonce_expires_in;
 }

--- a/certify-service/src/main/java/io/mosip/certify/advice/ExceptionHandlerAdvice.java
+++ b/certify-service/src/main/java/io/mosip/certify/advice/ExceptionHandlerAdvice.java
@@ -153,6 +153,12 @@ public class ExceptionHandlerAdvice extends ResponseEntityExceptionHandler imple
     }
 
     public ResponseEntity<VCError> handleVCIControllerExceptions(Exception ex) {
+        if (ex instanceof HttpMessageNotReadableException) {
+            return new ResponseEntity<>(
+                    getVCErrorDto(INVALID_REQUEST, ex.getMessage()),
+                    HttpStatus.BAD_REQUEST
+            );
+        }
         if(ex instanceof MethodArgumentNotValidException) {
             FieldError fieldError = ((MethodArgumentNotValidException) ex).getBindingResult().getFieldError();
             String message = fieldError != null ? fieldError.getDefaultMessage() : ex.getMessage();


### PR DESCRIPTION
## Description

When a client sends a credential issuance request containing the `c_nonce` field (which is a valid field as per the OpenID4VCI specification), the API was throwing an unhandled Jackson JSON parse error. This error was bubbling up as a generic `unknown_error` with a 500 Internal Server Error status, which is neither informative nor spec-compliant.

## Root Cause

The `CredentialRequest` DTO did not have the `c_nonce` and `c_nonce_expires_in` fields defined, causing Jackson's deserializer to fail when it encountered these fields in the request body. Additionally, the `ExceptionHandlerAdvice` was not explicitly handling `HttpMessageNotReadableException`, which meant any JSON parse error would fall through to the generic `unknown_error` handler.

## Changes Made

- Added `c_nonce` (String) and `c_nonce_expires_in` (Integer) fields to `CredentialRequest` DTO with proper JavaDoc as per the OpenID4VCI specification
- Added `@JsonIgnoreProperties(ignoreUnknown = true)` annotation to `CredentialRequest` to make the API resilient to any additional unknown fields in the future without crashing
- Added explicit handling for `HttpMessageNotReadableException` in `ExceptionHandlerAdvice` to return a proper `invalid_request` error with 400 Bad Request status instead of the generic 500 unknown_error

## How It Solves The Problem

Previously, when `c_nonce` arrived in the request, Jackson would throw an `HttpMessageNotReadableException` which was not caught explicitly, causing it to be swallowed by the generic error handler and returned as `unknown_error`. Now, the DTO officially supports `c_nonce` and `c_nonce_expires_in` as valid fields. Even if any other unknown field arrives, `@JsonIgnoreProperties` ensures the request is processed gracefully. And if a truly malformed JSON arrives, the exception handler now maps it correctly to `invalid_request` with a 400 status.

## Impact

- Clients sending valid OpenID4VCI requests with `c_nonce` will no longer receive a confusing 500 unknown_error response
- Error responses are now more meaningful and spec-compliant, making debugging easier for API consumers
- The API is more resilient to evolving OpenID4VCI spec changes that may introduce new fields in the future

## Related Issue
Closes #878

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for malformed credential requests with standardized error responses and clearer feedback messages.

* **New Features**
  * Credential requests now support additional security parameters for enhanced validation and processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/inji/inji-certify/pull/882)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->