### PR TITLE
Add CLAUDE.md and AGENTS.md for AI agent context

### DIFF
--- a/.claude/commands/raise-pr.md
+++ b/.claude/commands/raise-pr.md
@@ -1,0 +1,75 @@
+# raise-pr
+
+Create a PR from a new branch in the fork to the upstream repo.
+
+## Rules (always enforce, no exceptions)
+- **Never push to `upstream`** — its push URL is intentionally set to `DISABLED`.
+- **Always push to `origin`** (the personal fork).
+- **Always target `upstream/develop`** as the PR base branch, unless the user explicitly specifies a different base.
+- **No co-author lines** in commit messages (no `Co-Authored-By:` trailers).
+- **No Claude attribution** in the PR body (no `🤖 Generated with Claude Code` footer).
+- Branch names must follow the pattern: `feat/`, `fix/`, `docs/`, or `chore/` prefix.
+
+## Steps
+
+1. **Resolve remotes dynamically** — derive all values from git at runtime:
+   ```
+   git remote get-url origin    # e.g. https://github.com/alice/inji-certify.git
+   git remote get-url upstream  # e.g. https://github.com/inji/inji-certify.git
+   ```
+   Parse these URLs to extract:
+   - `FORK_OWNER` — the owner segment of the `origin` URL (e.g. `alice`)
+   - `UPSTREAM_OWNER/UPSTREAM_REPO` — from the `upstream` URL (e.g. `inji/inji-certify`)
+
+2. **Verify push to upstream is disabled**:
+   ```
+   git remote -v
+   ```
+   Confirm the `upstream` push URL shows `DISABLED`. Abort if it does not.
+
+3. **Fetch latest base branch** from upstream (default: `develop`):
+   ```
+   git fetch upstream develop
+   ```
+
+4. **Create a branch from upstream/develop**:
+   ```
+   git checkout -b <branch-name> upstream/develop
+   ```
+   - Derive the branch name from the change being made.
+   - Ask the user for a branch name if it is not clear from context.
+
+5. **Stage and commit the changes** (all uncommitted/untracked work):
+   ```
+   git add <files>
+   git commit -m "<concise subject line>
+
+   <optional body explaining what and why>"
+   ```
+   - Do **not** add any `Co-Authored-By:` or attribution trailers.
+
+6. **Push to the fork**:
+   ```
+   git push origin <branch-name>
+   ```
+
+7. **Create the PR** using the dynamically resolved values:
+   ```
+   gh pr create \
+     --repo <UPSTREAM_OWNER>/<UPSTREAM_REPO> \
+     --base develop \
+     --head <FORK_OWNER>:<branch-name> \
+     --title "<PR title>" \
+     --body "<PR description>"
+   ```
+   - PR body should describe *what* changed and *why*. No Claude attribution footer.
+
+8. **Report the PR URL** to the user.
+
+## Arguments
+
+Optional argument `$ARGUMENTS` may contain:
+- A custom base branch (e.g. `master`) — if provided, use it instead of `develop`.
+- A branch name or short description to use for naming the feature branch.
+
+Parse `$ARGUMENTS` and apply accordingly before starting.

--- a/.claude/commands/raise-pr.md
+++ b/.claude/commands/raise-pr.md
@@ -42,10 +42,11 @@ Create a PR from a new branch in the fork to the upstream repo.
 5. **Stage and commit the changes** (all uncommitted/untracked work):
    ```
    git add <files>
-   git commit -m "<concise subject line>
+   git commit -s -m "<concise subject line>
 
    <optional body explaining what and why>"
    ```
+   - The `-s` flag adds a `Signed-off-by:` trailer (required by inji).
    - Do **not** add any `Co-Authored-By:` or attribution trailers.
 
 6. **Push to the fork**:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This file describes the agent-relevant context for Inji Certify — its architec
 
 ## Project Identity
 
-Inji Certify is an **OpenID4VCI (draft 13) compliant Verifiable Credential issuance service**. It signs and issues credentials in W3C JSON-LD (`ldp_vc`), SD-JWT (`vc+sd-jwt`), and mock mDL (`mso_mdoc`) formats. It is a Spring Boot 3.2.3 / Java 21 multi-module Maven project licensed under MPL 2.0.
+Inji Certify is an **OpenID4VCI 1.0 compliant Verifiable Credential issuance service**. It signs and issues credentials in W3C JSON-LD (`ldp_vc`), SD-JWT (`dc+sd-jwt`), and mock mDL (`mso_mdoc`) formats. It is a Spring Boot 3.2.3 / Java 21 multi-module Maven project licensed under MPL 2.0.
 
 - **GitHub**: https://github.com/inji/inji-certify
 - **Docs**: https://docs.inji.io/inji-certify/overview
@@ -53,7 +53,7 @@ Certify uses a **runtime plugin model**. Two plugin modes exist, set via `mosip.
 | Format | Class | Notes |
 |---|---|---|
 | `ldp_vc` | `W3CJsonLD` | JSON-LD with linked-data proofs, supports revocation |
-| `vc+sd-jwt` | `SDJWT` | Selective Disclosure JWT |
+| `dc+sd-jwt` | `SDJWT` | Selective Disclosure JWT (renamed from `vc+sd-jwt` in OpenID4VCI 1.0) |
 | `mso_mdoc` | `MDocCredential` | Mock only; full implementation pending |
 
 `CredentialFactory` selects the right class based on `credentialFormat` in the `credential_config`.
@@ -70,7 +70,8 @@ Certify uses a **runtime plugin model**. Two plugin modes exist, set via `mosip.
 
 | Controller | Prefix | Purpose |
 |---|---|---|
-| `VCIssuanceController` | `/issuance/credential` | Core VC issuance (OpenID4VCI) |
+| `VCIssuanceController` | `/issuance/credential` | Core VC issuance (OpenID4VCI 1.0 — single unified endpoint) |
+| `NonceController` | `/nonce` | Dedicated `POST /nonce` endpoint for c_nonce generation (OpenID4VCI 1.0; no longer returned in token response) |
 | `WellKnownController` | `/.well-known/` | Issuer metadata, DID document, JWKS |
 | `CredentialConfigController` | `/credential-configurations` | CRUD for credential type configs |
 | `OAuthController` | `/oauth/` | Token issuance and IAR (Interactive Auth Request) |
@@ -79,6 +80,8 @@ Certify uses a **runtime plugin model**. Two plugin modes exist, set via `mosip.
 | `CredentialLedgerController` | `/ledger-search` | Search issued credentials |
 | `RenderingTemplateController` | `/rendering-template` | SVG/HTML templates for credential display |
 | `SystemInfoController` | `/system-info/certificate` | Fetch signing certificates (key export) |
+
+> **Note:** The vd11 and vd12 versioned issuance endpoints (`/issuance/vd11/credential`, `/issuance/vd12/credential`) and `CredentialConfigControllerV2` have been removed as part of the OpenID4VCI 1.0 cleanup.
 
 ---
 
@@ -159,7 +162,8 @@ Switch to Redis by setting `spring.cache.type=redis` and configuring `spring.dat
 - Credential config validation is done at the API level (`CredentialConfigController`) and enforced again at issuance time.
 - `didUrl` in `credential_config` can differ from `mosip.certify.data-provider-plugin.did-url` — the former is per-credential-type, the latter is the issuer-level DID.
 - Velocity templates are stored in DB (`rendering_template` table) and referenced by UUID in `credential_config`.
-- The `kid` prefix in SD-JWT credentials is configurable via `mosip.kernel.keymanager.signature.kid.prepend`.
+- The `kid` prefix in SD-JWT (`dc+sd-jwt`) credentials is configurable via `mosip.kernel.keymanager.signature.kid.prepend`.
+- c_nonce is **no longer returned in the access token response** (OpenID4VCI 1.0); clients must fetch it explicitly via `POST /nonce` (`NonceController` / `NonceServiceImpl`).
 - DID document is auto-generated at `/.well-known/did.json` — copy and host it externally for VC verification.
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,187 @@
+# AGENTS.md
+
+This file describes the agent-relevant context for Inji Certify — its architecture, plugin model, key flows, and conventions that agents need to work effectively in this codebase.
+
+---
+
+## Project Identity
+
+Inji Certify is an **OpenID4VCI (draft 13) compliant Verifiable Credential issuance service**. It signs and issues credentials in W3C JSON-LD (`ldp_vc`), SD-JWT (`vc+sd-jwt`), and mock mDL (`mso_mdoc`) formats. It is a Spring Boot 3.2.3 / Java 21 multi-module Maven project licensed under MPL 2.0.
+
+- **GitHub**: https://github.com/inji/inji-certify
+- **Docs**: https://docs.inji.io/inji-certify/overview
+- **API Docs**: https://mosip.stoplight.io/docs/inji-certify
+- **Base URL** (local): `http://localhost:8090/v1/certify`
+
+---
+
+## Maven Modules
+
+| Module | Role |
+|---|---|
+| `certify-parent` | Root POM; manages dependency versions and build plugins |
+| `certify-service` | Spring Boot application — all controllers, services, credential generators, filters, DB entities |
+| `certify-core` | Shared DTOs, constants, exception types, and service interfaces (`spi.*`) |
+| `certify-integration-api` | Plugin SPI interfaces (`DataProviderPlugin`, `VCIssuancePlugin`, `AuditPlugin`) and DTOs published to plugin authors |
+
+---
+
+## Plugin Architecture (Critical to Understand)
+
+Certify uses a **runtime plugin model**. Two plugin modes exist, set via `mosip.certify.plugin-mode`:
+
+### `DataProvider` mode (recommended default)
+- Plugin implements `certify-integration-api/.../spi/DataProviderPlugin`:
+  ```java
+  JSONObject fetchData(Map<String, Object> identityDetails) throws DataProviderExchangeException;
+  ```
+- Certify handles: templating (Apache Velocity), credential format construction, proof generation, signing.
+- Plugin dependency is added to `certify-service/pom.xml` and loaded via Spring component scan (`mosip.certify.integration.scan-base-package`).
+
+### `VCIssuance` mode (proxy/pass-through)
+- Plugin implements `certify-integration-api/.../spi/VCIssuancePlugin` — returns a fully signed VC itself.
+- Certify acts as an OpenID4VCI proxy. Used when integrating with pre-existing VC stacks (e.g., MOSIP IDA, Sunbird RC).
+
+### Plugin Loading at Runtime (Docker/Helm)
+- Plugin JARs can be mounted into the container's `loader_path/certify/` directory — no rebuild needed.
+- `certify-service-with-plugins` image pre-bundles mock plugins.
+
+---
+
+## Credential Formats
+
+| Format | Class | Notes |
+|---|---|---|
+| `ldp_vc` | `W3CJsonLD` | JSON-LD with linked-data proofs, supports revocation |
+| `vc+sd-jwt` | `SDJWT` | Selective Disclosure JWT |
+| `mso_mdoc` | `MDocCredential` | Mock only; full implementation pending |
+
+`CredentialFactory` selects the right class based on `credentialFormat` in the `credential_config`.
+
+---
+
+## Proof Generation
+
+`ProofGeneratorFactory` selects a proof generator from the `signatureCryptoSuite` in `credential_config`. Supported suites: `Ed25519Signature2018/2020`, `EcdsaSecp256r1Signature2019`, `EcdsaSecp256k1Signature2019`, `EcdsaKoblitzSignature2016`, `RsaSignature2018`, `ecdsa-rdfc-2019`, `ecdsa-jcs-2019`, `eddsa-rdfc-2022`, `eddsa-jcs-2022`.
+
+---
+
+## Key Controllers and Endpoints
+
+| Controller | Prefix | Purpose |
+|---|---|---|
+| `VCIssuanceController` | `/issuance/credential` | Core VC issuance (OpenID4VCI) |
+| `WellKnownController` | `/.well-known/` | Issuer metadata, DID document, JWKS |
+| `CredentialConfigController` | `/credential-configurations` | CRUD for credential type configs |
+| `OAuthController` | `/oauth/` | Token issuance and IAR (Interactive Auth Request) |
+| `PreAuthorizedCodeController` | `/credential-offer-data/`, `/pre-authorized-data/` | Pre-auth code flow |
+| `CredentialStatusController` | `/credentials/status`, `/credentials/status-list/{id}` | VC revocation/suspension |
+| `CredentialLedgerController` | `/ledger-search` | Search issued credentials |
+| `RenderingTemplateController` | `/rendering-template` | SVG/HTML templates for credential display |
+| `SystemInfoController` | `/system-info/certificate` | Fetch signing certificates (key export) |
+
+---
+
+## Core Service Flow (DataProvider mode)
+
+```
+Client → VCIssuanceController → CertifyIssuanceServiceImpl
+  → AccessTokenValidationFilter (JWT validation against AuthZ server JWKS)
+  → CredentialRequestValidator (format-specific: LdpVc / SdJwt / MsoMdoc)
+  → DataProviderPlugin.fetchData()
+  → VelocityTemplatingEngine (Velocity template from credential_config)
+  → CredentialFactory.createCredential()
+  → [Optional] StatusListCredentialService.addCredentialStatus()  ← revocation
+  → ProofGeneratorFactory → ProofGenerator.addProof()
+  → CredentialLedgerService.save()  ← if ledger enabled
+  → return CredentialResponse
+```
+
+---
+
+## Database Schema
+
+PostgreSQL (`inji_certify` DB, `certify` schema). Key tables:
+
+| Table | Purpose |
+|---|---|
+| `credential_config` | Registered credential types and their issuance config |
+| `ledger` | Audit log of every issued credential |
+| `status_list_credential` | BitstringStatusList VCs for revocation |
+| `status_list_available_indices` | Index pool for status list slots |
+| `credential_status_transaction` | Per-credential status change events |
+| `rendering_template` | SVG/HTML templates referenced by DIDs |
+| `key_alias`, `key_store`, `ca_cert_store` | MOSIP key manager tables |
+
+A `StatusListUpdateBatchJob` runs every minute to re-sign updated status list credentials.
+
+---
+
+## Configuration Properties (Most Important)
+
+```properties
+# Plugin selection
+mosip.certify.plugin-mode=DataProvider          # or VCIssuance
+mosip.certify.integration.data-provider-plugin=MockCSVDataProviderPlugin
+mosip.certify.integration.scan-base-package=io.mosip.certify.mock.integration
+
+# AuthZ server (e.g., eSignet)
+mosip.certify.authorization.url=http://localhost:8088
+mosip.certify.authn.issuer-uri=...
+mosip.certify.authn.jwk-set-uri=...
+
+# Issuer identity
+mosip.certify.domain.url=http://localhost:8090
+mosip.certify.data-provider-plugin.did-url=did:web:...
+
+# DB
+spring.datasource.url=jdbc:postgresql://localhost:5432/inji_certify?currentSchema=certify
+
+# Credential status (revocation)
+mosip.certify.data-provider-plugin.credential-status.allowed-status-purposes={'revocation'}
+mosip.certify.issuer.ledger-enabled=true
+```
+
+---
+
+## Caching
+
+Certify uses Spring Cache with either `simple` (in-memory) or Redis backend. Cache names:
+`userinfo`, `vcissuance`, `templatecache`, `certificatedatacache`, `credentialConfig`, `renderTemplate`, `jwks`, `preAuthCodeCache`, `credentialOfferCache`, `issuerMetadataCache`.
+
+Switch to Redis by setting `spring.cache.type=redis` and configuring `spring.data.redis.*`.
+
+---
+
+## Key Design Conventions
+
+- All property names use the `mosip.certify.*` namespace.
+- Credential config validation is done at the API level (`CredentialConfigController`) and enforced again at issuance time.
+- `didUrl` in `credential_config` can differ from `mosip.certify.data-provider-plugin.did-url` — the former is per-credential-type, the latter is the issuer-level DID.
+- Velocity templates are stored in DB (`rendering_template` table) and referenced by UUID in `credential_config`.
+- The `kid` prefix in SD-JWT credentials is configurable via `mosip.kernel.keymanager.signature.kid.prepend`.
+- DID document is auto-generated at `/.well-known/did.json` — copy and host it externally for VC verification.
+
+---
+
+## External Dependencies
+
+- **eSignet** (or compatible OIDC server): acts as the OAuth 2.0 authorization server.
+- **MOSIP Key Manager**: signs VCs via HSM/SoftHSM; key config in `mosip.kernel.keymanager.*`.
+- **digital-credential-plugins** repo: provides mock and reference plugin implementations.
+
+---
+
+## References
+
+- [Plugin interfaces](./certify-integration-api/src/main/java/io/mosip/certify/api/spi/)
+- [Credential format classes](./certify-service/src/main/java/io/mosip/certify/credential/)
+- [Proof generators](./certify-service/src/main/java/io/mosip/certify/proofgenerators/) *(if present)*
+- [Sample local config](./certify-service/src/main/resources/application-local.properties)
+- [DB scripts](./db_scripts/)
+- [Docker Compose quickstart](./docker-compose/docker-compose-injistack/README.md)
+- [Local dev guide](./docs/Local-Development.md)
+- [Credential config guide](./docs/Credential-Issuer-Configuration.md)
+- [VCIssuance vs DataProvider](./docs/VCIssuance-vs-DataProvider.md)
+- [SD-JWT support](./docs/SD-JWT-Support.md)
+- [VC Revocation](./docs/VC-Revocation-Support.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+All architectural details, build commands, plugin conventions, configuration properties, and workflow guidance are maintained in [AGENTS.md](./AGENTS.md).


### PR DESCRIPTION
## Summary

Adds documentation files to help AI coding agents (Claude Code and others) work effectively in this repository, aligned with the OpenID4VCI 1.0 changes in the `develop` branch.

## Files Added

- **AGENTS.md** — Comprehensive architecture reference covering:
  - Plugin model (DataProvider vs VCIssuance modes) with SPI method signatures
  - Credential formats — including the `vc+sd-jwt` → `dc+sd-jwt` rename per OpenID4VCI 1.0
  - Full VC issuance request flow with every component named
  - New `NonceController` (`POST /nonce`) and removal of vd11/vd12 endpoints
  - Key controllers, endpoints, and services
  - Database schema and caching
  - Key configuration properties and design conventions
  - External dependency relationships (eSignet, MOSIP Key Manager, digital-credential-plugins)

- **CLAUDE.md** — Minimal entry point for Claude Code that delegates to AGENTS.md; all content is maintained in one place.

- **.claude/commands/raise-pr.md** — Project-level `/raise-pr` slash command that encodes the contribution workflow for this repo:
  - Always branches from `upstream/develop`
  - Always pushes to the personal fork (`origin`), never to `upstream`
  - Resolves fork owner and upstream repo dynamically from git remotes
  - Always signs off commits with `-s` (DCO requirement)
  - No co-author or attribution trailers