### PR TITLE
[MOSIP-37808] Updated DB attributes for inji-certify

### DIFF
--- a/db_scripts/init_values.yaml
+++ b/db_scripts/init_values.yaml
@@ -4,7 +4,11 @@
 databases:
   inji_certify:
     enabled: true
-    host: "postgres-postgresql.postgres"
+    scriptsDir: inji_certify       # fixed - must match db_scripts/ folder in repo
+    dbName: inji_certify           # customize e.g. inji_certify02
+    dbUser: injicertifyuser        # customize e.g. injicertifyuser02
+    defaultDb: postgres
+    host: "postgres-postgresql"
     port: 5432
     su:
       user: postgres

--- a/db_scripts/init_values.yaml
+++ b/db_scripts/init_values.yaml
@@ -6,7 +6,7 @@ databases:
     enabled: true
     scriptsDir: inji_certify       # fixed - must match db_scripts/ folder in repo
     dbName: inji_certify           # customize e.g. inji_certify02
-    dbUser: injicertifyuser        # customize e.g. injicertifyuser02
+    dbUser: certifyuser        # customize e.g. injicertifyuser02
     defaultDb: postgres
     host: "postgres-postgresql"
     port: 5432

--- a/db_scripts/inji_certify/db.sql
+++ b/db_scripts/inji_certify/db.sql
@@ -3,7 +3,7 @@
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 -- -------------------------------------------------------------------------------------------------
 
-CREATE DATABASE inji_certify
+CREATE DATABASE :mosipdbname
 	ENCODING = 'UTF8' 
 	LC_COLLATE = 'en_US.UTF-8' 
 	LC_CTYPE = 'en_US.UTF-8' 
@@ -11,12 +11,12 @@ CREATE DATABASE inji_certify
 	OWNER = postgres
 	TEMPLATE  = template0;
 
-COMMENT ON DATABASE inji_certify IS 'Certify related data is stored in this database';
+COMMENT ON DATABASE :mosipdbname IS 'Certify related data is stored in this database';
 
-\c inji_certify postgres
+\c :mosipdbname postgres
 
 DROP SCHEMA IF EXISTS certify CASCADE;
 CREATE SCHEMA certify;
 ALTER SCHEMA certify OWNER TO postgres;
-ALTER DATABASE inji_certify SET search_path TO certify,pg_catalog,public;
+ALTER DATABASE :mosipdbname SET search_path TO certify,pg_catalog,public;
 

--- a/db_scripts/inji_certify/ddl.sql
+++ b/db_scripts/inji_certify/ddl.sql
@@ -1,4 +1,4 @@
-\c inji_certify
+\c :mosipdbname
 
 \ir ddl/certify-key_alias.sql
 \ir ddl/certify-key_policy_def.sql

--- a/db_scripts/inji_certify/deploy.properties
+++ b/db_scripts/inji_certify/deploy.properties
@@ -3,4 +3,5 @@ DB_PORT=5432
 SU_USER=postgres
 DEFAULT_DB_NAME=postgres
 MOSIP_DB_NAME=inji_certify
+DB_UNAME=certifyuser
 DML_FLAG=1

--- a/db_scripts/inji_certify/deploy.sh
+++ b/db_scripts/inji_certify/deploy.sh
@@ -21,24 +21,24 @@ CONN=$(PGPASSWORD=$SU_USER_PWD psql -v ON_ERROR_STOP=1 --username=$SU_USER --hos
 echo "Terminated connections"
 
 ## Drop db and role
-PGPASSWORD=$SU_USER_PWD psql -v ON_ERROR_STOP=1 --username=$SU_USER --host=$DB_SERVERIP --port=$DB_PORT --dbname=$DEFAULT_DB_NAME -f drop_db.sql 
-PGPASSWORD=$SU_USER_PWD psql -v ON_ERROR_STOP=1 --username=$SU_USER --host=$DB_SERVERIP --port=$DB_PORT --dbname=$DEFAULT_DB_NAME -f drop_role.sql 
+PGPASSWORD=$SU_USER_PWD psql -v ON_ERROR_STOP=1 --username=$SU_USER --host=$DB_SERVERIP --port=$DB_PORT --dbname=$DEFAULT_DB_NAME -f drop_db.sql -v mosipdbname=$MOSIP_DB_NAME
+PGPASSWORD=$SU_USER_PWD psql -v ON_ERROR_STOP=1 --username=$SU_USER --host=$DB_SERVERIP --port=$DB_PORT --dbname=$DEFAULT_DB_NAME -f drop_role.sql -v dbuname=$DB_UNAME
 
 ## Create users
 echo `date "+%m/%d/%Y %H:%M:%S"` ": Creating database users" | tee
-PGPASSWORD=$SU_USER_PWD psql -v ON_ERROR_STOP=1 --username=$SU_USER --host=$DB_SERVERIP --port=$DB_PORT --dbname=$DEFAULT_DB_NAME -f role_dbuser.sql -v dbuserpwd=\'$DBUSER_PWD\' 
+PGPASSWORD=$SU_USER_PWD psql -v ON_ERROR_STOP=1 --username=$SU_USER --host=$DB_SERVERIP --port=$DB_PORT --dbname=$DEFAULT_DB_NAME -f role_dbuser.sql -v dbuserpwd=\'$DBUSER_PWD\' -v dbuname=$DB_UNAME
 
 ## Create DB
-PGPASSWORD=$SU_USER_PWD psql -v ON_ERROR_STOP=1 --username=$SU_USER --host=$DB_SERVERIP --port=$DB_PORT --dbname=$DEFAULT_DB_NAME -f db.sql 
-PGPASSWORD=$SU_USER_PWD psql -v ON_ERROR_STOP=1 --username=$SU_USER --host=$DB_SERVERIP --port=$DB_PORT --dbname=$DEFAULT_DB_NAME -f ddl.sql 
+PGPASSWORD=$SU_USER_PWD psql -v ON_ERROR_STOP=1 --username=$SU_USER --host=$DB_SERVERIP --port=$DB_PORT --dbname=$DEFAULT_DB_NAME -f db.sql -v mosipdbname=$MOSIP_DB_NAME
+PGPASSWORD=$SU_USER_PWD psql -v ON_ERROR_STOP=1 --username=$SU_USER --host=$DB_SERVERIP --port=$DB_PORT --dbname=$DEFAULT_DB_NAME -f ddl.sql -v mosipdbname=$MOSIP_DB_NAME -v dbuname=$DB_UNAME
 
 ## Grants
-PGPASSWORD=$SU_USER_PWD psql -v ON_ERROR_STOP=1 --username=$SU_USER --host=$DB_SERVERIP --port=$DB_PORT --dbname=$DEFAULT_DB_NAME -f grants.sql 
+PGPASSWORD=$SU_USER_PWD psql -v ON_ERROR_STOP=1 --username=$SU_USER --host=$DB_SERVERIP --port=$DB_PORT --dbname=$DEFAULT_DB_NAME -f grants.sql -v mosipdbname=$MOSIP_DB_NAME -v dbuname=$DB_UNAME
 
 ## Populate tables
 if [ ${DML_FLAG} == 1 ]
 then
     echo `date "+%m/%d/%Y %H:%M:%S"` ": Deploying DML for ${MOSIP_DB_NAME} database" 
-    PGPASSWORD=$SU_USER_PWD psql -v ON_ERROR_STOP=1 --username=$SU_USER --host=$DB_SERVERIP --port=$DB_PORT --dbname=$DEFAULT_DB_NAME -a -b -f dml.sql 
+    PGPASSWORD=$SU_USER_PWD psql -v ON_ERROR_STOP=1 --username=$SU_USER --host=$DB_SERVERIP --port=$DB_PORT --dbname=$DEFAULT_DB_NAME -a -b -f dml.sql -v mosipdbname=$MOSIP_DB_NAME
 fi
 

--- a/db_scripts/inji_certify/dml.sql
+++ b/db_scripts/inji_certify/dml.sql
@@ -3,7 +3,7 @@
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 -- -------------------------------------------------------------------------------------------------
 
-\c inji_certify
+\c :mosipdbname
 
 
 \COPY certify.key_policy_def (APP_ID,KEY_VALIDITY_DURATION,PRE_EXPIRE_DAYS,ACCESS_ALLOWED,IS_ACTIVE,CR_BY,CR_DTIMES) FROM './dml/certify-key_policy_def.csv' delimiter ',' HEADER  csv;

--- a/db_scripts/inji_certify/drop_db.sql
+++ b/db_scripts/inji_certify/drop_db.sql
@@ -3,5 +3,5 @@
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 -- -------------------------------------------------------------------------------------------------
 
-DROP DATABASE IF EXISTS inji_certify;
+DROP DATABASE IF EXISTS :mosipdbname;
 

--- a/db_scripts/inji_certify/drop_role.sql
+++ b/db_scripts/inji_certify/drop_role.sql
@@ -3,4 +3,4 @@
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 -- -------------------------------------------------------------------------------------------------
 
-drop role if exists certifyuser;
+drop role if exists :dbuname;

--- a/db_scripts/inji_certify/grants.sql
+++ b/db_scripts/inji_certify/grants.sql
@@ -3,27 +3,27 @@
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 -- -------------------------------------------------------------------------------------------------
 
-\c inji_certify
+\c :mosipdbname
 
 GRANT CONNECT
-   ON DATABASE inji_certify
-   TO certifyuser;
+   ON DATABASE :mosipdbname
+   TO :dbuname;
 
 GRANT USAGE
    ON SCHEMA certify
-   TO certifyuser;
+   TO :dbuname;
 
 GRANT SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES
    ON ALL TABLES IN SCHEMA certify
-   TO certifyuser;
+   TO :dbuname;
 
 ALTER DEFAULT PRIVILEGES IN SCHEMA certify
-	GRANT SELECT,INSERT,UPDATE,DELETE,REFERENCES ON TABLES TO certifyuser;
+	GRANT SELECT,INSERT,UPDATE,DELETE,REFERENCES ON TABLES TO :dbuname;
 
 GRANT USAGE, SELECT
    ON ALL SEQUENCES IN SCHEMA certify
-   TO certifyuser;
+   TO :dbuname;
 
 ALTER DEFAULT PRIVILEGES IN SCHEMA certify
-   GRANT USAGE, SELECT ON SEQUENCES TO certifyuser;
+   GRANT USAGE, SELECT ON SEQUENCES TO :dbuname;
 

--- a/db_scripts/inji_certify/role_dbuser.sql
+++ b/db_scripts/inji_certify/role_dbuser.sql
@@ -3,7 +3,7 @@
 -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 -- -------------------------------------------------------------------------------------------------
 
-CREATE ROLE certifyuser WITH
+CREATE ROLE :dbuname WITH
 	INHERIT
 	LOGIN
 	PASSWORD :dbuserpwd;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Parameterized database setup to accept configurable database name, username and password instead of hardcoded values.
  * Deployment flow updated to pass those configuration variables to all database scripts for consistent execution.
  * Default database user set to certifyuser and the database host value adjusted in initialization configuration for correct connectivity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/inji/inji-certify/pull/885?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->