### PR TITLE
[INJICERT-1159_release-1.0.x] changed Ed25519 to EdDSA for cryptographic binding methods supported

### DIFF
--- a/certify-service/src/main/java/io/mosip/certify/proof/JwtProofValidator.java
+++ b/certify-service/src/main/java/io/mosip/certify/proof/JwtProofValidator.java
@@ -119,8 +119,7 @@ public class JwtProofValidator implements ProofValidator {
                 boolean verified = jwt.verify(verifier);
                 claimsSetVerifier.verify(jwt.getJWTClaimsSet(), null);
                 return verified;
-            } else if (JWSAlgorithm.Ed25519.equals(jwt.getHeader().getAlgorithm()) ||
-                    JWSAlgorithm.EdDSA.equals(jwt.getHeader().getAlgorithm()))
+            } else if (JWSAlgorithm.EdDSA.equals(jwt.getHeader().getAlgorithm()))
             {
                 Ed25519Verifier verifier = new Ed25519Verifier(jwk.toOctetKeyPair());
                 boolean verified = jwt.verify(verifier);

--- a/certify-service/src/test/java/io/mosip/certify/proof/JwtProofValidatorTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/proof/JwtProofValidatorTest.java
@@ -40,7 +40,7 @@ class JwtProofValidatorTest {
         MockitoAnnotations.openMocks(this);
         jwtProofValidator = new JwtProofValidator();
         proofConfiguration = Map.of("jwt", Map.of(
-                "proof_signing_alg_values_supported", List.of("RS256", "ES256K", "Ed25519")));
+                "proof_signing_alg_values_supported", List.of("RS256", "ES256K", "EdDSA")));
         ReflectionTestUtils.setField(jwtProofValidator, "credentialIdentifier", "test-credential-id");
     }
 
@@ -441,7 +441,7 @@ class JwtProofValidatorTest {
                 .generate();
 
         // Create JWT header with Ed25519 algorithm and JWK
-        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.Ed25519)
+        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.EdDSA)
                 .type(new JOSEObjectType("openid4vci-proof+jwt"))
                 .keyID(keyId + Base64.getUrlEncoder().withoutPadding().encodeToString(edJWK.toPublicJWK().toJSONString().getBytes(StandardCharsets.UTF_8)))
                 .build();
@@ -525,10 +525,10 @@ class JwtProofValidatorTest {
     }
 
     @Test
-    void testValidateV2_ValidJWT_Ed25519() throws Exception {
+    void testValidateV2_ValidJWT_EdDSA() throws Exception {
         String keyId = "did:jwk:";
         String credentialProof = createValidEd25519JWT(keyId);
-        Map<String, Object> proofConfig = Map.of("jwt", Map.of("proof_signing_alg_values_supported", List.of("Ed25519")));
+        Map<String, Object> proofConfig = Map.of("jwt", Map.of("proof_signing_alg_values_supported", List.of("EdDSA")));
         boolean result = jwtProofValidator.validate("test-client", "test-nonce", credentialProof, proofConfig);
         assertTrue(result, "Expected validation to succeed for valid Ed25519 JWT");
     }

--- a/db_upgrade_script/inji_certify/sql/0.14.0_to_1.0.0_rollback.sql
+++ b/db_upgrade_script/inji_certify/sql/0.14.0_to_1.0.0_rollback.sql
@@ -29,7 +29,7 @@ SET credential_format = 'vc+sd-jwt'
 WHERE credential_format = 'dc+sd-jwt';
 
 UPDATE certify.credential_config
-SET proof_types_supported = '{"jwt": {"proof_signing_alg_values_supported": ["RS256", "ES256", "PS256", "Ed25519"]}}'::jsonb
+SET proof_types_supported = '{}'::jsonb
 WHERE proof_types_supported = '{"jwt": {"proof_signing_alg_values_supported": ["RS256", "ES256", "PS256", "EdDSA"]}}'::jsonb;
 
 -- Replace EdDSA back to Ed25519 in existing JWT proof algorithm lists

--- a/db_upgrade_script/inji_certify/sql/0.14.0_to_1.0.0_rollback.sql
+++ b/db_upgrade_script/inji_certify/sql/0.14.0_to_1.0.0_rollback.sql
@@ -27,3 +27,31 @@ COMMENT ON COLUMN certify.credential_config.credential_subject IS 'Credential Su
 UPDATE certify.credential_config
 SET credential_format = 'vc+sd-jwt'
 WHERE credential_format = 'dc+sd-jwt';
+
+UPDATE certify.credential_config
+SET proof_types_supported = '{"jwt": {"proof_signing_alg_values_supported": ["RS256", "ES256", "PS256", "Ed25519"]}}'::jsonb
+WHERE proof_types_supported = '{"jwt": {"proof_signing_alg_values_supported": ["RS256", "ES256", "PS256", "EdDSA"]}}'::jsonb;
+
+-- Replace EdDSA back to Ed25519 in existing JWT proof algorithm lists
+UPDATE certify.credential_config
+SET proof_types_supported = jsonb_set(
+        proof_types_supported,
+        '{jwt,proof_signing_alg_values_supported}',
+        (
+            SELECT COALESCE(jsonb_agg(DISTINCT val), '[]'::jsonb)
+            FROM (
+                     SELECT
+                         CASE
+                             WHEN alg = '"EdDSA"'::jsonb THEN '"Ed25519"'::jsonb
+                             ELSE alg
+                             END AS val
+                     FROM jsonb_array_elements(proof_types_supported #> '{jwt,proof_signing_alg_values_supported}') AS alg
+                 ) sub
+        )
+                            )
+WHERE proof_types_supported #> '{jwt,proof_signing_alg_values_supported}' IS NOT NULL
+  AND EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements(proof_types_supported #> '{jwt,proof_signing_alg_values_supported}') AS alg
+      WHERE alg = '"EdDSA"'::jsonb
+  );

--- a/db_upgrade_script/inji_certify/sql/0.14.0_to_1.0.0_upgrade.sql
+++ b/db_upgrade_script/inji_certify/sql/0.14.0_to_1.0.0_upgrade.sql
@@ -27,7 +27,7 @@ WHERE credential_format = 'vc+sd-jwt';
 
 UPDATE certify.credential_config
 SET proof_types_supported = '{"jwt": {"proof_signing_alg_values_supported": ["RS256", "ES256", "PS256", "EdDSA"]}}'::jsonb
-WHERE proof_types_supported = '{}'::jsonb AND credential_format = 'dc+sd-jwt';
+WHERE proof_types_supported = '{}'::jsonb;
 
 -- Replace legacy Ed25519 with EdDSA in existing JWT proof algorithm lists
 UPDATE certify.credential_config

--- a/db_upgrade_script/inji_certify/sql/0.14.0_to_1.0.0_upgrade.sql
+++ b/db_upgrade_script/inji_certify/sql/0.14.0_to_1.0.0_upgrade.sql
@@ -27,7 +27,7 @@ WHERE credential_format = 'vc+sd-jwt';
 
 UPDATE certify.credential_config
 SET proof_types_supported = '{"jwt": {"proof_signing_alg_values_supported": ["RS256", "ES256", "PS256", "EdDSA"]}}'::jsonb
-WHERE proof_types_supported = '{}'::jsonb;
+WHERE proof_types_supported = '{}'::jsonb AND credential_format = 'dc+sd-jwt';
 
 -- Replace legacy Ed25519 with EdDSA in existing JWT proof algorithm lists
 UPDATE certify.credential_config

--- a/db_upgrade_script/inji_certify/sql/0.14.0_to_1.0.0_upgrade.sql
+++ b/db_upgrade_script/inji_certify/sql/0.14.0_to_1.0.0_upgrade.sql
@@ -24,3 +24,31 @@ COMMENT ON COLUMN certify.credential_config.claims IS 'Claims: JSON object conta
 UPDATE certify.credential_config
 SET credential_format = 'dc+sd-jwt'
 WHERE credential_format = 'vc+sd-jwt';
+
+UPDATE certify.credential_config
+SET proof_types_supported = '{"jwt": {"proof_signing_alg_values_supported": ["RS256", "ES256", "PS256", "EdDSA"]}}'::jsonb
+WHERE proof_types_supported = '{}'::jsonb;
+
+-- Replace legacy Ed25519 with EdDSA in existing JWT proof algorithm lists
+UPDATE certify.credential_config
+SET proof_types_supported = jsonb_set(
+        proof_types_supported,
+        '{jwt,proof_signing_alg_values_supported}',
+        (
+            SELECT COALESCE(jsonb_agg(DISTINCT val), '[]'::jsonb)
+            FROM (
+                     SELECT
+                         CASE
+                             WHEN alg = '"Ed25519"'::jsonb THEN '"EdDSA"'::jsonb
+                             ELSE alg
+                             END AS val
+                     FROM jsonb_array_elements(proof_types_supported #> '{jwt,proof_signing_alg_values_supported}') AS alg
+                 ) sub
+        )
+                            )
+WHERE proof_types_supported #> '{jwt,proof_signing_alg_values_supported}' IS NOT NULL
+  AND EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements(proof_types_supported #> '{jwt,proof_signing_alg_values_supported}') AS alg
+      WHERE alg = '"Ed25519"'::jsonb
+  );

--- a/docker-compose/docker-compose-injistack/config/certify-default.properties
+++ b/docker-compose/docker-compose-injistack/config/certify-default.properties
@@ -52,7 +52,6 @@ mosip.certify.discovery.issuer-id=${mosip.certify.domain.url}${server.servlet.pa
 mosip.certify.authorization.url=https://esignet-mock.collab.mosip.net
 
 ##--------------change this later---------------------------------
-mosip.certify.supported.jwt-proof-alg={'RS256','PS256', 'ES256', 'Ed25519'}
 mosip.certify.plugin-mode=DataProvider
 
 ##--------------Known limitation (Sunbird mode)-------------------
@@ -200,7 +199,7 @@ mosip.certify.credential-config.credential-signing-alg-values-supported={\
   'eddsa-jcs-2022': {'EdDSA'}\
 }
 mosip.certify.credential-config.proof-types-supported={\
-  'jwt': {'proof_signing_alg_values_supported': {'RS256', 'PS256', 'ES256', 'Ed25519'}}\
+  'jwt': {'proof_signing_alg_values_supported': {'RS256', 'PS256', 'ES256', 'EdDSA'}}\
 }
 #Case-sensitive list of status purposes that are allowed to be configured for credential types in credential configuration.
 mosip.certify.data-provider-plugin.credential-status.allowed-status-purposes={'revocation'}


### PR DESCRIPTION
### Desciption

#769 

- Earlier Ed25519 was used as JWS algo in cryptographic binding methods supported and also same was checked in the JWTProofValidator class.
- Now I have changed Ed25519 to EdDSA for cryptographic binding methods supported in the JWTProofValidator class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated JWT signature validation to handle Ed25519-based signatures using the `EdDSA` algorithm label consistently.
* **Database & Configuration**
  * Upgrade migrated credential/proof configuration to replace `Ed25519` with `EdDSA` and initialized missing proof settings for JWT configurations.
  * Rollback restores prior credential/proof configuration, including reverting `EdDSA` back to `Ed25519`.
  * Updated default configuration to support `EdDSA` (and removed the top-level JWT proof algorithm list).
* **Tests**
  * Adjusted JWT proof signing and validation tests to expect `EdDSA` instead of `Ed25519`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->