### PR TITLE
fix: add WWW-Authenticate header to 401 response for NotAuthenticatedException

### DIFF
--- a/certify-core/src/main/java/io/mosip/certify/core/constants/Constants.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/constants/Constants.java
@@ -51,4 +51,6 @@ public class Constants {
     public static final String CREDENTIAL_OFFER_PREFIX = "credential_offer:";
     public static final String PRE_AUTHORIZED_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:pre-authorized_code";
     public static final String AS_METADATA_PREFIX = "as_metadata:";
+    // Request attribute used by the access token filter to pass the auth-failure reason to the exception handler.
+    public static final String AUTH_ERROR_ATTRIBUTE = "certify.authError";
 }

--- a/certify-service/src/main/java/io/mosip/certify/advice/ExceptionHandlerAdvice.java
+++ b/certify-service/src/main/java/io/mosip/certify/advice/ExceptionHandlerAdvice.java
@@ -5,6 +5,7 @@
  */
 package io.mosip.certify.advice;
 
+import io.mosip.certify.core.constants.Constants;
 import io.mosip.certify.core.dto.Error;
 import io.mosip.certify.core.dto.ResponseWrapper;
 import io.mosip.certify.core.dto.VCError;
@@ -98,7 +99,7 @@ public class ExceptionHandlerAdvice extends ResponseEntityExceptionHandler imple
             return handleOAuthControllerExceptions(ex);
         }
         if (path != null && path.contains("/issuance/")) {
-            return handleVCIControllerExceptions(ex);
+            return handleVCIControllerExceptions(ex, servletRequest);
         }
 
         return handleInternalControllerException(ex);
@@ -151,7 +152,7 @@ public class ExceptionHandlerAdvice extends ResponseEntityExceptionHandler imple
         return new ResponseEntity<ResponseWrapper>(getResponseWrapper(UNKNOWN_ERROR, ex.getMessage()), HttpStatus.OK);
     }
 
-    public ResponseEntity<VCError> handleVCIControllerExceptions(Exception ex) {
+    public ResponseEntity<VCError> handleVCIControllerExceptions(Exception ex, HttpServletRequest request) {
         if(ex instanceof MethodArgumentNotValidException) {
             FieldError fieldError = ((MethodArgumentNotValidException) ex).getBindingResult().getFieldError();
             String message = fieldError != null ? fieldError.getDefaultMessage() : ex.getMessage();
@@ -164,7 +165,12 @@ public class ExceptionHandlerAdvice extends ResponseEntityExceptionHandler imple
         }
         if(ex instanceof NotAuthenticatedException) {
             String errorCode = ((CertifyException) ex).getErrorCode();
-            return new ResponseEntity<>(getVCErrorDto(errorCode, getMessage(errorCode, errorCode)), HttpStatus.UNAUTHORIZED);
+            Object reason = request.getAttribute(Constants.AUTH_ERROR_ATTRIBUTE);
+            String description = (reason instanceof String) ? (String) reason : getMessage(errorCode, errorCode);
+            HttpHeaders headers = new HttpHeaders();
+            // Server currently supports only Bearer; make this scheme-aware when DPoP is supported.
+            headers.set(HttpHeaders.WWW_AUTHENTICATE, "Bearer error=\"invalid_token\"");
+            return new ResponseEntity<>(getVCErrorDto(errorCode, description), headers, HttpStatus.UNAUTHORIZED);
         }
         if(ex instanceof InvalidRequestException) {
             String errorCode = ((InvalidRequestException) ex).getErrorCode();

--- a/certify-service/src/main/java/io/mosip/certify/filter/AccessTokenValidationFilter.java
+++ b/certify-service/src/main/java/io/mosip/certify/filter/AccessTokenValidationFilter.java
@@ -16,8 +16,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtValidationException;
 import org.springframework.security.oauth2.jwt.JwtClaimNames;
 import org.springframework.security.oauth2.jwt.JwtClaimValidator;
 import org.springframework.security.oauth2.jwt.JwtIssuerValidator;
@@ -40,6 +42,11 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @Profile("!local")
 public class AccessTokenValidationFilter extends OncePerRequestFilter {
+
+    static final String ERROR_INVALID_TOKEN = "The access token is invalid.";
+    static final String ERROR_EXPIRED_TOKEN = "The access token has expired.";
+    static final String ERROR_DPOP_NOT_SUPPORTED = "DPoP tokens are not supported. Use a Bearer token.";
+    static final String ERROR_MISSING_BEARER = "Authorization header with a Bearer token is required.";
 
     @Value("${mosip.certify.authn.issuer-uri}")
     private String issuerUri;
@@ -110,21 +117,33 @@ public class AccessTokenValidationFilter extends OncePerRequestFilter {
 
                 } catch (Exception e) {
                     log.error("Access token validation failed", e);
+                    request.setAttribute(Constants.AUTH_ERROR_ATTRIBUTE, resolveJwtErrorDescription(e));
                 }
+            } else {
+                request.setAttribute(Constants.AUTH_ERROR_ATTRIBUTE, ERROR_INVALID_TOKEN);
             }
-        }
-
-        if (authorizationHeader != null && authorizationHeader.startsWith("DPoP ")) {
+        } else if (authorizationHeader != null && authorizationHeader.startsWith("DPoP ")) {
             log.error("DPoP token received but only Bearer tokens are supported");
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            response.setHeader("WWW-Authenticate", "Bearer error=\"invalid_token\"");
-            response.setContentType("application/json");
-            response.getWriter().write("{\"error\":\"invalid_token\",\"error_description\":\"DPoP tokens are not supported. Use Bearer token.\"}");
-            return;
+            request.setAttribute(Constants.AUTH_ERROR_ATTRIBUTE, ERROR_DPOP_NOT_SUPPORTED);
+        } else {
+            request.setAttribute(Constants.AUTH_ERROR_ATTRIBUTE, ERROR_MISSING_BEARER);
         }
 
-        log.error("No Bearer / Opaque token provided, continue with the request chain");
+        log.error("No valid Bearer / Opaque token provided, continue with the request chain");
         parsedAccessToken.setActive(false);
         filterChain.doFilter(request, response);
+    }
+
+    private String resolveJwtErrorDescription(Exception e) {
+        if (e instanceof JwtValidationException) {
+            boolean expired = ((JwtValidationException) e).getErrors().stream()
+                    .map(OAuth2Error::getDescription)
+                    .filter(Objects::nonNull)
+                    .anyMatch(description -> description.toLowerCase().contains("expired"));
+            if (expired) {
+                return ERROR_EXPIRED_TOKEN;
+            }
+        }
+        return ERROR_INVALID_TOKEN;
     }
 }

--- a/certify-service/src/main/java/io/mosip/certify/filter/AccessTokenValidationFilter.java
+++ b/certify-service/src/main/java/io/mosip/certify/filter/AccessTokenValidationFilter.java
@@ -114,6 +114,15 @@ public class AccessTokenValidationFilter extends OncePerRequestFilter {
             }
         }
 
+        if (authorizationHeader != null && authorizationHeader.startsWith("DPoP ")) {
+            log.error("DPoP token received but only Bearer tokens are supported");
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setHeader("WWW-Authenticate", "Bearer error=\"invalid_token\"");
+            response.setContentType("application/json");
+            response.getWriter().write("{\"error\":\"invalid_token\",\"error_description\":\"DPoP tokens are not supported. Use Bearer token.\"}");
+            return;
+        }
+
         log.error("No Bearer / Opaque token provided, continue with the request chain");
         parsedAccessToken.setActive(false);
         filterChain.doFilter(request, response);

--- a/certify-service/src/test/java/io/mosip/certify/filter/AccessTokenValidationFilterTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/filter/AccessTokenValidationFilterTest.java
@@ -172,6 +172,28 @@ class AccessTokenValidationFilterTest {
         verify(filterChain).doFilter(request, response);
     }
 
+    @Test
+    public void whenDPoPAuthorizationHeader_shouldReturn401WithWWWAuthenticateHeader() throws ServletException, IOException {
+        request.addHeader("Authorization", "DPoP " + TOKEN);
+        request.setRequestURI("/api/v1/secured");
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        assertEquals(401, response.getStatus());
+        assertEquals("Bearer error=\"invalid_token\"", response.getHeader("WWW-Authenticate"));
+        verify(filterChain, never()).doFilter(any(), any());
+    }
+
+    @Test
+    public void whenDPoPAuthorizationHeader_shouldNotPropagateToFilterChain() throws ServletException, IOException {
+        request.addHeader("Authorization", "DPoP " + TOKEN);
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, never()).doFilter(request, response);
+        verify(parsedAccessToken, never()).setActive(any(Boolean.class));
+    }
+
     private Map<String, Object> createValidClaims() {
         Map<String, Object> claims = new HashMap<>();
         claims.put(JwtClaimNames.SUB, "test-subject");

--- a/certify-service/src/test/java/io/mosip/certify/filter/AccessTokenValidationFilterTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/filter/AccessTokenValidationFilterTest.java
@@ -173,25 +173,43 @@ class AccessTokenValidationFilterTest {
     }
 
     @Test
-    public void whenDPoPAuthorizationHeader_shouldReturn401WithWWWAuthenticateHeader() throws ServletException, IOException {
+    public void whenDPoPAuthorizationHeader_shouldMarkTokenInactiveAndContinue() throws ServletException, IOException {
         request.addHeader("Authorization", "DPoP " + TOKEN);
         request.setRequestURI("/api/v1/secured");
 
         filter.doFilterInternal(request, response, filterChain);
 
-        assertEquals(401, response.getStatus());
-        assertEquals("Bearer error=\"invalid_token\"", response.getHeader("WWW-Authenticate"));
-        verify(filterChain, never()).doFilter(any(), any());
+        verify(parsedAccessToken).setActive(false);
+        assertEquals(AccessTokenValidationFilter.ERROR_DPOP_NOT_SUPPORTED,
+                request.getAttribute(Constants.AUTH_ERROR_ATTRIBUTE));
+        verify(filterChain).doFilter(request, response);
     }
 
     @Test
-    public void whenDPoPAuthorizationHeader_shouldNotPropagateToFilterChain() throws ServletException, IOException {
-        request.addHeader("Authorization", "DPoP " + TOKEN);
+    public void whenExpiredToken_shouldSetExpiredReasonAttribute() throws ServletException, IOException {
+        request.addHeader("Authorization", "Bearer " + TOKEN);
+
+        when(jwtDecoder.decode(TOKEN)).thenThrow(
+                new JwtValidationException("Token expired",
+                        Arrays.asList(new OAuth2Error("invalid_token", "Jwt expired at...", null)))
+        );
 
         filter.doFilterInternal(request, response, filterChain);
 
-        verify(filterChain, never()).doFilter(request, response);
-        verify(parsedAccessToken, never()).setActive(any(Boolean.class));
+        verify(parsedAccessToken).setActive(false);
+        assertEquals(AccessTokenValidationFilter.ERROR_EXPIRED_TOKEN,
+                request.getAttribute(Constants.AUTH_ERROR_ATTRIBUTE));
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    public void whenNoAuthorizationHeader_shouldSetMissingTokenReasonAttribute() throws ServletException, IOException {
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(parsedAccessToken).setActive(false);
+        assertEquals(AccessTokenValidationFilter.ERROR_MISSING_BEARER,
+                request.getAttribute(Constants.AUTH_ERROR_ATTRIBUTE));
+        verify(filterChain).doFilter(request, response);
     }
 
     private Map<String, Object> createValidClaims() {


### PR DESCRIPTION
## Problem

When a VCI client sends a DPoP-bound access token to certify's credential endpoint, certify's `AccessTokenValidationFilter` rejects it (hardcoded `startsWith("Bearer ")` check) and the request proceeds with an inactive token → `NotAuthenticatedException` is thrown → 401 returned **without** `WWW-Authenticate` header.

Per **RFC 6750 §3**, a resource server MUST include `WWW-Authenticate` in 401 responses. Without it:
- VCI clients cannot determine the expected auth scheme
- DPoP-capable clients have no way to know they should retry with Bearer
- The credential issuance flow fails silently

## Fix

Add `WWW-Authenticate: Bearer error="<errorCode>"` header to the 401 response in `ExceptionHandlerAdvice` when `NotAuthenticatedException` is thrown.

```java
HttpHeaders headers = new HttpHeaders();
headers.set("WWW-Authenticate", "Bearer error=\"" + errorCode + "\"");
return new ResponseEntity<>(getVCErrorDto(...), headers, HttpStatus.UNAUTHORIZED);
```

## Impact

With this fix, VCI clients that receive a 401 with `WWW-Authenticate: Bearer` can retry the credential request using `Authorization: Bearer <token>` — enabling the DPoP→Bearer fallback flow per RFC 9449 §7.2.

## References
- RFC 6750 §3: https://www.rfc-editor.org/rfc/rfc6750#section-3
- RFC 9449 §7.2: https://www.rfc-editor.org/rfc/rfc9449#section-7.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unsupported `DPoP` authorization headers now result in `401 Unauthorized` with `WWW-Authenticate: Bearer error="invalid_token"` and a JSON error response.
  * Invalid/expired access tokens now produce more accurate error messaging (including an explicit expired vs invalid distinction).
  * Credential requests now surface the token’s specific error details when authentication fails.

* **Tests**
  * Added/updated coverage for `DPoP`, expired, and missing `Authorization` header scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->