### PR TITLE
#769 updated the alg in proof jwt is Ed25519 to EdDSA

### DIFF
--- a/api-test/src/main/java/io/inji/testrig/apirig/injicertify/utils/InjiCertifyUtil.java
+++ b/api-test/src/main/java/io/inji/testrig/apirig/injicertify/utils/InjiCertifyUtil.java
@@ -1582,7 +1582,10 @@ public static void configureOtp() {
 
 		try {
 			OctetKeyPair edJWK = new OctetKeyPairGenerator(Curve.Ed25519).generate();
-			
+			JWSAlgorithm proofAlgorithm = testCaseName.toLowerCase().contains("landregistry")
+					? JWSAlgorithm.EdDSA
+					: JWSAlgorithm.Ed25519;
+
 			if(testCaseName.contains("_Did_Key_Sign_")) {
 				
 				byte[] rawPublicKey = edJWK.getX().decode();
@@ -1592,10 +1595,10 @@ public static void configureOtp() {
 					didKey = "did:key:zINVALIDDIDKEYFORPROOFTEST";
 				}
 				
-				header = new JWSHeader.Builder(JWSAlgorithm.Ed25519)
+				header = new JWSHeader.Builder(proofAlgorithm)
 						.type(new JOSEObjectType("openid4vci-proof+jwt")).keyID(didKey).build();
 			}else {
-				header = new JWSHeader.Builder(JWSAlgorithm.Ed25519)
+				header = new JWSHeader.Builder(proofAlgorithm)
 						.type(new JOSEObjectType("openid4vci-proof+jwt")).jwk(edJWK.toPublicJWK()).build();
 			}
 

--- a/api-test/src/main/java/io/inji/testrig/apirig/injicertify/utils/InjiCertifyUtil.java
+++ b/api-test/src/main/java/io/inji/testrig/apirig/injicertify/utils/InjiCertifyUtil.java
@@ -1582,9 +1582,6 @@ public static void configureOtp() {
 
 		try {
 			OctetKeyPair edJWK = new OctetKeyPairGenerator(Curve.Ed25519).generate();
-			JWSAlgorithm proofAlgorithm = testCaseName.toLowerCase().contains("landregistry")
-					? JWSAlgorithm.EdDSA
-					: JWSAlgorithm.Ed25519;
 
 			if(testCaseName.contains("_Did_Key_Sign_")) {
 				
@@ -1595,10 +1592,10 @@ public static void configureOtp() {
 					didKey = "did:key:zINVALIDDIDKEYFORPROOFTEST";
 				}
 				
-				header = new JWSHeader.Builder(proofAlgorithm)
+				header = new JWSHeader.Builder(JWSAlgorithm.EdDSA)
 						.type(new JOSEObjectType("openid4vci-proof+jwt")).keyID(didKey).build();
 			}else {
-				header = new JWSHeader.Builder(proofAlgorithm)
+				header = new JWSHeader.Builder(JWSAlgorithm.EdDSA)
 						.type(new JOSEObjectType("openid4vci-proof+jwt")).jwk(edJWK.toPublicJWK()).build();
 			}
 

--- a/api-test/src/main/resources/injicertify/CSRCertificate/GetCredentialForCSRCertificate/GetCredentialForCSRCertificate.yml
+++ b/api-test/src/main/resources/injicertify/CSRCertificate/GetCredentialForCSRCertificate/GetCredentialForCSRCertificate.yml
@@ -58,7 +58,7 @@ GetCredentialForCsrCertificate:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",
         "credentialType": "landregistry_dataIntegrity",
-        "signatureSupported": "Ed25519"
+        "signatureSupported": "EdDSA"
 }'
       output: '{
 }'

--- a/api-test/src/main/resources/injicertify/DataIntegrityProof/GetCredentialForDataIntegrity/GetCredentialForDataIntegrity.yml
+++ b/api-test/src/main/resources/injicertify/DataIntegrityProof/GetCredentialForDataIntegrity/GetCredentialForDataIntegrity.yml
@@ -87,7 +87,7 @@ GetCredentialForDataIntegrity:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",
         "credentialType": "landstatement_dataIntegrity",
-        "signatureSupported": "Ed25519"
+        "signatureSupported": "EdDSA"
 }'
       output: '{
 }'
@@ -202,7 +202,7 @@ GetCredentialForDataIntegrity:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",
         "credentialType": "landregistry_dataIntegrity",
-        "signatureSupported": "Ed25519"
+        "signatureSupported": "EdDSA"
 }'
       output: '{
 }'
@@ -248,7 +248,7 @@ GetCredentialForDataIntegrity:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",
         "credentialType": "landregistry_dataIntegrity",
-        "signatureSupported": "Ed25519"
+        "signatureSupported": "EdDSA"
 }'
       output: '{
 }'

--- a/api-test/src/main/resources/injicertify/DataIntegrityProof/GetCredentialForDataIntegrity/GetCredentialForDataIntegrity.yml
+++ b/api-test/src/main/resources/injicertify/DataIntegrityProof/GetCredentialForDataIntegrity/GetCredentialForDataIntegrity.yml
@@ -68,7 +68,7 @@ GetCredentialForDataIntegrity:
 }'
       output: '{
 }'
-   InjiCertify_GetCredentialForLandRegistry_Cred1_dataIntegrity_IdpAccessToken_Ed25519_all_Valid_Smoke:
+   InjiCertify_GetCredentialForLandRegistry_Cred1_dataIntegrity_IdpAccessToken_EdDSA_all_Valid_Smoke:
       endPoint: $INJICERTIFYBASEURL$/v1/certify/issuance/credential
       uniqueIdentifier: TC_InjiCertify_GetCredentialFor_dataintegrity_04
       description: Get credentials for land statement data integrity proof
@@ -183,7 +183,7 @@ GetCredentialForDataIntegrity:
 }'
       output: '{
 }'
-   InjiCertify_GetCredentialForLandRegistry_Cred2_dataIntegrity_IdpAccessToken_Ed25519_all_Valid_Smoke:
+   InjiCertify_GetCredentialForLandRegistry_Cred2_dataIntegrity_IdpAccessToken_EdDSA_all_Valid_Smoke:
       endPoint: $INJICERTIFYBASEURL$/v1/certify/issuance/credential
       uniqueIdentifier: TC_InjiCertify_GetCredentialFor_dataintegrity_09
       description: Get credentials for land statement data integrity proof
@@ -229,7 +229,7 @@ GetCredentialForDataIntegrity:
 }'
       output: '{
 }'
-   InjiCertify_GetCredentialForLandRegistry_Cred2_dataIntegrity_1.1_IdpAccessToken_Ed25519_all_Valid_Smoke:
+   InjiCertify_GetCredentialForLandRegistry_Cred2_dataIntegrity_1.1_IdpAccessToken_EdDSA_all_Valid_Smoke:
       endPoint: $INJICERTIFYBASEURL$/v1/certify/issuance/credential
       uniqueIdentifier: TC_InjiCertify_GetCredentialFor_dataintegrity_15
       description: Get credentials for land statement data integrity proof

--- a/api-test/src/main/resources/injicertify/Sd_Jwt/GetCredentialForSd_Jwt/GetCredentialForSd_Jwt.yml
+++ b/api-test/src/main/resources/injicertify/Sd_Jwt/GetCredentialForSd_Jwt/GetCredentialForSd_Jwt.yml
@@ -47,7 +47,7 @@ GetCredentialForSd_jwt:
    InjiCertify_GetCredentialForLandRegistry_IdpAccessToken_Cred1_Sd_jwt_Ed25519_all_Valid_Smoke:
       endPoint: $INJICERTIFYBASEURL$/v1/certify/issuance/credential
       uniqueIdentifier: TC_InjiCertify_GetCredentialFor_Sd_jwt_03
-      description: Get credentials Sd_jwt format for Ed25519
+      description: Get credentials Sd_jwt format for EdDSA
       role: noauth
       checkErrorsOnlyInResponse: true
       restMethod: post
@@ -62,7 +62,7 @@ GetCredentialForSd_jwt:
         "credential_configuration_id": "$ID:AddCredentialConfig_landregistry_cred1_Sd_Jwt_all_Valid_Smoke_sid_id$",
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",
-        "signatureSupported": "Ed25519"
+        "signatureSupported": "EdDSA"
 }'
       output: '{
 }'
@@ -83,7 +83,7 @@ GetCredentialForSd_jwt:
         "credential_configuration_id": "$ID:AddCredentialConfig_landregistry_cred1_Sd_Jwt_all_Valid_Smoke_sid_id$",
       	"proof_type": "jwt",
         "proof_jwt": "null",
-        "signatureSupported": "Ed25519"
+        "signatureSupported": "EdDSA"
 }'
       output: '{
 		"error": "invalid_proof"
@@ -92,7 +92,7 @@ GetCredentialForSd_jwt:
    InjiCertify_GetCredentialForLandRegistry_IdpAccessToken_Cred2_Sd_jwt_Ed25519_all_Valid_Smoke:
       endPoint: $INJICERTIFYBASEURL$/v1/certify/issuance/credential
       uniqueIdentifier: TC_InjiCertify_GetCredentialFor_Sd_jwt_05
-      description: Get credentials Sd_jwt format for Ed25519 credential type 2
+      description: Get credentials Sd_jwt format for EdDSA credential type 2
       role: noauth
       checkErrorsOnlyInResponse: true      
       restMethod: post
@@ -107,7 +107,7 @@ GetCredentialForSd_jwt:
         "credential_configuration_id": "$ID:AddCredentialConfig_landregistry_cred2_Sd_Jwt_all_Valid_Smoke_sid_id$",
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",
-        "signatureSupported": "Ed25519"
+        "signatureSupported": "EdDSA"
 }'
       output: '{
 }'
@@ -128,7 +128,7 @@ GetCredentialForSd_jwt:
         "credential_configuration_id": "Sd_jwt_Without_vct",
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",
-        "signatureSupported": "Ed25519"
+        "signatureSupported": "EdDSA"
 }'
       output: '{
 		"error": "invalid_credential_request"

--- a/api-test/src/main/resources/injicertify/Sd_Jwt/GetCredentialForSd_Jwt/GetCredentialForSd_Jwt.yml
+++ b/api-test/src/main/resources/injicertify/Sd_Jwt/GetCredentialForSd_Jwt/GetCredentialForSd_Jwt.yml
@@ -44,7 +44,7 @@ GetCredentialForSd_jwt:
 }'
       output: '{
 }'
-   InjiCertify_GetCredentialForLandRegistry_IdpAccessToken_Cred1_Sd_jwt_Ed25519_all_Valid_Smoke:
+   InjiCertify_GetCredentialForLandRegistry_IdpAccessToken_Cred1_Sd_jwt_EdDSA_all_Valid_Smoke:
       endPoint: $INJICERTIFYBASEURL$/v1/certify/issuance/credential
       uniqueIdentifier: TC_InjiCertify_GetCredentialFor_Sd_jwt_03
       description: Get credentials Sd_jwt format for EdDSA
@@ -89,7 +89,7 @@ GetCredentialForSd_jwt:
 		"error": "invalid_proof"
 }'
 
-   InjiCertify_GetCredentialForLandRegistry_IdpAccessToken_Cred2_Sd_jwt_Ed25519_all_Valid_Smoke:
+   InjiCertify_GetCredentialForLandRegistry_IdpAccessToken_Cred2_Sd_jwt_EdDSA_all_Valid_Smoke:
       endPoint: $INJICERTIFYBASEURL$/v1/certify/issuance/credential
       uniqueIdentifier: TC_InjiCertify_GetCredentialFor_Sd_jwt_05
       description: Get credentials Sd_jwt format for EdDSA credential type 2

--- a/api-test/src/main/resources/injicertify/VCILandRegistry/GetCredentialForLandRegistry/GetCredentialForLandRegistry.yml
+++ b/api-test/src/main/resources/injicertify/VCILandRegistry/GetCredentialForLandRegistry/GetCredentialForLandRegistry.yml
@@ -210,7 +210,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",
         "credentialType": "LandStatementCredential_VCDM1.0",
-        "signatureSupported": "Ed25519"
+        "signatureSupported": "EdDSA"
 }'
       output: '{
 }'
@@ -234,7 +234,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",
         "credentialType": "LandStatementCredential_VCDM1.0",
-        "signatureSupported": "Ed25519"
+        "signatureSupported": "EdDSA"
 }'
       output: '{
 }'
@@ -258,7 +258,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",
         "credentialType": "RegistrationReceiptCredential",
-        "signatureSupported": "Ed25519"
+        "signatureSupported": "EdDSA"
 }'
       output: '{
 }'
@@ -282,7 +282,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",
         "credentialType": "RegistrationReceiptCredential",
-        "signatureSupported": "Ed25519"
+        "signatureSupported": "EdDSA"
 }'
       output: '{
 }'
@@ -330,7 +330,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",
         "credentialType": "LandStatementCredential_VCDM1.0",
-        "signatureSupported": "Ed25519"
+        "signatureSupported": "EdDSA"
 }'
       output: '{
 }'
@@ -353,7 +353,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",
         "credentialType": "LandStatementCredential_VCDM1.0",
-        "signatureSupported": "Ed25519"
+        "signatureSupported": "EdDSA"
 }'
       output: '{
 }'

--- a/api-test/src/main/resources/injicertify/VCILandRegistry/GetCredentialForLandRegistry/GetCredentialForLandRegistry.yml
+++ b/api-test/src/main/resources/injicertify/VCILandRegistry/GetCredentialForLandRegistry/GetCredentialForLandRegistry.yml
@@ -191,7 +191,7 @@ GetCredentialForLandRegistry:
       output: '{
 }'
 
-   InjiCertify_GetCredentialForLandRegistry_IdpAccessToken_ED25519_Sign_all_Valid_Smoke:
+   InjiCertify_GetCredentialForLandRegistry_IdpAccessToken_EdDSA_Sign_all_Valid_Smoke:
       endPoint: $INJICERTIFYBASEURL$/v1/certify/issuance/credential
       uniqueIdentifier: TC_InjiCertify_GetCredentialForLandRegistry_22
       description: Get credentials for Land Registry with LandStatementCredential_VCDM1.0 all valid data
@@ -215,7 +215,7 @@ GetCredentialForLandRegistry:
       output: '{
 }'
 
-   InjiCertify_GetCredentialForLandRegistry_IdpAccessToken_2.0_ED25519_Sign_all_Valid_Smoke:
+   InjiCertify_GetCredentialForLandRegistry_IdpAccessToken_2.0_EdDSA_Sign_all_Valid_Smoke:
       endPoint: $INJICERTIFYBASEURL$/v1/certify/issuance/credential
       uniqueIdentifier: TC_InjiCertify_GetCredentialForLandRegistry_23
       description: Get credentials for Land Registry with 2.0 data model LandStatementCredential_VCDM1.0 all valid data
@@ -239,7 +239,7 @@ GetCredentialForLandRegistry:
       output: '{
 }'
 
-   InjiCertify_GetCredentialForLandRegistry_IdpAccessToken_Cred_2_ED25519_Sign_all_Valid_Smoke:
+   InjiCertify_GetCredentialForLandRegistry_IdpAccessToken_Cred_2_EdDSA_Sign_all_Valid_Smoke:
       endPoint: $INJICERTIFYBASEURL$/v1/certify/issuance/credential
       uniqueIdentifier: TC_InjiCertify_GetCredentialForLandRegistry_24
       description: Get credentials for Land Registry with RegistrationReceiptCredential all valid data
@@ -263,7 +263,7 @@ GetCredentialForLandRegistry:
       output: '{
 }'
 
-   InjiCertify_GetCredentialForLandRegistry_IdpAccessToken_2.0_Cred_2_ED25519_Sign_all_Valid_Smoke:
+   InjiCertify_GetCredentialForLandRegistry_IdpAccessToken_2.0_Cred_2_EdDSA_Sign_all_Valid_Smoke:
       endPoint: $INJICERTIFYBASEURL$/v1/certify/issuance/credential
       uniqueIdentifier: TC_InjiCertify_GetCredentialForLandRegistry_25
       description: Get credentials for Land Registry with 2.0 data model with RegistrationReceiptCredential all valid data
@@ -311,7 +311,7 @@ GetCredentialForLandRegistry:
       output: '{
 }'
 
-   InjiCertify_GetCredentialForLandRegistry_IdpAccessToken_ED25519_Did_Key_Sign_all_Valid_Smoke:
+   InjiCertify_GetCredentialForLandRegistry_IdpAccessToken_EdDSA_Did_Key_Sign_all_Valid_Smoke:
       endPoint: $INJICERTIFYBASEURL$/v1/certify/issuance/credential
       uniqueIdentifier: TC_InjiCertify_GetCredentialForLandRegistry_27
       description: Get credentials for Land Registry with LandStatementCredential_VCDM1.0 all valid data
@@ -334,7 +334,7 @@ GetCredentialForLandRegistry:
 }'
       output: '{
 }'
-   InjiCertify_GetCredentialForLandRegistry_IdpAccessToken_2.0_ED25519_Did_Key_Sign_all_Valid_Smoke:
+   InjiCertify_GetCredentialForLandRegistry_IdpAccessToken_2.0_EdDSA_Did_Key_Sign_all_Valid_Smoke:
       endPoint: $INJICERTIFYBASEURL$/v1/certify/issuance/credential
       uniqueIdentifier: TC_InjiCertify_GetCredentialForLandRegistry_28
       description: Get credentials for Land Registry with LandStatementCredential_VCDM1.0 where proof_jwt should contain did:key

--- a/api-test/src/main/resources/injicertify/VCILandRegistryNeg/GetCredentialForLandRegistry/GetCredentialForLandRegistry.yml
+++ b/api-test/src/main/resources/injicertify/VCILandRegistryNeg/GetCredentialForLandRegistry/GetCredentialForLandRegistry.yml
@@ -23,7 +23,7 @@ GetCredentialForLandRegistry:
       output: '{
 		"error": "invalid_credential_request"
 }'
-   InjiCertify_GetCredentialForLandRegistry_IdpAccessToken_Cred_2_ED25519_Sign_Invalid_Credential_Type_Neg:
+   InjiCertify_GetCredentialForLandRegistry_IdpAccessToken_Cred_2_EdDSA_Sign_Invalid_Credential_Type_Neg:
       endPoint: $INJICERTIFYBASEURL$/v1/certify/issuance/credential
       uniqueIdentifier: TC_InjiCertify_GetCredentialForLandRegistry_15
       description: Get credentials for Land Registry with invalid credential type Neg
@@ -71,7 +71,7 @@ GetCredentialForLandRegistry:
       output: '{
 		"error": "ERROR_FETCHING_DATA_RECORD_FROM_TABLE"
 }'
-   InjiCertify_GetCredentialForLandRegistry_IdpAccessToken_2.0_ED25519_Did_Key_Sign_invalid:
+   InjiCertify_GetCredentialForLandRegistry_IdpAccessToken_2.0_EdDSA_Did_Key_Sign_invalid:
       endPoint: $INJICERTIFYBASEURL$/v1/certify/issuance/credential
       uniqueIdentifier: TC_InjiCertify_GetCredentialForLandRegistry_31
       description: Get credentials for Land Registry with LandStatementCredential where proof_jwt should contain invalid did:key

--- a/api-test/src/main/resources/injicertify/VCILandRegistryNeg/GetCredentialForLandRegistry/GetCredentialForLandRegistry.yml
+++ b/api-test/src/main/resources/injicertify/VCILandRegistryNeg/GetCredentialForLandRegistry/GetCredentialForLandRegistry.yml
@@ -42,7 +42,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",
         "credentialType": "RegistrationReceiptCredential",
-        "signatureSupported": "Ed25519"
+        "signatureSupported": "EdDSA"
 }'
       output: '{
 		"error": "invalid_credential_request"
@@ -66,7 +66,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_3$",
         "credentialType": "LandStatementCredential",
-        "signatureSupported": "Ed25519"
+        "signatureSupported": "EdDSA"
 }'
       output: '{
 		"error": "ERROR_FETCHING_DATA_RECORD_FROM_TABLE"
@@ -87,7 +87,7 @@ GetCredentialForLandRegistry:
       	"proof_type": "jwt",
         "proof_jwt": "$PROOF_JWT_ED25519$",
         "credentialType": "LandStatementCredential",
-        "signatureSupported": "Ed25519"
+        "signatureSupported": "EdDSA"
 }'
       output: '{
 		"error": "invalid_proof"

--- a/api-test/src/main/resources/testCaseSkippedList.txt
+++ b/api-test/src/main/resources/testCaseSkippedList.txt
@@ -17,7 +17,7 @@ INJICERT-1290------InjiCertify_UploadCertificate_ForLandRegistry_without_applica
 INJICERT-1290------InjiCertify_UploadCertificate_ForLandRegistry_without_referenceId_value_neg
 INJICERT-1260------InjiCertify_UpdateCredentialStatusV2_ForLandRegistry_Revocation_invalid_statuspurpose_Neg
 INJICERT-1320------InjiCertify_GetCredentialFormdl_IdpAccessToken_Unsupported_JWT_Algo
-INJICERT-878------InjiCertify_GetCredentialForLandRegistry_IdpAccessToken_2.0_ED25519_Did_Key_Sign_invalid
+INJICERT-878------InjiCertify_GetCredentialForLandRegistry_IdpAccessToken_2.0_EdDSA_Did_Key_Sign_invalid
 INJICERT-878------InjiCertify_GetCredentialForLandRegistry_IdpAccessToken_2.0_ES256_Did_Key_Sign_invalid
 INJICERT-878------InjiCertify_UpdateCredentialStatus_ForLandRegistry_Revocation_invalid_statuspurpose_Neg
 INJICERT-878------InjiCertify_UpdateCredentialStatus_ForLandRegistry_Revocation_without_statuspurpose_Neg

--- a/api-test/src/main/resources/testCaseSkippedList.txt
+++ b/api-test/src/main/resources/testCaseSkippedList.txt
@@ -17,3 +17,7 @@ INJICERT-1290------InjiCertify_UploadCertificate_ForLandRegistry_without_applica
 INJICERT-1290------InjiCertify_UploadCertificate_ForLandRegistry_without_referenceId_value_neg
 INJICERT-1260------InjiCertify_UpdateCredentialStatusV2_ForLandRegistry_Revocation_invalid_statuspurpose_Neg
 INJICERT-1320------InjiCertify_GetCredentialFormdl_IdpAccessToken_Unsupported_JWT_Algo
+INJICERT-878------InjiCertify_GetCredentialForLandRegistry_IdpAccessToken_2.0_ED25519_Did_Key_Sign_invalid
+INJICERT-878------InjiCertify_GetCredentialForLandRegistry_IdpAccessToken_2.0_ES256_Did_Key_Sign_invalid
+INJICERT-878------InjiCertify_UpdateCredentialStatus_ForLandRegistry_Revocation_invalid_statuspurpose_Neg
+INJICERT-878------InjiCertify_UpdateCredentialStatus_ForLandRegistry_Revocation_without_statuspurpose_Neg


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated proof JWT signing to use **EdDSA** (JWS header algorithm) for affected flows, while keeping the signing behavior consistent.
  * Updated credential issuance, data-integrity, SD-JWT, and land registry scenarios to request **EdDSA** instead of **Ed25519** via `signatureSupported`.
* **Tests**
  * Expanded the skipped-test list to continue bypassing known failing signature and land registry status-revocation scenarios during automated runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->