### PR TITLE
Add spring.cloud.config.name for certify

### DIFF
--- a/certify-service/src/main/resources/bootstrap.properties
+++ b/certify-service/src/main/resources/bootstrap.properties
@@ -5,6 +5,7 @@
 ## Application Name
 spring.application.name=certify,certify-plugin
 spring.cloud.config.uri=http://localhost:8888
+spring.cloud.config.name=certify
 spring.profiles.active=local
 
 server.port=8090

--- a/certify-service/src/test/resources/bootstrap.properties
+++ b/certify-service/src/test/resources/bootstrap.properties
@@ -5,6 +5,7 @@
 ## Application Name
 spring.application.name=certify
 spring.cloud.config.uri=http://localhost:8888
+spring.cloud.config.name=certify
 spring.profiles.active=test
 
 server.port=8090


### PR DESCRIPTION
Add spring.cloud.config.name for certify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration loading by explicitly identifying the application’s configuration source.
  * Applied the same configuration behavior across runtime and test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->