### PR TITLE
fix: issuerAuth as untagged cose_sign1

### DIFF
--- a/certify-service/src/main/java/io/mosip/certify/utils/MDocProcessor.java
+++ b/certify-service/src/main/java/io/mosip/certify/utils/MDocProcessor.java
@@ -465,6 +465,7 @@ public class MDocProcessor {
             signRequest.setApplicationId(appID);
             signRequest.setReferenceId(refID);
             signRequest.setAlgorithm(signAlgorithm);
+            signRequest.setIncludeCOSETag(false);
 
             // Set unprotected header in request
             signRequest.setUnprotectedHeader(Map.of("includeCertificate", true));

--- a/certify-service/src/test/java/io/mosip/certify/utils/MDocProcessorTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/utils/MDocProcessorTest.java
@@ -717,6 +717,7 @@ public class MDocProcessorTest {
         assertEquals("Application ID should match", "testApp", requestDto.getApplicationId());
         assertEquals("Reference ID should match", "testRef", requestDto.getReferenceId());
         assertEquals("Algorithm should match", "ES256", requestDto.getAlgorithm());
+        assertEquals("Untagged COSE_Sign1 is expected", false, requestDto.getIncludeCOSETag());
     }
 
     @Test(expected = CertifyException.class)


### PR DESCRIPTION
Fixes: https://github.com/inji/inji-certify/issues/939

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated document signing to produce untagged COSE signatures, improving compatibility with systems expecting this format.

- **Tests**
  - Added validation to confirm that generated signatures exclude the COSE tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->