### PR TITLE
fix: Mdoc structure as per spec

### DIFF
--- a/certify-core/src/main/java/io/mosip/certify/core/constants/Constants.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/constants/Constants.java
@@ -34,17 +34,22 @@ public class Constants {
     public  static final String CONFIRMATION = "cnf";
     public  static final String ISSUER = "iss";
     public static final String TYPE = "type";
+
+    // mDoc specific
     public static final String DOCTYPE = "docType";
     public static final String CLAIMS = "claims";
     public static final String DID_JWK_PREFIX = "did:jwk:";
     public static final String NAMESPACES = "nameSpaces";
     public static final String DIGEST_ID = "digestID";
     public static final String VALIDITY_INFO = "validityInfo";
-    public static final String _HOLDER_ID = "_holderId";
     public static final String ELEMENT_IDENTIFIER = "elementIdentifier";
     public static final String ELEMENT_VALUE = "elementValue";
     public static final String __CBOR_TAG = "__cbor_tag";
     public static final String __CBOR_VALUE = "__cbor_value";
+    public static final String SIGNED = "signed";
+    //End of mDoc specific
+
+    public static final String _HOLDER_ID = "_holderId";
     public static final String CREDENTIAL_CONFIGURATIONS_SUPPORTED = "credential_configurations_supported";
     public static final String MANDATORY = "mandatory";
     public static final String PRE_AUTH_CODE_PREFIX = "pre_auth_code:";

--- a/certify-service/src/main/java/io/mosip/certify/credential/MDocCredential.java
+++ b/certify-service/src/main/java/io/mosip/certify/credential/MDocCredential.java
@@ -73,11 +73,9 @@ public class MDocCredential extends Credential {
             Map<String, Object> mso = mDocProcessor.createMobileSecurityObject(mDocJson, namespaceDigests);
             byte[] signedMSO = mDocProcessor.signMSO(mso, appID, refID, signAlgorithm);
             Map<String, Object> issuerSigned = MDocProcessor.createIssuerSignedStructure(taggedNamespaces, signedMSO);
-            Map<String, Object> mDocSignedCredential = new HashMap<>();
-            mDocSignedCredential.put(Constants.DOCTYPE, mso.get(Constants.DOCTYPE));
-            mDocSignedCredential.put("issuerSigned", issuerSigned);
+
             // Encode to CBOR, then to Base64
-            byte[] cborIssuerSigned = MDocProcessor.encodeToCBOR(mDocSignedCredential);
+            byte[] cborIssuerSigned = MDocProcessor.encodeToCBOR(issuerSigned);
             String base64UrlCredential = Base64.getUrlEncoder().withoutPadding().encodeToString(cborIssuerSigned);
 
             vcResult.setCredential(base64UrlCredential);

--- a/certify-service/src/main/java/io/mosip/certify/utils/MDocProcessor.java
+++ b/certify-service/src/main/java/io/mosip/certify/utils/MDocProcessor.java
@@ -22,7 +22,6 @@ import io.mosip.kernel.signature.service.CoseSignatureService;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.time.LocalDate;
@@ -66,22 +65,30 @@ public class MDocProcessor {
             if (templateNode.has(Constants.VALIDITY_INFO)) {
                 JsonNode validityInfo = templateNode.get(Constants.VALIDITY_INFO);
                 Map<String, Object> validity = objectMapper.convertValue(validityInfo, Map.class);
+                ZonedDateTime currentTime = ZonedDateTime.now(ZoneOffset.UTC);
+                String formattedCurrentTime = currentTime
+                        .format(DateTimeFormatter.ofPattern(Constants.UTC_DATETIME_PATTERN));
 
                 if (validity.containsKey(VCDM2Constants.VALID_FROM)) {
                     String validFromValue = (String) validity.get(VCDM2Constants.VALID_FROM);
                     if ("${_validFrom}".equals(validFromValue)) {
-                        String currentTime = ZonedDateTime.now(ZoneOffset.UTC)
-                                .format(DateTimeFormatter.ofPattern(Constants.UTC_DATETIME_PATTERN));
-                        validity.put(VCDM2Constants.VALID_FROM, currentTime);
+                        validity.put(VCDM2Constants.VALID_FROM, createCBORTaggedDateTime(formattedCurrentTime));
+                    }
+                }
+
+                if (validity.containsKey("signed")) {
+                    String signedValue = (String) validity.get("signed");
+                    if ("${_signed}".equals(signedValue)) {
+                        validity.put("signed", createCBORTaggedDateTime(formattedCurrentTime));
                     }
                 }
                 if (validity.containsKey(VCDM2Constants.VALID_UNTIL)) {
                     String validUntilValue = (String) validity.get(VCDM2Constants.VALID_UNTIL);
                     if ("${_validUntil}".equals(validUntilValue)) {
-                        String futureTime = ZonedDateTime.now(ZoneOffset.UTC)
+                        String futureTime = currentTime
                                 .plusYears(mDocConfig.getValidityPeriodYears())
                                 .format(DateTimeFormatter.ofPattern(Constants.UTC_DATETIME_PATTERN));
-                        validity.put(VCDM2Constants.VALID_UNTIL, futureTime);
+                        validity.put(VCDM2Constants.VALID_UNTIL, createCBORTaggedDateTime(futureTime));
                     }
                 }
 
@@ -234,6 +241,24 @@ public class MDocProcessor {
         }
     }
 
+    public static byte[] encodeToTaggedCBOR(Object obj) throws Exception {
+        try {
+            byte[] innerCborBytes = encodeToCBOR(obj);
+
+            // Format: #6.24(bstr .cbor convertToDataItem(preprocessedData))
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            CborEncoder encoder = new CborEncoder(baos);
+            ByteString taggedCbor = new ByteString(innerCborBytes);
+            taggedCbor.setTag(24);
+            encoder.encode(taggedCbor);
+
+            return baos.toByteArray();
+        } catch (Exception e) {
+            log.error("Error encoding to CBOR: {}", e.getMessage(), e);
+            throw new Exception("CBOR encoding failed: " + e.getMessage(), e);
+        }
+    }
+
     /**
      * Preprocesses objects for CBOR encoding (handles dates, byte arrays, etc.)
      */
@@ -370,6 +395,18 @@ public class MDocProcessor {
     }
 
     /**
+     * Creates a CBOR tagged datetime (tag 0) for datetime strings (RFC 3339 format)
+     * RFC 8610: tdate = #6.0(tstr) where tstr = #3
+     * This wraps full datetime timestamps in Tag 0 as per mso_mdoc specification
+     */
+    private static Map<String, Object> createCBORTaggedDateTime(String dateTimeStr) {
+        Map<String, Object> taggedDate = new HashMap<>();
+        taggedDate.put(Constants.__CBOR_TAG, 0);
+        taggedDate.put(Constants.__CBOR_VALUE, dateTimeStr);
+        return taggedDate;
+    }
+
+    /**
      * Creates the Mobile Security Object (MSO) structure
      */
     public Map<String, Object> createMobileSecurityObject
@@ -393,6 +430,7 @@ public class MDocProcessor {
             Map<String, Object> originalValidity = (Map<String, Object>) mDocJson.get(Constants.VALIDITY_INFO);
             validityInfo.put(VCDM2Constants.VALID_FROM, originalValidity.get(VCDM2Constants.VALID_FROM));
             validityInfo.put(VCDM2Constants.VALID_UNTIL, originalValidity.get(VCDM2Constants.VALID_UNTIL));
+            validityInfo.put("signed", originalValidity.get("signed"));
         }
         mso.put(Constants.VALIDITY_INFO, validityInfo);
 

--- a/certify-service/src/main/java/io/mosip/certify/utils/MDocProcessor.java
+++ b/certify-service/src/main/java/io/mosip/certify/utils/MDocProcessor.java
@@ -62,6 +62,40 @@ public class MDocProcessor {
             JsonNode templateNode = objectMapper.readTree(templatedJSON);
             Map<String, Object> finalMDoc = new HashMap<>();
 
+            if (templateNode.has(Constants.VALIDITY_INFO)) {
+                JsonNode validityInfo = templateNode.get(Constants.VALIDITY_INFO);
+                Map<String, Object> validity = objectMapper.convertValue(validityInfo, Map.class);
+                ZonedDateTime currentTime = ZonedDateTime.now(ZoneOffset.UTC);
+                String formattedCurrentTime = currentTime
+                        .format(DateTimeFormatter.ofPattern(Constants.UTC_DATETIME_PATTERN));
+
+                if (validity.containsKey(VCDM2Constants.VALID_FROM)) {
+                    String validFromValue = (String) validity.get(VCDM2Constants.VALID_FROM);
+                    if ("${_validFrom}".equals(validFromValue)) {
+                        validity.put(VCDM2Constants.VALID_FROM, createCBORTaggedDateTime(formattedCurrentTime));
+                    }
+                }
+
+                if (validity.containsKey("signed")) {
+                    String signedValue = (String) validity.get("signed");
+                    if ("${_signed}".equals(signedValue)) {
+                        validity.put("signed", createCBORTaggedDateTime(formattedCurrentTime));
+                    }
+                }
+                if (validity.containsKey(VCDM2Constants.VALID_UNTIL)) {
+                    String validUntilValue = (String) validity.get(VCDM2Constants.VALID_UNTIL);
+                    if ("${_validUntil}".equals(validUntilValue)) {
+                        String futureTime = currentTime
+                                .plusYears(mDocConfig.getValidityPeriodYears())
+                                .format(DateTimeFormatter.ofPattern(Constants.UTC_DATETIME_PATTERN));
+                        validity.put(VCDM2Constants.VALID_UNTIL, createCBORTaggedDateTime(futureTime));
+                    }
+                }
+
+
+                finalMDoc.put(Constants.VALIDITY_INFO, validity);
+            }
+
             if (templateParams.containsKey(Constants.DID_URL)) {
                 finalMDoc.put("_issuer", templateParams.get(Constants.DID_URL));
             }
@@ -389,18 +423,15 @@ public class MDocProcessor {
         mso.put("valueDigests", nameSpacesDigests);
         mso.put(Constants.DOCTYPE, mDocJson.get("_docType"));
 
+        // Create validity info with current timestamp
         Map<String, Object> validityInfo = new HashMap<>();
-        ZonedDateTime currentTime = ZonedDateTime.now(ZoneOffset.UTC);
-        String formattedCurrentTime = currentTime
-                .format(DateTimeFormatter.ofPattern(Constants.UTC_DATETIME_PATTERN));
-        String futureTime = currentTime
-                .plusYears(mDocConfig.getValidityPeriodYears())
-                .format(DateTimeFormatter.ofPattern(Constants.UTC_DATETIME_PATTERN));
 
-        validityInfo.put(Constants.SIGNED, createCBORTaggedDateTime(formattedCurrentTime));
-        validityInfo.put(VCDM2Constants.VALID_FROM, createCBORTaggedDateTime(formattedCurrentTime));
-        validityInfo.put(VCDM2Constants.VALID_UNTIL, createCBORTaggedDateTime(futureTime));
-
+        if (mDocJson.containsKey(Constants.VALIDITY_INFO)) {
+            Map<String, Object> originalValidity = (Map<String, Object>) mDocJson.get(Constants.VALIDITY_INFO);
+            validityInfo.put(VCDM2Constants.VALID_FROM, originalValidity.get(VCDM2Constants.VALID_FROM));
+            validityInfo.put(VCDM2Constants.VALID_UNTIL, originalValidity.get(VCDM2Constants.VALID_UNTIL));
+            validityInfo.put("signed", originalValidity.get("signed"));
+        }
         mso.put(Constants.VALIDITY_INFO, validityInfo);
 
         // Add device key info (placeholder - should be from wallet's PoP)
@@ -420,7 +451,6 @@ public class MDocProcessor {
         String deviceKeyEncoded = deviceInfo.toString();
         if (deviceKeyEncoded.startsWith(Constants.DID_JWK_PREFIX)) {
             deviceKeyEncoded = deviceKeyEncoded.substring(Constants.DID_JWK_PREFIX.length());
-            deviceKeyEncoded = deviceKeyEncoded.replace("#0", "");
         }
 
         byte[] decodedBytes = Base64.getUrlDecoder().decode(deviceKeyEncoded);

--- a/certify-service/src/main/java/io/mosip/certify/utils/MDocProcessor.java
+++ b/certify-service/src/main/java/io/mosip/certify/utils/MDocProcessor.java
@@ -445,7 +445,7 @@ public class MDocProcessor {
      * Creates device key info structure (placeholder implementation)
      */
     private static Map<String, Object> createDeviceKeyInfo(Object deviceInfo) throws Exception {
-        if(deviceInfo == null) {
+        if (deviceInfo == null) {
             throw new IllegalArgumentException("Device info (holder ID) is required for mDoc credential");
         }
         String deviceKeyEncoded = deviceInfo.toString();
@@ -493,7 +493,7 @@ public class MDocProcessor {
      */
     public byte[] signMSO(Map<String, Object> mso, String appID, String refID, String signAlgorithm) throws Exception {
         try {
-            byte[] msoCbor = encodeToCBOR(mso);
+            byte[] msoCbor = encodeToTaggedCBOR(mso);
 
             CoseSignRequestDto signRequest = new CoseSignRequestDto();
 

--- a/certify-service/src/main/java/io/mosip/certify/utils/MDocProcessor.java
+++ b/certify-service/src/main/java/io/mosip/certify/utils/MDocProcessor.java
@@ -62,46 +62,48 @@ public class MDocProcessor {
             JsonNode templateNode = objectMapper.readTree(templatedJSON);
             Map<String, Object> finalMDoc = new HashMap<>();
 
-            if (templateNode.has(Constants.VALIDITY_INFO)) {
-                JsonNode validityInfo = templateNode.get(Constants.VALIDITY_INFO);
-                Map<String, Object> validity = objectMapper.convertValue(validityInfo, Map.class);
-                ZonedDateTime currentTime = ZonedDateTime.now(ZoneOffset.UTC);
-                String formattedCurrentTime = currentTime
-                        .format(DateTimeFormatter.ofPattern(Constants.UTC_DATETIME_PATTERN));
+            JsonNode validityInfo = Objects.requireNonNull(
+                    templateNode.get(Constants.VALIDITY_INFO),
+                    "Missing validity info"
+            );
 
-                if (validity.containsKey(VCDM2Constants.VALID_FROM)) {
-                    String validFromValue = (String) validity.get(VCDM2Constants.VALID_FROM);
-                    if ("${_validFrom}".equals(validFromValue)) {
-                        validity.put(VCDM2Constants.VALID_FROM, createCBORTaggedDateTime(formattedCurrentTime));
-                    }
-                }
+            Map<String, Object> validity = objectMapper.convertValue(validityInfo, Map.class);
 
-                if (validity.containsKey("signed")) {
-                    String signedValue = (String) validity.get("signed");
-                    if ("${_signed}".equals(signedValue)) {
-                        validity.put("signed", createCBORTaggedDateTime(formattedCurrentTime));
-                    }
-                }
-                if (validity.containsKey(VCDM2Constants.VALID_UNTIL)) {
-                    String validUntilValue = (String) validity.get(VCDM2Constants.VALID_UNTIL);
-                    if ("${_validUntil}".equals(validUntilValue)) {
-                        String futureTime = currentTime
-                                .plusYears(mDocConfig.getValidityPeriodYears())
-                                .format(DateTimeFormatter.ofPattern(Constants.UTC_DATETIME_PATTERN));
-                        validity.put(VCDM2Constants.VALID_UNTIL, createCBORTaggedDateTime(futureTime));
-                    }
-                }
+            String validFromValue = Objects.requireNonNull(
+                    (String) validity.get(VCDM2Constants.VALID_FROM),
+                    "Missing validFrom"
+            );
+            String signedValue = Objects.requireNonNull(
+                    (String) validity.get(Constants.SIGNED),
+                    "Missing signed"
+            );
+            String validUntilValue = Objects.requireNonNull(
+                    (String) validity.get(VCDM2Constants.VALID_UNTIL),
+                    "Missing validUntil"
+            );
 
+            ZonedDateTime currentTime = ZonedDateTime.now(ZoneOffset.UTC);
+            String formattedCurrentTime = currentTime.format(DateTimeFormatter.ofPattern(Constants.UTC_DATETIME_PATTERN));
 
-                finalMDoc.put(Constants.VALIDITY_INFO, validity);
+            if ("${_validFrom}".equals(validFromValue)) {
+                validity.put(VCDM2Constants.VALID_FROM, createCBORTaggedDateTime(formattedCurrentTime));
             }
+            if ("${_signed}".equals(signedValue)) {
+                validity.put(Constants.SIGNED, createCBORTaggedDateTime(formattedCurrentTime));
+            }
+            if ("${_validUntil}".equals(validUntilValue)) {
+                String futureTime = currentTime.plusYears(mDocConfig.getValidityPeriodYears())
+                        .format(DateTimeFormatter.ofPattern(Constants.UTC_DATETIME_PATTERN));
+                validity.put(VCDM2Constants.VALID_UNTIL, createCBORTaggedDateTime(futureTime));
+            }
+
+            finalMDoc.put(Constants.VALIDITY_INFO, validity);
 
             if (templateParams.containsKey(Constants.DID_URL)) {
                 finalMDoc.put("_issuer", templateParams.get(Constants.DID_URL));
             }
-            if (templateNode.has(Constants.DOCTYPE)) {
-                finalMDoc.put("_docType", templateNode.get(Constants.DOCTYPE).asText());
-            }
+            String docType = Objects.requireNonNull(templateNode.get(Constants.DOCTYPE), "Missing docType").asText();
+            finalMDoc.put("_docType", docType);
             if (templateParams.containsKey(Constants._HOLDER_ID)) {
                 finalMDoc.put(Constants._HOLDER_ID, templateParams.get(Constants._HOLDER_ID));
             }
@@ -430,7 +432,7 @@ public class MDocProcessor {
             Map<String, Object> originalValidity = (Map<String, Object>) mDocJson.get(Constants.VALIDITY_INFO);
             validityInfo.put(VCDM2Constants.VALID_FROM, originalValidity.get(VCDM2Constants.VALID_FROM));
             validityInfo.put(VCDM2Constants.VALID_UNTIL, originalValidity.get(VCDM2Constants.VALID_UNTIL));
-            validityInfo.put("signed", originalValidity.get("signed"));
+            validityInfo.put(Constants.SIGNED, originalValidity.get(Constants.SIGNED));
         }
         mso.put(Constants.VALIDITY_INFO, validityInfo);
 
@@ -451,6 +453,7 @@ public class MDocProcessor {
         String deviceKeyEncoded = deviceInfo.toString();
         if (deviceKeyEncoded.startsWith(Constants.DID_JWK_PREFIX)) {
             deviceKeyEncoded = deviceKeyEncoded.substring(Constants.DID_JWK_PREFIX.length());
+            deviceKeyEncoded = deviceKeyEncoded.replace("#0","");
         }
 
         byte[] decodedBytes = Base64.getUrlDecoder().decode(deviceKeyEncoded);

--- a/certify-service/src/main/java/io/mosip/certify/utils/MDocProcessor.java
+++ b/certify-service/src/main/java/io/mosip/certify/utils/MDocProcessor.java
@@ -62,40 +62,6 @@ public class MDocProcessor {
             JsonNode templateNode = objectMapper.readTree(templatedJSON);
             Map<String, Object> finalMDoc = new HashMap<>();
 
-            if (templateNode.has(Constants.VALIDITY_INFO)) {
-                JsonNode validityInfo = templateNode.get(Constants.VALIDITY_INFO);
-                Map<String, Object> validity = objectMapper.convertValue(validityInfo, Map.class);
-                ZonedDateTime currentTime = ZonedDateTime.now(ZoneOffset.UTC);
-                String formattedCurrentTime = currentTime
-                        .format(DateTimeFormatter.ofPattern(Constants.UTC_DATETIME_PATTERN));
-
-                if (validity.containsKey(VCDM2Constants.VALID_FROM)) {
-                    String validFromValue = (String) validity.get(VCDM2Constants.VALID_FROM);
-                    if ("${_validFrom}".equals(validFromValue)) {
-                        validity.put(VCDM2Constants.VALID_FROM, createCBORTaggedDateTime(formattedCurrentTime));
-                    }
-                }
-
-                if (validity.containsKey("signed")) {
-                    String signedValue = (String) validity.get("signed");
-                    if ("${_signed}".equals(signedValue)) {
-                        validity.put("signed", createCBORTaggedDateTime(formattedCurrentTime));
-                    }
-                }
-                if (validity.containsKey(VCDM2Constants.VALID_UNTIL)) {
-                    String validUntilValue = (String) validity.get(VCDM2Constants.VALID_UNTIL);
-                    if ("${_validUntil}".equals(validUntilValue)) {
-                        String futureTime = currentTime
-                                .plusYears(mDocConfig.getValidityPeriodYears())
-                                .format(DateTimeFormatter.ofPattern(Constants.UTC_DATETIME_PATTERN));
-                        validity.put(VCDM2Constants.VALID_UNTIL, createCBORTaggedDateTime(futureTime));
-                    }
-                }
-
-
-                finalMDoc.put(Constants.VALIDITY_INFO, validity);
-            }
-
             if (templateParams.containsKey(Constants.DID_URL)) {
                 finalMDoc.put("_issuer", templateParams.get(Constants.DID_URL));
             }
@@ -423,15 +389,18 @@ public class MDocProcessor {
         mso.put("valueDigests", nameSpacesDigests);
         mso.put(Constants.DOCTYPE, mDocJson.get("_docType"));
 
-        // Create validity info with current timestamp
         Map<String, Object> validityInfo = new HashMap<>();
+        ZonedDateTime currentTime = ZonedDateTime.now(ZoneOffset.UTC);
+        String formattedCurrentTime = currentTime
+                .format(DateTimeFormatter.ofPattern(Constants.UTC_DATETIME_PATTERN));
+        String futureTime = currentTime
+                .plusYears(mDocConfig.getValidityPeriodYears())
+                .format(DateTimeFormatter.ofPattern(Constants.UTC_DATETIME_PATTERN));
 
-        if (mDocJson.containsKey(Constants.VALIDITY_INFO)) {
-            Map<String, Object> originalValidity = (Map<String, Object>) mDocJson.get(Constants.VALIDITY_INFO);
-            validityInfo.put(VCDM2Constants.VALID_FROM, originalValidity.get(VCDM2Constants.VALID_FROM));
-            validityInfo.put(VCDM2Constants.VALID_UNTIL, originalValidity.get(VCDM2Constants.VALID_UNTIL));
-            validityInfo.put("signed", originalValidity.get("signed"));
-        }
+        validityInfo.put(Constants.SIGNED, createCBORTaggedDateTime(formattedCurrentTime));
+        validityInfo.put(VCDM2Constants.VALID_FROM, createCBORTaggedDateTime(formattedCurrentTime));
+        validityInfo.put(VCDM2Constants.VALID_UNTIL, createCBORTaggedDateTime(futureTime));
+
         mso.put(Constants.VALIDITY_INFO, validityInfo);
 
         // Add device key info (placeholder - should be from wallet's PoP)
@@ -451,6 +420,7 @@ public class MDocProcessor {
         String deviceKeyEncoded = deviceInfo.toString();
         if (deviceKeyEncoded.startsWith(Constants.DID_JWK_PREFIX)) {
             deviceKeyEncoded = deviceKeyEncoded.substring(Constants.DID_JWK_PREFIX.length());
+            deviceKeyEncoded = deviceKeyEncoded.replace("#0", "");
         }
 
         byte[] decodedBytes = Base64.getUrlDecoder().decode(deviceKeyEncoded);

--- a/certify-service/src/main/java/io/mosip/certify/utils/MDocProcessor.java
+++ b/certify-service/src/main/java/io/mosip/certify/utils/MDocProcessor.java
@@ -503,6 +503,7 @@ public class MDocProcessor {
             signRequest.setApplicationId(appID);
             signRequest.setReferenceId(refID);
             signRequest.setAlgorithm(signAlgorithm);
+            signRequest.setIncludeCOSETag(false);
 
             // Set unprotected header in request
             signRequest.setUnprotectedHeader(Map.of("includeCertificate", true));

--- a/certify-service/src/test/java/io/mosip/certify/credential/MDocCredentialTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/credential/MDocCredentialTest.java
@@ -58,13 +58,13 @@ public class MDocCredentialTest {
     // ==================== Format Handling Tests ====================
 
     @Test
-    public void testCanHandleReturnsTrueForMsoMdoc() {
+    public void should_returnTrue_when_canHandleMsoMdoc() {
         assertTrue("Should handle MSO_MDOC format",
                 mDocCredential.canHandle(VCFormats.MSO_MDOC));
     }
 
     @Test
-    public void testCanHandleReturnsFalseForOtherFormat() {
+    public void should_returnFalse_when_canHandleOtherFormat() {
         assertFalse("Should not handle ldp_vc", mDocCredential.canHandle(VCFormats.LDP_VC));
         assertFalse("Should not handle dc+sd-jwt", mDocCredential.canHandle(VCFormats.DC_SD_JWT));
         assertFalse("Should not handle null", mDocCredential.canHandle(null));
@@ -73,7 +73,7 @@ public class MDocCredentialTest {
     // ==================== Credential Creation Tests ====================
 
     @Test
-    public void testCreateCredentialWithValidInput() throws Exception {
+    public void should_createCredential_when_validInputProvided() throws Exception {
         String templateName = "mDocTemplate";
         Map<String, Object> templateParams = new HashMap<>();
         templateParams.put("name", "John Doe");
@@ -101,7 +101,7 @@ public class MDocCredentialTest {
     }
 
     @Test
-    public void testCreateCredentialWithComplexTemplate() throws Exception {
+    public void should_createCredential_when_complexTemplateProvided() throws Exception {
         String templateName = "complexTemplate";
         Map<String, Object> templateParams = new HashMap<>();
         templateParams.put("familyName", "Doe");
@@ -126,7 +126,7 @@ public class MDocCredentialTest {
     }
 
     @Test(expected = CertifyException.class)
-    public void testCreateCredentialThrowsExceptionWhenFormatterFails() {
+    public void should_throwException_when_formatterFails() {
         String templateName = "badTemplate";
         Map<String, Object> templateParams = new HashMap<>();
 
@@ -137,7 +137,7 @@ public class MDocCredentialTest {
     }
 
     @Test(expected = CertifyException.class)
-    public void testCreateCredentialThrowsExceptionWhenProcessingFails() {
+    public void should_throwException_when_processingFails() {
         String templateName = "badTemplate";
         Map<String, Object> templateParams = new HashMap<>();
         String templatedJSON = "{\"docType\":\"org.iso.18013.5.1.mDL\"}";
@@ -150,7 +150,7 @@ public class MDocCredentialTest {
     }
 
     @Test(expected = CertifyException.class)
-    public void testCreateCredentialThrowsExceptionWhenJsonSerializationFails() throws Exception {
+    public void should_throwException_when_jsonSerializationFails() throws Exception {
         String templateName = "mDocTemplate";
         Map<String, Object> templateParams = new HashMap<>();
         String templatedJSON = "{\"docType\":\"org.iso.18013.5.1.mDL\"}";
@@ -167,7 +167,7 @@ public class MDocCredentialTest {
     // ==================== Proof Generation Tests ====================
 
     @Test
-    public void testAddProofGeneratesCorrectVCResult() throws Exception {
+    public void should_generateCorrectVCResult_when_addProofCalled() throws Exception {
         String vcToSign = "{\"_docType\":\"org.iso.18013.5.1.mDL\",\"nameSpaces\":{}}";
         String appID = "testApp";
         String refID = "testRef";
@@ -215,7 +215,7 @@ public class MDocCredentialTest {
     }
 
     @Test
-    public void testAddProofReturnsBase64UrlEncodedCredential() throws Exception {
+    public void should_returnBase64UrlEncodedCredential_when_addProofCalled() throws Exception {
         String vcToSign = "{\"_docType\":\"org.iso.18013.5.1.mDL\"}";
         Map<String, Object> mDocJson = createTestMDocJson();
         Map<String, Object> saltedNamespaces = createTestSaltedNamespaces();
@@ -252,7 +252,7 @@ public class MDocCredentialTest {
     }
 
     @Test
-    public void testAddProofWithDifferentSignatureAlgorithms() throws Exception {
+    public void should_handleDifferentSignatureAlgorithms_when_addProofCalled() throws Exception {
         String vcToSign = "{\"_docType\":\"org.iso.18013.5.1.mDL\"}";
         String[] algorithms = {"ES256", "ES384", "ES512"};
 
@@ -288,7 +288,7 @@ public class MDocCredentialTest {
     }
 
     @Test
-    public void testAddProofWithNullHeaders() throws Exception {
+    public void should_handleNullHeaders_when_addProofCalled() throws Exception {
         String vcToSign = "{\"_docType\":\"org.iso.18013.5.1.mDL\"}";
         Map<String, Object> mDocJson = createTestMDocJson();
         Map<String, Object> saltedNamespaces = createTestSaltedNamespaces();
@@ -322,7 +322,7 @@ public class MDocCredentialTest {
     // ==================== Error Handling Tests ====================
 
     @Test(expected = CertifyException.class)
-    public void testAddProofThrowsExceptionWhenJsonParsingFails() throws Exception {
+    public void should_throwException_when_jsonParsingFails() throws Exception {
         String vcToSign = "invalid json";
         String appID = "testApp";
         String refID = "testRef";
@@ -336,7 +336,7 @@ public class MDocCredentialTest {
     }
 
     @Test(expected = CertifyException.class)
-    public void testAddProofThrowsExceptionWhenSaltingFails() throws Exception {
+    public void should_throwException_when_saltingFails() throws Exception {
         String vcToSign = "{\"_docType\":\"org.iso.18013.5.1.mDL\"}";
         Map<String, Object> mDocJson = createTestMDocJson();
 
@@ -352,7 +352,7 @@ public class MDocCredentialTest {
     }
 
     @Test(expected = CertifyException.class)
-    public void testAddProofThrowsExceptionWhenDigestCalculationFails() throws Exception {
+    public void should_throwException_when_digestCalculationFails() throws Exception {
         String vcToSign = "{\"_docType\":\"org.iso.18013.5.1.mDL\"}";
         Map<String, Object> mDocJson = createTestMDocJson();
         Map<String, Object> saltedNamespaces = createTestSaltedNamespaces();
@@ -370,7 +370,7 @@ public class MDocCredentialTest {
     }
 
     @Test(expected = CertifyException.class)
-    public void testAddProofThrowsExceptionWhenMSOCreationFails() throws Exception {
+    public void should_throwException_when_msoCreationFails() throws Exception {
         String vcToSign = "{\"_docType\":\"org.iso.18013.5.1.mDL\"}";
         Map<String, Object> mDocJson = createTestMDocJson();
         Map<String, Object> saltedNamespaces = createTestSaltedNamespaces();
@@ -391,7 +391,7 @@ public class MDocCredentialTest {
     }
 
     @Test(expected = CertifyException.class)
-    public void testAddProofThrowsExceptionWhenMSOSigningFails() throws Exception {
+    public void should_throwException_when_msoSigningFails() throws Exception {
         String vcToSign = "{\"_docType\":\"org.iso.18013.5.1.mDL\"}";
         Map<String, Object> mDocJson = createTestMDocJson();
         Map<String, Object> saltedNamespaces = createTestSaltedNamespaces();
@@ -414,7 +414,7 @@ public class MDocCredentialTest {
     }
 
     @Test(expected = CertifyException.class)
-    public void testAddProofThrowsExceptionWhenCBOREncodingFails() throws Exception {
+    public void should_throwException_when_cborEncodingFails() throws Exception {
         String vcToSign = "{\"_docType\":\"org.iso.18013.5.1.mDL\"}";
         Map<String, Object> mDocJson = createTestMDocJson();
         Map<String, Object> saltedNamespaces = createTestSaltedNamespaces();
@@ -443,7 +443,7 @@ public class MDocCredentialTest {
     }
 
     @Test(expected = CertifyException.class)
-    public void testAddProofThrowsExceptionWhenIssuerSignedStructureFails() throws Exception {
+    public void should_throwException_when_issuerSignedStructureFails() throws Exception {
         String vcToSign = "{\"_docType\":\"org.iso.18013.5.1.mDL\"}";
         Map<String, Object> mDocJson = createTestMDocJson();
         Map<String, Object> saltedNamespaces = createTestSaltedNamespaces();

--- a/certify-service/src/test/java/io/mosip/certify/credential/MDocCredentialTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/credential/MDocCredentialTest.java
@@ -126,7 +126,7 @@ public class MDocCredentialTest {
     }
 
     @Test(expected = CertifyException.class)
-    public void testCreateCredentialThrowsExceptionWhenFormatterFails() throws Exception {
+    public void testCreateCredentialThrowsExceptionWhenFormatterFails() {
         String templateName = "badTemplate";
         Map<String, Object> templateParams = new HashMap<>();
 
@@ -137,7 +137,7 @@ public class MDocCredentialTest {
     }
 
     @Test(expected = CertifyException.class)
-    public void testCreateCredentialThrowsExceptionWhenProcessingFails() throws Exception {
+    public void testCreateCredentialThrowsExceptionWhenProcessingFails() {
         String templateName = "badTemplate";
         Map<String, Object> templateParams = new HashMap<>();
         String templatedJSON = "{\"docType\":\"org.iso.18013.5.1.mDL\"}";
@@ -176,7 +176,6 @@ public class MDocCredentialTest {
 
         Map<String, Object> mDocJson = createTestMDocJson();
         Map<String, Object> saltedNamespaces = createTestSaltedNamespaces();
-        Map<String, Map<Integer, byte[]>> namespaceDigests = new HashMap<>();
         Map<String, Object> taggedNamespaces = createTestTaggedNamespaces();
         Map<String, Object> mso = createTestMSO();
         byte[] signedMSO = new byte[]{1, 2, 3, 4};
@@ -208,6 +207,10 @@ public class MDocCredentialTest {
 
             verify(mDocProcessor).createMobileSecurityObject(eq(mDocJson), any());
             verify(mDocProcessor).signMSO(mso, appID, refID, signAlgorithm);
+            // Issuer signed is CBOR encoded and base64 url encoded
+            mockedStatic.verify(() -> MDocProcessor.encodeToCBOR(issuerSigned));
+            byte[] decodedMdoc = Base64.getUrlDecoder().decode(result.getCredential().toString());
+            assertArrayEquals(decodedMdoc, cborIssuerSigned);
         }
     }
 

--- a/certify-service/src/test/java/io/mosip/certify/utils/MDocProcessorTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/utils/MDocProcessorTest.java
@@ -126,19 +126,20 @@ public class MDocProcessorTest {
             List<Map<String, Object>> items = (List<Map<String, Object>>) nameSpaces.get("org.iso.18013.5.1");
             assertEquals("Should have 3 elements", 3, items.size());
 
-            assertEquals("family_name", items.get(0).get("elementIdentifier"));
-            assertEquals("Doe", items.get(0).get("elementValue"));
-            assertEquals(0, items.get(0).get("digestID"));
+            assertEquals("family_name", items.getFirst().get("elementIdentifier"));
+            assertEquals("Doe", items.getFirst().get("elementValue"));
+            assertEquals(0, items.getFirst().get("digestID"));
         }
     }
 
     @Test
-    public void processTemplatedJson_ValidityInfoPlaceholders_ReplacedWithTimestamps() throws Exception {
+    public void processTemplatedJson_ValidityInfoPlaceholders_ReplacedWithTimestamps() {
         String templatedJSON = "{"
                 + "\"docType\": \"org.iso.18013.5.1.mDL\","
                 + "\"validityInfo\": {"
                 + "  \"validFrom\": \"${_validFrom}\","
-                + "  \"validUntil\": \"${_validUntil}\""
+                + "  \"validUntil\": \"${_validUntil}\","
+                + "  \"signed\": \"${_signed}\""
                 + "},"
                 + "\"nameSpaces\": {}"
                 + "}";
@@ -148,17 +149,20 @@ public class MDocProcessorTest {
         Map<String, Object> validityInfo = (Map<String, Object>) result.get("validityInfo");
         assertNotNull("ValidityInfo should not be null", validityInfo);
 
-        String validFrom = (String) validityInfo.get(VCDM2Constants.VALID_FROM);
-        String validUntil = (String) validityInfo.get(VCDM2Constants.VALID_UNTIL);
+        String validFrom =  (String)((Map<String,Object>) validityInfo.get(VCDM2Constants.VALID_FROM)).get(Constants.__CBOR_VALUE);
+        String validUntil =  (String)((Map<String,Object>) validityInfo.get(VCDM2Constants.VALID_UNTIL)).get(Constants.__CBOR_VALUE);
+        String signed =  (String)((Map<String,Object>) validityInfo.get(Constants.SIGNED)).get(Constants.__CBOR_VALUE);
 
         assertNotNull("ValidFrom should be set", validFrom);
         assertNotNull("ValidUntil should be set", validUntil);
         assertNotEquals("${_validFrom}", validFrom);
+        assertNotEquals("${_signed}", signed);
         assertNotEquals("${_validUntil}", validUntil);
 
         // Verify timestamp format (ISO 8601)
         assertTrue("ValidFrom should match ISO 8601",
                 validFrom.matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.*"));
+        assertTrue(signed.matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.*"));
         assertTrue("ValidUntil should match ISO 8601",
                 validUntil.matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.*"));
     }
@@ -997,7 +1001,7 @@ public class MDocProcessorTest {
         Map<String, Object> result = mDocProcessor.processTemplatedJson(template, new HashMap<>());
 
         Map<String, Object> validityInfo = (Map<String, Object>) result.get("validityInfo");
-        String validUntil = (String) validityInfo.get(VCDM2Constants.VALID_UNTIL);
+        String validUntil = (String) ((Map<String, Object>) validityInfo.get("validUntil")).get(Constants.__CBOR_VALUE);
 
         assertNotNull("ValidUntil should be set", validUntil);
         // Verify it's approximately 10 years in the future (allowing for execution time)

--- a/certify-service/src/test/java/io/mosip/certify/utils/MDocProcessorTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/utils/MDocProcessorTest.java
@@ -12,6 +12,8 @@ import io.mosip.kernel.signature.dto.CoseSignRequestDto;
 import io.mosip.kernel.signature.dto.CoseSignResponseDto;
 import io.mosip.kernel.signature.service.CoseSignatureService;
 import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.*;
@@ -46,6 +48,23 @@ import static org.mockito.Mockito.*;
 @RunWith(MockitoJUnitRunner.class)
 public class MDocProcessorTest {
 
+    private static MockedStatic<ZonedDateTime> mockedZonedDateTime;
+    private static final ZonedDateTime FIXED_NOW = ZonedDateTime.of(2026, 7, 20, 10, 0, 0, 0, ZoneOffset.UTC);
+
+    @BeforeClass
+    public static void setUpZonedDateTimeMock() {
+        mockedZonedDateTime = mockStatic(ZonedDateTime.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
+        mockedZonedDateTime.when(() -> ZonedDateTime.now(ZoneOffset.UTC))
+                .thenReturn(FIXED_NOW);
+    }
+
+    @AfterClass
+    public static void tearDownZonedDateTimeMock() {
+        if (mockedZonedDateTime != null) {
+            mockedZonedDateTime.close();
+        }
+    }
+
     @Mock
     private MDocConfig mDocConfig;
 
@@ -72,99 +91,28 @@ public class MDocProcessorTest {
 
     @Test
     public void processTemplatedJson_ValidmDLTemplate_MapsToISO18013Elements() {
-        // Mock ZonedDateTime.now() to return a fixed date for consistent testing
-        ZonedDateTime fixedDateTime = ZonedDateTime.of(2026, 7, 20, 10, 0, 0, 0, ZoneOffset.UTC);
-        
-        try (MockedStatic<ZonedDateTime> mockedZonedDateTime = mockStatic(ZonedDateTime.class, CALLS_REAL_METHODS)) {
-            mockedZonedDateTime.when(() -> ZonedDateTime.now(ZoneOffset.UTC))
-                    .thenReturn(fixedDateTime);
+        String templatedJSON = createFullmDLTemplate();
 
-            String templatedJSON = "{"
-                    + "\"docType\": \"org.iso.18013.5.1.mDL\","
-                    + "\"validityInfo\": {"
-                    + "  \"validFrom\": \"${_validFrom}\","
-                    + "  \"validUntil\": \"${_validUntil}\","
-                    + "  \"signed\": \"${_signed}\""
-                    + "},"
-                    + "\"nameSpaces\": {"
-                    + "  \"org.iso.18013.5.1\": ["
-                    + "    {\"digestID\": 0, \"elementIdentifier\": \"family_name\", \"elementValue\": \"Doe\"},"
-                    + "    {\"digestID\": 1, \"elementIdentifier\": \"given_name\", \"elementValue\": \"John\"},"
-                    + "    {\"digestID\": 2, \"elementIdentifier\": \"birth_date\", \"elementValue\": \"1990-08-25\"}"
-                    + "  ]"
-                    + "}"
-                    + "}";
+        Map<String, Object> templateParams = new HashMap<>();
+        templateParams.put("didUrl", "https://issuer.example.com/did");
+        templateParams.put("_holderId", "did:jwk:test123");
 
-            Map<String, Object> templateParams = new HashMap<>();
-            templateParams.put("didUrl", "https://issuer.example.com/did");
-            templateParams.put("_holderId", "did:jwk:test123");
+        Map<String, Object> result = mDocProcessor.processTemplatedJson(templatedJSON, templateParams);
 
-            Map<String, Object> result = mDocProcessor.processTemplatedJson(templatedJSON, templateParams);
+        assertNotNull("Result should not be null", result);
+        assertEquals("DocType should match", "org.iso.18013.5.1.mDL", result.get("_docType"));
+        assertEquals("HolderId should match", "did:jwk:test123", result.get("_holderId"));
+        assertEquals("Issuer should match", "https://issuer.example.com/did", result.get("_issuer"));
 
-            assertNotNull("Result should not be null", result);
-            assertEquals("DocType should match", "org.iso.18013.5.1.mDL", result.get("_docType"));
-            assertEquals("HolderId should match", "did:jwk:test123", result.get("_holderId"));
-            assertEquals("Issuer should match", "https://issuer.example.com/did", result.get("_issuer"));
-            assertEquals("ValidityInfo should match",  Map.of(
-                    "signed", Map.of(
-                            Constants.__CBOR_TAG, 0,
-                            Constants.__CBOR_VALUE, "2026-07-20T10:00:00.000Z"
-                    ),
-                    "validFrom", Map.of(
-                            Constants.__CBOR_TAG, 0,
-                            Constants.__CBOR_VALUE, "2026-07-20T10:00:00.000Z"
-                    ),
-                    "validUntil", Map.of(
-                            Constants.__CBOR_TAG, 0,
-                            Constants.__CBOR_VALUE, "2031-07-20T10:00:00.000Z"
-                    )
-            ), result.get("validityInfo"));
+        Map<String, Object> nameSpaces = (Map<String, Object>) result.get("nameSpaces");
+        assertNotNull("NameSpaces should not be null", nameSpaces);
 
-            Map<String, Object> nameSpaces = (Map<String, Object>) result.get("nameSpaces");
-            assertNotNull("NameSpaces should not be null", nameSpaces);
+        List<Map<String, Object>> items = (List<Map<String, Object>>) nameSpaces.get("org.iso.18013.5.1");
+        assertEquals("Should have 3 elements", 3, items.size());
 
-            List<Map<String, Object>> items = (List<Map<String, Object>>) nameSpaces.get("org.iso.18013.5.1");
-            assertEquals("Should have 3 elements", 3, items.size());
-
-            assertEquals("family_name", items.getFirst().get("elementIdentifier"));
-            assertEquals("Doe", items.getFirst().get("elementValue"));
-            assertEquals(0, items.getFirst().get("digestID"));
-        }
-    }
-
-    @Test
-    public void processTemplatedJson_ValidityInfoPlaceholders_ReplacedWithTimestamps() {
-        String templatedJSON = "{"
-                + "\"docType\": \"org.iso.18013.5.1.mDL\","
-                + "\"validityInfo\": {"
-                + "  \"validFrom\": \"${_validFrom}\","
-                + "  \"validUntil\": \"${_validUntil}\","
-                + "  \"signed\": \"${_signed}\""
-                + "},"
-                + "\"nameSpaces\": {}"
-                + "}";
-
-        Map<String, Object> result = mDocProcessor.processTemplatedJson(templatedJSON, new HashMap<>());
-
-        Map<String, Object> validityInfo = (Map<String, Object>) result.get("validityInfo");
-        assertNotNull("ValidityInfo should not be null", validityInfo);
-
-        String validFrom =  (String)((Map<String,Object>) validityInfo.get(VCDM2Constants.VALID_FROM)).get(Constants.__CBOR_VALUE);
-        String validUntil =  (String)((Map<String,Object>) validityInfo.get(VCDM2Constants.VALID_UNTIL)).get(Constants.__CBOR_VALUE);
-        String signed =  (String)((Map<String,Object>) validityInfo.get(Constants.SIGNED)).get(Constants.__CBOR_VALUE);
-
-        assertNotNull("ValidFrom should be set", validFrom);
-        assertNotNull("ValidUntil should be set", validUntil);
-        assertNotEquals("${_validFrom}", validFrom);
-        assertNotEquals("${_signed}", signed);
-        assertNotEquals("${_validUntil}", validUntil);
-
-        // Verify timestamp format (ISO 8601)
-        assertTrue("ValidFrom should match ISO 8601",
-                validFrom.matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.*"));
-        assertTrue(signed.matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.*"));
-        assertTrue("ValidUntil should match ISO 8601",
-                validUntil.matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.*"));
+        assertEquals("family_name", items.getFirst().get("elementIdentifier"));
+        assertEquals("Doe", items.getFirst().get("elementValue"));
+        assertEquals(0, items.getFirst().get("digestID"));
     }
 
     @Test
@@ -644,12 +592,6 @@ public class MDocProcessorTest {
         mDocJson.put("_docType", "org.iso.18013.5.1.mDL");
         mDocJson.put("_holderId", createTestDidJwk());
 
-        Map<String, Object> validityInfo = new HashMap<>();
-        validityInfo.put(VCDM2Constants.VALID_FROM, "2024-01-01T00:00:00Z");
-        validityInfo.put(VCDM2Constants.VALID_UNTIL, "2025-01-01T00:00:00Z");
-        validityInfo.put(Constants.SIGNED, "2024-01-01T00:00:00Z");
-        mDocJson.put("validityInfo", validityInfo);
-
         Map<String, Map<Integer, byte[]>> namespaceDigests = new HashMap<>();
         Map<Integer, byte[]> digests = new HashMap<>();
         digests.put(0, new byte[32]);
@@ -663,11 +605,20 @@ public class MDocProcessorTest {
         assertEquals("Digest algorithm should match", "SHA-256", result.get("digestAlgorithm"));
         assertEquals("DocType should match", "org.iso.18013.5.1.mDL", result.get(Constants.DOCTYPE));
 
-        Map<String, Object> actualValidityInfo = (Map<String, Object>) result.get("validityInfo");
-        assertNotNull("Should have validityInfo", actualValidityInfo);
-        assertEquals("ValidFrom should match", "2024-01-01T00:00:00Z", actualValidityInfo.get(VCDM2Constants.VALID_FROM));
-        assertEquals("ValidUntil should match", "2025-01-01T00:00:00Z", actualValidityInfo.get(VCDM2Constants.VALID_UNTIL));
-        assertEquals("Signed should match", "2024-01-01T00:00:00Z", actualValidityInfo.get(Constants.SIGNED));
+        Map<String, Object> validityInfo = (Map<String, Object>) result.get("validityInfo");
+        assertNotNull("Should have validityInfo", validityInfo);
+        assertEquals("ValidFrom should match", Map.of(
+                Constants.__CBOR_TAG, 0,
+                Constants.__CBOR_VALUE, "2026-07-20T10:00:00.000Z"
+        ), validityInfo.get(VCDM2Constants.VALID_FROM));
+        assertEquals("ValidUntil should match", Map.of(
+                Constants.__CBOR_TAG, 0,
+                Constants.__CBOR_VALUE, "2031-07-20T10:00:00.000Z"
+        ), validityInfo.get(VCDM2Constants.VALID_UNTIL));
+        assertEquals("Signed should match", Map.of(
+                Constants.__CBOR_TAG, 0,
+                Constants.__CBOR_VALUE, "2026-07-20T10:00:00.000Z"
+        ), validityInfo.get("signed"));
         assertNotNull("Should have valueDigests", result.get("valueDigests"));
         assertNotNull("Should have deviceKeyInfo", result.get("deviceKeyInfo"));
     }
@@ -702,17 +653,19 @@ public class MDocProcessorTest {
     }
 
     @Test
-    public void createMobileSecurityObject_ValidityInfo_PreservesValues() throws Exception {
+    public void createMobileSecurityObject_Adds_ValidityInfo() throws Exception {
         Map<String, Object> mDocJson = new HashMap<>();
         mDocJson.put("_docType", "org.test.doc");
         mDocJson.put("_holderId", createTestDidJwk());
 
-        String validFrom = "2024-06-15T10:30:00Z";
-        String validUntil = "2025-06-15T10:30:00Z";
-        Map<String, Object> validityInfo = new HashMap<>();
-        validityInfo.put(VCDM2Constants.VALID_FROM, validFrom);
-        validityInfo.put(VCDM2Constants.VALID_UNTIL, validUntil);
-        mDocJson.put("validityInfo", validityInfo);
+        Map<String, Object> validFrom = Map.of(
+                Constants.__CBOR_TAG, 0,
+                Constants.__CBOR_VALUE, "2026-07-20T10:00:00.000Z"
+        );
+        Map<String, Object> validUntil = Map.of(
+                Constants.__CBOR_TAG, 0,
+                Constants.__CBOR_VALUE, "2031-07-20T10:00:00.000Z"
+        );
 
         Map<String, Object> result = mDocProcessor.createMobileSecurityObject(mDocJson, new HashMap<>());
 
@@ -992,21 +945,6 @@ public class MDocProcessorTest {
     }
 
     // ==================== Configuration Tests ====================
-
-    @Test
-    public void mDocConfig_ValidityPeriod_UsedInTemplate() throws Exception {
-        when(mDocConfig.getValidityPeriodYears()).thenReturn(10);
-
-        String template = "{\"validityInfo\": {\"validFrom\": \"${_validFrom}\", \"validUntil\": \"${_validUntil}\"}}";
-        Map<String, Object> result = mDocProcessor.processTemplatedJson(template, new HashMap<>());
-
-        Map<String, Object> validityInfo = (Map<String, Object>) result.get("validityInfo");
-        String validUntil = (String) ((Map<String, Object>) validityInfo.get("validUntil")).get(Constants.__CBOR_VALUE);
-
-        assertNotNull("ValidUntil should be set", validUntil);
-        // Verify it's approximately 10 years in the future (allowing for execution time)
-        assertTrue("ValidUntil should be in the future", validUntil.compareTo("2030-01-01") > 0);
-    }
 
     @Test
     public void mDocConfig_MsoVersion_UsedInMSO() throws Exception {

--- a/certify-service/src/test/java/io/mosip/certify/utils/MDocProcessorTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/utils/MDocProcessorTest.java
@@ -746,6 +746,7 @@ public class MDocProcessorTest {
         assertEquals("Application ID should match", "testApp", requestDto.getApplicationId());
         assertEquals("Reference ID should match", "testRef", requestDto.getReferenceId());
         assertEquals("Algorithm should match", "ES256", requestDto.getAlgorithm());
+        assertEquals("Include COSE Tag should match", false, requestDto.getIncludeCOSETag());
     }
 
     @Test(expected = CertifyException.class)

--- a/certify-service/src/test/java/io/mosip/certify/utils/MDocProcessorTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/utils/MDocProcessorTest.java
@@ -15,6 +15,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.AfterClass;
 import org.junit.Test;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.runner.RunWith;
 import org.mockito.*;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -23,11 +24,13 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.Serializable;
 import java.time.ZonedDateTime;
 import java.time.ZoneOffset;
 import java.util.*;
 import java.util.Base64;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -50,6 +53,20 @@ public class MDocProcessorTest {
 
     private static MockedStatic<ZonedDateTime> mockedZonedDateTime;
     private static final ZonedDateTime FIXED_NOW = ZonedDateTime.of(2026, 7, 20, 10, 0, 0, 0, ZoneOffset.UTC);
+    private static final Map<String, Map<String, ? extends Serializable>> expectedValidityInfo = Map.of(
+            "signed", Map.of(
+                    Constants.__CBOR_TAG, 0,
+                    Constants.__CBOR_VALUE, "2026-07-20T10:00:00.000Z"
+            ),
+            "validFrom", Map.of(
+                    Constants.__CBOR_TAG, 0,
+                    Constants.__CBOR_VALUE, "2026-07-20T10:00:00.000Z"
+            ),
+            "validUntil", Map.of(
+                    Constants.__CBOR_TAG, 0,
+                    Constants.__CBOR_VALUE, "2031-07-20T10:00:00.000Z"
+            )
+    );
 
     @BeforeClass
     public static void setUpZonedDateTimeMock() {
@@ -114,20 +131,7 @@ public class MDocProcessorTest {
         assertEquals("Doe", items.getFirst().get("elementValue"));
         assertEquals(0, items.getFirst().get("digestID"));
 
-        assertEquals("ValidityInfo should match",  Map.of(
-                "signed", Map.of(
-                        Constants.__CBOR_TAG, 0,
-                        Constants.__CBOR_VALUE, "2026-07-20T10:00:00.000Z"
-                ),
-                "validFrom", Map.of(
-                        Constants.__CBOR_TAG, 0,
-                        Constants.__CBOR_VALUE, "2026-07-20T10:00:00.000Z"
-                ),
-                "validUntil", Map.of(
-                        Constants.__CBOR_TAG, 0,
-                        Constants.__CBOR_VALUE, "2031-07-20T10:00:00.000Z"
-                )
-        ), result.get("validityInfo"));
+        assertEquals("ValidityInfo should match", expectedValidityInfo, result.get("validityInfo"));
     }
 
     @Test
@@ -168,6 +172,8 @@ public class MDocProcessorTest {
     @Test
     public void should_preserveStructure_when_complexElementValueProcessed() throws Exception {
         String templatedJSON = "{"
+                + getValidityInfoTemplate()+","
+                +"\"docType\": \"org.iso.18013.5.1.mDL\","
                 + "\"nameSpaces\": {"
                 + "  \"org.iso.18013.5.1\": ["
                 + "    {"
@@ -209,11 +215,46 @@ public class MDocProcessorTest {
         assertTrue("Result should be empty", result.isEmpty());
     }
 
+    @Test
+    public void should_throwException_when_validityInfoInvalid() {
+        provideValidityInfoTestCases().forEach(args -> {
+            String testName = (String) args.get()[0];
+            String templatedJSON = (String) args.get()[1];
+            String expectedErrorMessage = (String) args.get()[2];
+
+            Map<String, Object> templateParams = new HashMap<>();
+            templateParams.put("didUrl", "https://issuer.example.com/did");
+            templateParams.put("_holderId", "did:jwk:test123");
+
+            CertifyException exception = assertThrows(CertifyException.class, () ->
+                    mDocProcessor.processTemplatedJson(templatedJSON, templateParams));
+
+            assertEquals("Test case [" + testName + "] failed", "Error processing templated JSON: "+expectedErrorMessage, exception.getMessage());
+        });
+    }
+
+    @Test
+    public void should_throwException_when_docTypeMissing() {
+        String templatedJSON = "{"
+                + getValidityInfoTemplate() + ","
+                + "\"nameSpaces\": {}"
+                + "}";
+
+        Map<String, Object> templateParams = new HashMap<>();
+        templateParams.put("didUrl", "https://issuer.example.com/did");
+        templateParams.put("_holderId", "did:jwk:test123");
+
+        CertifyException exception = assertThrows(CertifyException.class, () ->
+                mDocProcessor.processTemplatedJson(templatedJSON, templateParams));
+
+        assertEquals("Error processing templated JSON: Missing docType", exception.getMessage());
+    }
 
     @Test
     public void should_handleAllNamespaces_when_multipleNamespacesProcessed() throws Exception {
         String templatedJSON = "{"
                 + "\"docType\": \"org.mosip.credential\","
+                + getValidityInfoTemplate()+","
                 + "\"nameSpaces\": {"
                 + "  \"org.iso.18013.5.1\": ["
                 + "    {\"digestID\": 0, \"elementIdentifier\": \"family_name\", \"elementValue\": \"Doe\"}"
@@ -524,7 +565,7 @@ public class MDocProcessorTest {
 
             // These should be encoded as regular strings without tag 1004
             List<DataItem> decoded = new CborDecoder(new ByteArrayInputStream(encoded)).decode();
-            co.nstant.in.cbor.model.Map map = (co.nstant.in.cbor.model.Map) decoded.get(0);
+            co.nstant.in.cbor.model.Map map = (co.nstant.in.cbor.model.Map) decoded.getFirst();
             DataItem textItem = map.get(new UnicodeString("text"));
             assertNotNull("Text item should exist", textItem);
         }
@@ -568,7 +609,7 @@ public class MDocProcessorTest {
                 + "\"x\":\"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4\","
                 + "\"y\":\"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM\"}";
         String encodedKey = Base64.getUrlEncoder().encodeToString(jwkJson.getBytes());
-        String didJwk = "did:jwk:" + encodedKey;
+        String didJwk = "did:jwk:" + encodedKey+"#0";
 
         Map<String, Object> mDocJson = new HashMap<>();
         mDocJson.put("_holderId", didJwk);
@@ -641,12 +682,7 @@ public class MDocProcessorTest {
         Map<String, Object> mDocJson = new HashMap<>();
         mDocJson.put("_docType", "org.iso.18013.5.1.mDL");
         mDocJson.put("_holderId", createTestDidJwk());
-
-        Map<String, Object> validityInfo = new HashMap<>();
-        validityInfo.put(VCDM2Constants.VALID_FROM, "2024-01-01T00:00:00Z");
-        validityInfo.put(VCDM2Constants.VALID_UNTIL, "2025-01-01T00:00:00Z");
-        validityInfo.put(Constants.SIGNED, "2024-01-01T00:00:00Z");
-        mDocJson.put("validityInfo", validityInfo);
+        mDocJson.put("validityInfo", expectedValidityInfo);
 
         Map<String, Map<Integer, byte[]>> namespaceDigests = new HashMap<>();
         Map<Integer, byte[]> digests = new HashMap<>();
@@ -662,19 +698,7 @@ public class MDocProcessorTest {
         assertEquals("DocType should match", "org.iso.18013.5.1.mDL", result.get(Constants.DOCTYPE));
 
         Map<String, Object> actualValidityInfo = (Map<String, Object>) result.get("validityInfo");
-        assertNotNull("Should have validityInfo", actualValidityInfo);
-        assertEquals("ValidFrom should match", Map.of(
-                Constants.__CBOR_TAG, 0,
-                Constants.__CBOR_VALUE, "2026-07-20T10:00:00.000Z"
-        ), actualValidityInfo.get(VCDM2Constants.VALID_FROM));
-        assertEquals("ValidUntil should match", Map.of(
-                Constants.__CBOR_TAG, 0,
-                Constants.__CBOR_VALUE, "2031-07-20T10:00:00.000Z"
-        ), actualValidityInfo.get(VCDM2Constants.VALID_UNTIL));
-        assertEquals("Signed should match", Map.of(
-                Constants.__CBOR_TAG, 0,
-                Constants.__CBOR_VALUE, "2026-07-20T10:00:00.000Z"
-        ), actualValidityInfo.get("signed"));
+        assertEquals(expectedValidityInfo, actualValidityInfo);
         assertNotNull("Should have valueDigests", result.get("valueDigests"));
         assertNotNull("Should have deviceKeyInfo", result.get("deviceKeyInfo"));
     }
@@ -713,26 +737,12 @@ public class MDocProcessorTest {
         Map<String, Object> mDocJson = new HashMap<>();
         mDocJson.put("_docType", "org.test.doc");
         mDocJson.put("_holderId", createTestDidJwk());
-
-        Map<String, Object> validFrom = Map.of(
-                Constants.__CBOR_TAG, 0,
-                Constants.__CBOR_VALUE, "2026-07-20T10:00:00.000Z"
-        );
-        Map<String, Object> signed = Map.of(
-                Constants.__CBOR_TAG, 0,
-                Constants.__CBOR_VALUE, "2026-07-20T10:00:00.000Z"
-        );
-        Map<String, Object> validUntil = Map.of(
-                Constants.__CBOR_TAG, 0,
-                Constants.__CBOR_VALUE, "2031-07-20T10:00:00.000Z"
-        );
+        mDocJson.put("validityInfo", expectedValidityInfo);
 
         Map<String, Object> result = mDocProcessor.createMobileSecurityObject(mDocJson, new HashMap<>());
 
         Map<String, Object> resultValidity = (Map<String, Object>) result.get("validityInfo");
-        assertEquals("ValidFrom should match", validFrom, resultValidity.get(VCDM2Constants.VALID_FROM));
-        assertEquals("ValidUntil should match", validUntil, resultValidity.get(VCDM2Constants.VALID_UNTIL));
-        assertEquals("Signed should match", signed, resultValidity.get("signed"));
+        assertEquals(expectedValidityInfo, resultValidity);
     }
 
     // ==================== COSE Signing Tests ====================
@@ -1011,7 +1021,7 @@ public class MDocProcessorTest {
     public void should_addValidityPeriod_asPer_MdocConfig() throws Exception {
         when(mDocConfig.getValidityPeriodYears()).thenReturn(10);
 
-        String template = "{\"validityInfo\": {\"validFrom\": \"${_validFrom}\",\"signed\": \"${_signed}\", \"validUntil\": \"${_validUntil}\"}}";
+        String template = "{\"validityInfo\": {\"validFrom\": \"${_validFrom}\",\"signed\": \"${_signed}\", \"validUntil\": \"${_validUntil}\"}, \"docType\": \"${_docType}\"}";
         Map<String, Object> result = mDocProcessor.processTemplatedJson(template, new HashMap<>());
 
         Map<String, Object> validityInfo = (Map<String, Object>) result.get("validityInfo");
@@ -1133,11 +1143,7 @@ public class MDocProcessorTest {
     private String createFullmDLTemplate() {
         return "{"
                 + "\"docType\": \"org.iso.18013.5.1.mDL\","
-                + "\"validityInfo\": {"
-                + "  \"validFrom\": \"${_validFrom}\","
-                + "  \"validUntil\": \"${_validUntil}\","
-                + "  \"signed\": \"${_signed}\""
-                + "},"
+                + getValidityInfoTemplate()+","
                 + "\"nameSpaces\": {"
                 + "  \"org.iso.18013.5.1\": ["
                 + "    {\"digestID\": 0, \"elementIdentifier\": \"family_name\", \"elementValue\": \"Doe\"},"
@@ -1145,6 +1151,14 @@ public class MDocProcessorTest {
                 + "    {\"digestID\": 2, \"elementIdentifier\": \"birth_date\", \"elementValue\": \"1990-08-25\"}"
                 + "  ]"
                 + "}"
+                + "}";
+    }
+
+    private static String getValidityInfoTemplate() {
+        return "\"validityInfo\": {"
+                + "  \"validFrom\": \"${_validFrom}\","
+                + "  \"validUntil\": \"${_validUntil}\","
+                + "  \"signed\": \"${_signed}\""
                 + "}";
     }
 
@@ -1168,5 +1182,53 @@ public class MDocProcessorTest {
         return sb.toString();
     }
 
+    private static Stream<Arguments> provideValidityInfoTestCases() {
+        return Stream.of(
+                Arguments.of(
+                        "Missing validFrom field",
+                        "{"
+                                + "\"docType\": \"org.iso.18013.5.1.mDL\","
+                                + "\"holderId\": \"${_holderId}\","
+                                + "\"validityInfo\": {"
+                                + "\"signed\": \"${_signed}\","
+                                + "\"validUntil\": \"${_validUntil}\""
+                                + "}"
+                                + "}",
+                        "Missing validFrom"
+                ),
+                Arguments.of(
+                        "Missing signed field",
+                        "{"
+                                + "\"docType\": \"org.iso.18013.5.1.mDL\","
+                                + "\"holderId\": \"${_holderId}\","
+                                + "\"validityInfo\": {"
+                                + "\"validFrom\": \"${_validFrom}\","
+                                + "\"validUntil\": \"${_validUntil}\""
+                                + "}"
+                                + "}",
+                        "Missing signed"
+                ),
+                Arguments.of(
+                        "Missing validUntil field",
+                        "{"
+                                + "\"docType\": \"org.iso.18013.5.1.mDL\","
+                                + "\"holderId\": \"${_holderId}\","
+                                + "\"validityInfo\": {"
+                                + "\"validFrom\": \"${_validFrom}\","
+                                + "\"signed\": \"${_signed}\""
+                                + "}"
+                                + "}",
+                        "Missing validUntil"
+                ),
+                Arguments.of(
+                        "Validity info entirely missing",
+                        "{"
+                                + "\"docType\": \"org.iso.18013.5.1.mDL\","
+                                + "\"holderId\": \"${_holderId}\""
+                                + "}",
+                        "Missing validity info"
+                )
+        );
+    }
 
 }

--- a/certify-service/src/test/java/io/mosip/certify/utils/MDocProcessorTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/utils/MDocProcessorTest.java
@@ -747,6 +747,21 @@ public class MDocProcessorTest {
         assertEquals("Reference ID should match", "testRef", requestDto.getReferenceId());
         assertEquals("Algorithm should match", "ES256", requestDto.getAlgorithm());
         assertEquals("Include COSE Tag should match", false, requestDto.getIncludeCOSETag());
+
+        // Assert the request dto payload is B64 encoded - tagged mso #6.24(bstr .cbor mso)
+        String payload = requestDto.getPayload();
+        try {
+            byte[] decodedPayload = Base64.getUrlDecoder().decode(payload);
+            assertTrue("Decoded payload should contain data", decodedPayload.length > 0);
+            // Verify the decoded payload is a CBOR-encoded tag-24 wrapped ByteString (bstr .cbor mso)
+            List<DataItem> cborItems = new CborDecoder(new ByteArrayInputStream(decodedPayload)).decode();
+            assertFalse("Should decode to CBOR items", cborItems.isEmpty());
+            DataItem item = cborItems.get(0);
+            assertTrue("Payload should be a ByteString", item instanceof ByteString);
+            assertEquals("Payload should have CBOR tag 24", 24, item.getTag().getValue());
+        } catch (IllegalArgumentException e) {
+            fail("Payload should be valid Base64 encoded: " + e.getMessage());
+        }
     }
 
     @Test(expected = CertifyException.class)

--- a/certify-service/src/test/java/io/mosip/certify/utils/MDocProcessorTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/utils/MDocProcessorTest.java
@@ -90,7 +90,7 @@ public class MDocProcessorTest {
     // ==================== Template Processing Tests ====================
 
     @Test
-    public void processTemplatedJson_ValidmDLTemplate_MapsToISO18013Elements() {
+    public void should_mapToISO18013Elements_when_validmDLTemplateIsProcessed() {
         String templatedJSON = createFullmDLTemplate();
 
         Map<String, Object> templateParams = new HashMap<>();
@@ -116,7 +116,7 @@ public class MDocProcessorTest {
     }
 
     @Test
-    public void processTemplatedJson_ComplexElementValue_PreservesStructure() throws Exception {
+    public void should_preserveStructure_when_complexElementValueProcessed() throws Exception {
         String templatedJSON = "{"
                 + "\"nameSpaces\": {"
                 + "  \"org.iso.18013.5.1\": ["
@@ -147,7 +147,7 @@ public class MDocProcessorTest {
     }
 
     @Test
-    public void processTemplatedJson_InvalidJson_ReturnsEmptyMap() {
+    public void should_returnEmptyMap_when_invalidJsonProcessed() {
         String invalidJSON = "{invalid json}";
         Map<String, Object> result;
         try {
@@ -161,7 +161,7 @@ public class MDocProcessorTest {
 
 
     @Test
-    public void processTemplatedJson_MultipleNamespaces_HandlesAll() throws Exception {
+    public void should_handleAllNamespaces_when_multipleNamespacesProcessed() throws Exception {
         String templatedJSON = "{"
                 + "\"docType\": \"org.mosip.credential\","
                 + "\"nameSpaces\": {"
@@ -184,7 +184,7 @@ public class MDocProcessorTest {
     // ==================== Random Salt Generation Tests ====================
 
     @Test
-    public void addRandomSalts_AddsRandomBytesToAllElements() {
+    public void should_addRandomBytes_when_addRandomSaltsCalled() {
         Map<String, Object> mDocJson = createTestMDocJson();
 
         Map<String, Object> result = MDocProcessor.addRandomSalts(mDocJson);
@@ -201,7 +201,7 @@ public class MDocProcessorTest {
     }
 
     @Test
-    public void addRandomSalts_GeneratesUniqueSalts() {
+    public void should_generateUniqueSalts_when_addRandomSaltsCalled() {
         Map<String, Object> mDocJson = new HashMap<>();
         Map<String, Object> nameSpaces = new HashMap<>();
         List<Map<String, Object>> elements = new ArrayList<>();
@@ -225,7 +225,7 @@ public class MDocProcessorTest {
     }
 
     @Test
-    public void addRandomSalts_PreservesOriginalData() {
+    public void should_preserveOriginalData_when_addRandomSaltsCalled() {
         Map<String, Object> mDocJson = createTestMDocJson();
 
         Map<String, Object> result = MDocProcessor.addRandomSalts(mDocJson);
@@ -239,7 +239,7 @@ public class MDocProcessorTest {
     // ==================== Digest Calculation Tests ====================
 
     @Test
-    public void calculateDigests_GeneratesCorrectSHA256Digests() throws Exception {
+    public void should_generateCorrectSHA256Digests_when_calculateDigestsCalled() throws Exception {
         Map<String, Object> saltedNamespaces = new HashMap<>();
         List<Map<String, Object>> elements = new ArrayList<>();
         elements.add(createSaltedElement(0, "family_name", "Doe"));
@@ -258,7 +258,7 @@ public class MDocProcessorTest {
     }
 
     @Test
-    public void calculateDigests_MultipleElements_MapsDigestsByID() throws Exception {
+    public void should_mapDigestsByID_when_multipleElementsProvided() throws Exception {
         Map<String, Object> saltedNamespaces = new HashMap<>();
         List<Map<String, Object>> elements = new ArrayList<>();
 
@@ -280,7 +280,7 @@ public class MDocProcessorTest {
     }
 
     @Test
-    public void calculateDigests_WrapsWithCBORTag24() throws Exception {
+    public void should_wrapWithCBORTag24_when_calculateDigestsCalled() throws Exception {
         Map<String, Object> saltedNamespaces = new HashMap<>();
         List<Map<String, Object>> elements = new ArrayList<>();
         elements.add(createSaltedElement(0, "test", "value"));
@@ -301,7 +301,7 @@ public class MDocProcessorTest {
     }
 
     @Test
-    public void calculateDigests_VerifyDigestCalculation() throws Exception {
+    public void should_verifyDigestCalculation_when_calculateDigestsCalled() throws Exception {
         // Create element with known data
         Map<String, Object> element = new HashMap<>();
         element.put("digestID", 0);
@@ -328,7 +328,7 @@ public class MDocProcessorTest {
     // ==================== CBOR Encoding Tests ====================
 
     @Test
-    public void encodeToCBOR_SimpleMap_EncodesSuccessfully() throws Exception {
+    public void should_encodeSuccessfully_when_simpleMapEncoded() throws Exception {
         Map<String, Object> data = new HashMap<>();
         data.put("key", "value");
         data.put("number", 42);
@@ -345,7 +345,7 @@ public class MDocProcessorTest {
     }
 
     @Test
-    public void encodeToCBOR_WithByteArray_PreservesBytes() throws Exception {
+    public void should_preserveBytes_when_byteArrayEncoded() throws Exception {
         byte[] testBytes = new byte[]{1, 2, 3, 4, 5};
         Map<String, Object> data = new HashMap<>();
         data.put("bytes", testBytes);
@@ -362,7 +362,7 @@ public class MDocProcessorTest {
     }
 
     @Test
-    public void encodeToCBOR_NestedStructures_EncodesRecursively() throws Exception {
+    public void should_encodeRecursively_when_nestedStructuresEncoded() throws Exception {
         Map<String, Object> nested = new HashMap<>();
         nested.put("inner", "value");
         nested.put("innerNumber", 123);
@@ -378,7 +378,7 @@ public class MDocProcessorTest {
     }
 
     @Test
-    public void encodeToCBOR_DateString_AppliesTag1004() throws Exception {
+    public void should_applyTag1004_when_dateStringEncoded() throws Exception {
         Map<String, Object> data = new HashMap<>();
         data.put("birthDate", "1990-08-25");
 
@@ -397,7 +397,7 @@ public class MDocProcessorTest {
     }
 
     @Test
-    public void encodeToCBOR_AllDataTypes_HandlesCorrectly() throws Exception {
+    public void should_handleCorrectly_when_allDataTypesEncoded() throws Exception {
         Map<String, Object> data = new HashMap<>();
         data.put("string", "test");
         data.put("integer", 42);
@@ -416,7 +416,7 @@ public class MDocProcessorTest {
     }
 
     @Test
-    public void encodeToCBOR_NullInput_HandlesGracefully() throws Exception {
+    public void should_handleGracefully_when_nullInputEncoded() throws Exception {
         // Null is handled by preprocessForCBOR and converted to SimpleValue.NULL
         byte[] result = MDocProcessor.encodeToCBOR(Collections.singletonMap("nullKey", null));
 
@@ -427,7 +427,7 @@ public class MDocProcessorTest {
     // ==================== Date Handling Tests ====================
 
     @Test
-    public void dateHandling_ValidDates_RecognizedCorrectly() throws Exception {
+    public void should_recognizeCorrectly_when_validDatesHandled() throws Exception {
         String[] validDates = {
                 "2025-01-15",
                 "1990-12-31",
@@ -456,7 +456,7 @@ public class MDocProcessorTest {
     }
 
     @Test
-    public void dateHandling_NonDateStrings_NotTagged() throws Exception {
+    public void should_notTag_when_nonDateStringsHandled() throws Exception {
         String[] nonDates = {
                 "2025-13-01", // Invalid month
                 "2025/01/15", // Wrong format
@@ -483,7 +483,7 @@ public class MDocProcessorTest {
     // ==================== DeviceKeyInfo Tests ====================
 
     @Test
-    public void createDeviceKeyInfo_ValidDidJwkEC_ParsesCorrectly() throws Exception {
+    public void should_parseCorrectly_when_validDidJwkECProvided() throws Exception {
         String jwkJson = "{\"kty\":\"EC\",\"crv\":\"P-256\","
                 + "\"x\":\"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4\","
                 + "\"y\":\"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM\"}";
@@ -513,7 +513,7 @@ public class MDocProcessorTest {
     }
 
     @Test
-    public void createDeviceKeyInfo_P384Curve_MapsCorrectly() throws Exception {
+    public void should_mapCorrectly_when_p384CurveUsed() throws Exception {
         String jwkJson = "{\"kty\":\"EC\",\"crv\":\"P-384\","
                 + "\"x\":\"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4\","
                 + "\"y\":\"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM\"}";
@@ -531,7 +531,7 @@ public class MDocProcessorTest {
     }
 
     @Test
-    public void createDeviceKeyInfo_P521Curve_MapsCorrectly() throws Exception {
+    public void should_mapCorrectly_when_p521CurveUsed() throws Exception {
         String jwkJson = "{\"kty\":\"EC\",\"crv\":\"P-521\","
                 + "\"x\":\"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4\","
                 + "\"y\":\"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM\"}";
@@ -549,7 +549,7 @@ public class MDocProcessorTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void createDeviceKeyInfo_UnsupportedCurve_ThrowsException() throws Exception {
+    public void should_throwException_when_unsupportedCurveUsed() throws Exception {
         String jwkJson = "{\"kty\":\"EC\",\"crv\":\"secp256k1\","
                 + "\"x\":\"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4\","
                 + "\"y\":\"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM\"}";
@@ -563,7 +563,7 @@ public class MDocProcessorTest {
     }
 
     @Test
-    public void createDeviceKeyInfo_WithKeyId_PreservesKid() throws Exception {
+    public void should_preserveKid_when_keyIdProvided() throws Exception {
         String jwkJson = "{\"kty\":\"EC\",\"crv\":\"P-256\","
                 + "\"kid\":\"test-key-123\","
                 + "\"x\":\"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4\","
@@ -587,7 +587,7 @@ public class MDocProcessorTest {
     // ==================== MSO Structure Tests ====================
 
     @Test
-    public void createMobileSecurityObject_ValidInput_CreatesCompleteStructure() throws Exception {
+    public void should_createCompleteStructure_when_validInputProvided() throws Exception {
         Map<String, Object> mDocJson = new HashMap<>();
         mDocJson.put("_docType", "org.iso.18013.5.1.mDL");
         mDocJson.put("_holderId", createTestDidJwk());
@@ -624,7 +624,7 @@ public class MDocProcessorTest {
     }
 
     @Test
-    public void createMobileSecurityObject_ValueDigests_StructureCorrect() throws Exception {
+    public void should_structureCorrectly_when_valueDigestsProcessed() throws Exception {
         Map<String, Object> mDocJson = new HashMap<>();
         mDocJson.put("_docType", "org.test.doc");
         mDocJson.put("_holderId", createTestDidJwk());
@@ -653,7 +653,7 @@ public class MDocProcessorTest {
     }
 
     @Test
-    public void createMobileSecurityObject_Adds_ValidityInfo() throws Exception {
+    public void should_addValidityInfo_when_createMobileSecurityObjectIsCalled() throws Exception {
         Map<String, Object> mDocJson = new HashMap<>();
         mDocJson.put("_docType", "org.test.doc");
         mDocJson.put("_holderId", createTestDidJwk());
@@ -677,7 +677,7 @@ public class MDocProcessorTest {
     // ==================== COSE Signing Tests ====================
 
     @Test
-    public void signMSO_ValidInput_ReturnsSignedBytes() throws Exception {
+    public void should_returnSignedBytes_when_validInputProvided() throws Exception {
         Map<String, Object> mso = new HashMap<>();
         mso.put("version", "1.0");
         mso.put("digestAlgorithm", "SHA-256");
@@ -722,7 +722,7 @@ public class MDocProcessorTest {
     }
 
     @Test(expected = CertifyException.class)
-    public void signMSO_SigningFails_ThrowsException() throws Exception {
+    public void should_throwException_when_signingFails() throws Exception {
         Map<String, Object> mso = new HashMap<>();
         mso.put("version", "1.0");
 
@@ -735,7 +735,7 @@ public class MDocProcessorTest {
     // ==================== IssuerSigned Structure Tests ====================
 
     @Test
-    public void createIssuerSignedStructure_ValidInput_CreatesStructure() throws Exception {
+    public void should_createStructure_when_validInputProvided() throws Exception {
         Map<String, Object> processedNamespaces = new HashMap<>();
         List<Object> elements = new ArrayList<>();
 
@@ -767,7 +767,7 @@ public class MDocProcessorTest {
     }
 
     @Test
-    public void createIssuerSignedStructure_EmptyNamespaces_HandlesGracefully() throws Exception {
+    public void should_handleGracefully_when_emptyNamespacesProvided() throws Exception {
         Map<String, Object> processedNamespaces = new HashMap<>();
 
         co.nstant.in.cbor.model.Array coseArray = new co.nstant.in.cbor.model.Array();
@@ -788,7 +788,7 @@ public class MDocProcessorTest {
     }
 
     @Test(expected = IOException.class)
-    public void createIssuerSignedStructure_InvalidCBOR_ThrowsException() throws Exception {
+    public void should_throwException_when_invalidCBOREncountered() throws Exception {
         Map<String, Object> processedNamespaces = new HashMap<>();
 
         // Use bytes that will cause CborException - incomplete CBOR structure
@@ -799,7 +799,7 @@ public class MDocProcessorTest {
     // ==================== Integration Tests ====================
 
     @Test
-    public void multipleNamespacesWorkflow_HandlesCorrectly() throws Exception {
+    public void should_handleCorrectly_when_multipleNamespacesProcessed() throws Exception {
         Map<String, Object> mDocJson = new HashMap<>();
         mDocJson.put("_docType", "org.multi.credential");
         mDocJson.put("_holderId", createTestDidJwk());
@@ -825,7 +825,7 @@ public class MDocProcessorTest {
     // ==================== Edge Cases and Error Handling ====================
 
     @Test
-    public void addRandomSalts_EmptyNamespace_HandlesGracefully() {
+    public void should_handleGracefully_when_emptyNamespaceEncountered() {
         Map<String, Object> mDocJson = new HashMap<>();
         Map<String, Object> nameSpaces = new HashMap<>();
         nameSpaces.put("org.iso.18013.5.1", new ArrayList<>());
@@ -840,7 +840,7 @@ public class MDocProcessorTest {
     }
 
     @Test
-    public void calculateDigests_EmptyElements_HandlesGracefully() throws Exception {
+    public void should_handleGracefully_when_emptyElementsEncountered() throws Exception {
         Map<String, Object> saltedNamespaces = new HashMap<>();
         saltedNamespaces.put("org.iso.18013.5.1", new ArrayList<>());
 
@@ -854,7 +854,7 @@ public class MDocProcessorTest {
     }
 
     @Test
-    public void encodeToCBOR_NullValue_HandlesCorrectly() throws Exception {
+    public void should_handleCorrectly_when_nullValueEncoded() throws Exception {
         Map<String, Object> data = new HashMap<>();
         data.put("nullField", null);
         data.put("normalField", "value");
@@ -871,7 +871,7 @@ public class MDocProcessorTest {
     }
 
     @Test
-    public void encodeToCBOR_LargeNumbers_HandlesCorrectly() throws Exception {
+    public void should_handleCorrectly_when_largeNumbersEncoded() throws Exception {
         Map<String, Object> data = new HashMap<>();
         data.put("maxInt", Integer.MAX_VALUE);
         data.put("minInt", Integer.MIN_VALUE);
@@ -885,7 +885,7 @@ public class MDocProcessorTest {
     }
 
     @Test
-    public void encodeToCBOR_SpecialFloats_HandlesCorrectly() throws Exception {
+    public void should_handleCorrectly_when_specialFloatsEncoded() throws Exception {
         Map<String, Object> data = new HashMap<>();
         data.put("pi", 3.14159);
         data.put("negative", -2.5);
@@ -900,7 +900,7 @@ public class MDocProcessorTest {
     // ==================== CBOR Type Conversion Tests ====================
 
     @Test
-    public void convertToDataItem_Integer_ConvertsCorrectly() throws Exception {
+    public void should_convertCorrectly_when_integerConverted() throws Exception {
         Map<String, Object> data = new HashMap<>();
         data.put("positive", 42);
         data.put("negative", -42);
@@ -914,7 +914,7 @@ public class MDocProcessorTest {
     }
 
     @Test
-    public void convertToDataItem_Boolean_ConvertsCorrectly() throws Exception {
+    public void should_convertCorrectly_when_booleanConverted() throws Exception {
         Map<String, Object> data = new HashMap<>();
         data.put("trueValue", true);
         data.put("falseValue", false);
@@ -932,7 +932,7 @@ public class MDocProcessorTest {
     }
 
     @Test
-    public void convertToDataItem_List_ConvertsToArray() throws Exception {
+    public void should_convertToArray_when_listConverted() throws Exception {
         Map<String, Object> data = new HashMap<>();
         data.put("list", Arrays.asList("a", "b", "c"));
 
@@ -947,7 +947,7 @@ public class MDocProcessorTest {
     // ==================== Configuration Tests ====================
 
     @Test
-    public void mDocConfig_MsoVersion_UsedInMSO() throws Exception {
+    public void should_useMsoVersion_when_mDocConfigApplied() throws Exception {
         when(mDocConfig.getMsoVersion()).thenReturn("2.0");
 
         Map<String, Object> mDocJson = new HashMap<>();
@@ -960,7 +960,7 @@ public class MDocProcessorTest {
     }
 
     @Test
-    public void mDocConfig_DigestAlgorithm_UsedInMSO() throws Exception {
+    public void should_useDigestAlgorithm_when_mDocConfigApplied() throws Exception {
         when(mDocConfig.getDigestAlgorithm()).thenReturn("SHA-512");
 
         Map<String, Object> mDocJson = new HashMap<>();
@@ -975,7 +975,7 @@ public class MDocProcessorTest {
     // ==================== Compliance Tests (ISO 18013-5) ====================
 
     @Test
-    public void iso18013_IssuerSignedStructure_HasRequiredFields() throws Exception {
+    public void should_haveRequiredFields_when_issuerSignedStructureCreated() throws Exception {
         Map<String, Object> processedNamespaces = new HashMap<>();
         processedNamespaces.put("org.iso.18013.5.1", new ArrayList<>());
 
@@ -988,7 +988,7 @@ public class MDocProcessorTest {
     }
 
     @Test
-    public void iso18013_MSO_HasRequiredFields() throws Exception {
+    public void should_haveRequiredFields_when_msoCreated() throws Exception {
         Map<String, Object> mDocJson = new HashMap<>();
         mDocJson.put("_docType", "org.iso.18013.5.1.mDL");
         mDocJson.put("_holderId", createTestDidJwk());
@@ -1004,7 +1004,7 @@ public class MDocProcessorTest {
     }
 
     @Test
-    public void iso18013_IssuerSignedItem_Structure() throws Exception {
+    public void should_structureCorrectly_when_issuerSignedItemCreated() throws Exception {
         Map<String, Object> element = createSaltedElement(0, "family_name", "Doe");
 
         // Verify element has required fields

--- a/certify-service/src/test/java/io/mosip/certify/utils/MDocProcessorTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/utils/MDocProcessorTest.java
@@ -113,6 +113,56 @@ public class MDocProcessorTest {
         assertEquals("family_name", items.getFirst().get("elementIdentifier"));
         assertEquals("Doe", items.getFirst().get("elementValue"));
         assertEquals(0, items.getFirst().get("digestID"));
+
+        assertEquals("ValidityInfo should match",  Map.of(
+                "signed", Map.of(
+                        Constants.__CBOR_TAG, 0,
+                        Constants.__CBOR_VALUE, "2026-07-20T10:00:00.000Z"
+                ),
+                "validFrom", Map.of(
+                        Constants.__CBOR_TAG, 0,
+                        Constants.__CBOR_VALUE, "2026-07-20T10:00:00.000Z"
+                ),
+                "validUntil", Map.of(
+                        Constants.__CBOR_TAG, 0,
+                        Constants.__CBOR_VALUE, "2031-07-20T10:00:00.000Z"
+                )
+        ), result.get("validityInfo"));
+    }
+
+    @Test
+    public void processTemplatedJson_ValidityInfoPlaceholders_ReplacedWithTimestamps() {
+        String templatedJSON = "{"
+                + "\"docType\": \"org.iso.18013.5.1.mDL\","
+                + "\"validityInfo\": {"
+                + "  \"validFrom\": \"${_validFrom}\","
+                + "  \"validUntil\": \"${_validUntil}\","
+                + "  \"signed\": \"${_signed}\""
+                + "},"
+                + "\"nameSpaces\": {}"
+                + "}";
+
+        Map<String, Object> result = mDocProcessor.processTemplatedJson(templatedJSON, new HashMap<>());
+
+        Map<String, Object> validityInfo = (Map<String, Object>) result.get("validityInfo");
+        assertNotNull("ValidityInfo should not be null", validityInfo);
+
+        String validFrom =  (String)((Map<String,Object>) validityInfo.get(VCDM2Constants.VALID_FROM)).get(Constants.__CBOR_VALUE);
+        String validUntil =  (String)((Map<String,Object>) validityInfo.get(VCDM2Constants.VALID_UNTIL)).get(Constants.__CBOR_VALUE);
+        String signed =  (String)((Map<String,Object>) validityInfo.get(Constants.SIGNED)).get(Constants.__CBOR_VALUE);
+
+        assertNotNull("ValidFrom should be set", validFrom);
+        assertNotNull("ValidUntil should be set", validUntil);
+        assertNotEquals("${_validFrom}", validFrom);
+        assertNotEquals("${_signed}", signed);
+        assertNotEquals("${_validUntil}", validUntil);
+
+        // Verify timestamp format (ISO 8601)
+        assertTrue("ValidFrom should match ISO 8601",
+                validFrom.matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.*"));
+        assertTrue(signed.matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.*"));
+        assertTrue("ValidUntil should match ISO 8601",
+                validUntil.matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.*"));
     }
 
     @Test
@@ -592,6 +642,12 @@ public class MDocProcessorTest {
         mDocJson.put("_docType", "org.iso.18013.5.1.mDL");
         mDocJson.put("_holderId", createTestDidJwk());
 
+        Map<String, Object> validityInfo = new HashMap<>();
+        validityInfo.put(VCDM2Constants.VALID_FROM, "2024-01-01T00:00:00Z");
+        validityInfo.put(VCDM2Constants.VALID_UNTIL, "2025-01-01T00:00:00Z");
+        validityInfo.put(Constants.SIGNED, "2024-01-01T00:00:00Z");
+        mDocJson.put("validityInfo", validityInfo);
+
         Map<String, Map<Integer, byte[]>> namespaceDigests = new HashMap<>();
         Map<Integer, byte[]> digests = new HashMap<>();
         digests.put(0, new byte[32]);
@@ -605,20 +661,20 @@ public class MDocProcessorTest {
         assertEquals("Digest algorithm should match", "SHA-256", result.get("digestAlgorithm"));
         assertEquals("DocType should match", "org.iso.18013.5.1.mDL", result.get(Constants.DOCTYPE));
 
-        Map<String, Object> validityInfo = (Map<String, Object>) result.get("validityInfo");
-        assertNotNull("Should have validityInfo", validityInfo);
+        Map<String, Object> actualValidityInfo = (Map<String, Object>) result.get("validityInfo");
+        assertNotNull("Should have validityInfo", actualValidityInfo);
         assertEquals("ValidFrom should match", Map.of(
                 Constants.__CBOR_TAG, 0,
                 Constants.__CBOR_VALUE, "2026-07-20T10:00:00.000Z"
-        ), validityInfo.get(VCDM2Constants.VALID_FROM));
+        ), actualValidityInfo.get(VCDM2Constants.VALID_FROM));
         assertEquals("ValidUntil should match", Map.of(
                 Constants.__CBOR_TAG, 0,
                 Constants.__CBOR_VALUE, "2031-07-20T10:00:00.000Z"
-        ), validityInfo.get(VCDM2Constants.VALID_UNTIL));
+        ), actualValidityInfo.get(VCDM2Constants.VALID_UNTIL));
         assertEquals("Signed should match", Map.of(
                 Constants.__CBOR_TAG, 0,
                 Constants.__CBOR_VALUE, "2026-07-20T10:00:00.000Z"
-        ), validityInfo.get("signed"));
+        ), actualValidityInfo.get("signed"));
         assertNotNull("Should have valueDigests", result.get("valueDigests"));
         assertNotNull("Should have deviceKeyInfo", result.get("deviceKeyInfo"));
     }
@@ -662,6 +718,10 @@ public class MDocProcessorTest {
                 Constants.__CBOR_TAG, 0,
                 Constants.__CBOR_VALUE, "2026-07-20T10:00:00.000Z"
         );
+        Map<String, Object> signed = Map.of(
+                Constants.__CBOR_TAG, 0,
+                Constants.__CBOR_VALUE, "2026-07-20T10:00:00.000Z"
+        );
         Map<String, Object> validUntil = Map.of(
                 Constants.__CBOR_TAG, 0,
                 Constants.__CBOR_VALUE, "2031-07-20T10:00:00.000Z"
@@ -672,6 +732,7 @@ public class MDocProcessorTest {
         Map<String, Object> resultValidity = (Map<String, Object>) result.get("validityInfo");
         assertEquals("ValidFrom should match", validFrom, resultValidity.get(VCDM2Constants.VALID_FROM));
         assertEquals("ValidUntil should match", validUntil, resultValidity.get(VCDM2Constants.VALID_UNTIL));
+        assertEquals("Signed should match", signed, resultValidity.get("signed"));
     }
 
     // ==================== COSE Signing Tests ====================
@@ -947,6 +1008,21 @@ public class MDocProcessorTest {
     // ==================== Configuration Tests ====================
 
     @Test
+    public void should_addValidityPeriod_asPer_MdocConfig() throws Exception {
+        when(mDocConfig.getValidityPeriodYears()).thenReturn(10);
+
+        String template = "{\"validityInfo\": {\"validFrom\": \"${_validFrom}\",\"signed\": \"${_signed}\", \"validUntil\": \"${_validUntil}\"}}";
+        Map<String, Object> result = mDocProcessor.processTemplatedJson(template, new HashMap<>());
+
+        Map<String, Object> validityInfo = (Map<String, Object>) result.get("validityInfo");
+        String validUntil = (String) ((Map<String, Object>) validityInfo.get("validUntil")).get(Constants.__CBOR_VALUE);
+
+        assertNotNull("ValidUntil should be set", validUntil);
+        // Verify it's approximately 10 years in the future (allowing for execution time)
+        assertTrue("ValidUntil should be in the future", validUntil.compareTo("2030-01-01") > 0);
+    }
+
+    @Test
     public void should_useMsoVersion_when_mDocConfigApplied() throws Exception {
         when(mDocConfig.getMsoVersion()).thenReturn("2.0");
 
@@ -1059,7 +1135,8 @@ public class MDocProcessorTest {
                 + "\"docType\": \"org.iso.18013.5.1.mDL\","
                 + "\"validityInfo\": {"
                 + "  \"validFrom\": \"${_validFrom}\","
-                + "  \"validUntil\": \"${_validUntil}\""
+                + "  \"validUntil\": \"${_validUntil}\","
+                + "  \"signed\": \"${_signed}\""
                 + "},"
                 + "\"nameSpaces\": {"
                 + "  \"org.iso.18013.5.1\": ["

--- a/certify-service/src/test/java/io/mosip/certify/utils/MDocProcessorTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/utils/MDocProcessorTest.java
@@ -14,16 +14,17 @@ import io.mosip.kernel.signature.service.CoseSignatureService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
+import org.mockito.*;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.time.ZonedDateTime;
+import java.time.ZoneOffset;
 import java.util.*;
+import java.util.Base64;
 import java.util.Map;
 
 import static org.junit.Assert.*;
@@ -70,42 +71,65 @@ public class MDocProcessorTest {
     // ==================== Template Processing Tests ====================
 
     @Test
-    public void processTemplatedJson_ValidmDLTemplate_MapsToISO18013Elements() throws Exception {
-        String templatedJSON = "{"
-                + "\"docType\": \"org.iso.18013.5.1.mDL\","
-                + "\"validityInfo\": {"
-                + "  \"validFrom\": \"${_validFrom}\","
-                + "  \"validUntil\": \"${_validUntil}\""
-                + "},"
-                + "\"nameSpaces\": {"
-                + "  \"org.iso.18013.5.1\": ["
-                + "    {\"digestID\": 0, \"elementIdentifier\": \"family_name\", \"elementValue\": \"Doe\"},"
-                + "    {\"digestID\": 1, \"elementIdentifier\": \"given_name\", \"elementValue\": \"John\"},"
-                + "    {\"digestID\": 2, \"elementIdentifier\": \"birth_date\", \"elementValue\": \"1990-08-25\"}"
-                + "  ]"
-                + "}"
-                + "}";
+    public void processTemplatedJson_ValidmDLTemplate_MapsToISO18013Elements() {
+        // Mock ZonedDateTime.now() to return a fixed date for consistent testing
+        ZonedDateTime fixedDateTime = ZonedDateTime.of(2026, 7, 20, 10, 0, 0, 0, ZoneOffset.UTC);
+        
+        try (MockedStatic<ZonedDateTime> mockedZonedDateTime = mockStatic(ZonedDateTime.class, CALLS_REAL_METHODS)) {
+            mockedZonedDateTime.when(() -> ZonedDateTime.now(ZoneOffset.UTC))
+                    .thenReturn(fixedDateTime);
 
-        Map<String, Object> templateParams = new HashMap<>();
-        templateParams.put("didUrl", "https://issuer.example.com/did");
-        templateParams.put("_holderId", "did:jwk:test123");
+            String templatedJSON = "{"
+                    + "\"docType\": \"org.iso.18013.5.1.mDL\","
+                    + "\"validityInfo\": {"
+                    + "  \"validFrom\": \"${_validFrom}\","
+                    + "  \"validUntil\": \"${_validUntil}\","
+                    + "  \"signed\": \"${_signed}\""
+                    + "},"
+                    + "\"nameSpaces\": {"
+                    + "  \"org.iso.18013.5.1\": ["
+                    + "    {\"digestID\": 0, \"elementIdentifier\": \"family_name\", \"elementValue\": \"Doe\"},"
+                    + "    {\"digestID\": 1, \"elementIdentifier\": \"given_name\", \"elementValue\": \"John\"},"
+                    + "    {\"digestID\": 2, \"elementIdentifier\": \"birth_date\", \"elementValue\": \"1990-08-25\"}"
+                    + "  ]"
+                    + "}"
+                    + "}";
 
-        Map<String, Object> result = mDocProcessor.processTemplatedJson(templatedJSON, templateParams);
+            Map<String, Object> templateParams = new HashMap<>();
+            templateParams.put("didUrl", "https://issuer.example.com/did");
+            templateParams.put("_holderId", "did:jwk:test123");
 
-        assertNotNull("Result should not be null", result);
-        assertEquals("DocType should match", "org.iso.18013.5.1.mDL", result.get("_docType"));
-        assertEquals("HolderId should match", "did:jwk:test123", result.get("_holderId"));
-        assertEquals("Issuer should match", "https://issuer.example.com/did", result.get("_issuer"));
+            Map<String, Object> result = mDocProcessor.processTemplatedJson(templatedJSON, templateParams);
 
-        Map<String, Object> nameSpaces = (Map<String, Object>) result.get("nameSpaces");
-        assertNotNull("NameSpaces should not be null", nameSpaces);
+            assertNotNull("Result should not be null", result);
+            assertEquals("DocType should match", "org.iso.18013.5.1.mDL", result.get("_docType"));
+            assertEquals("HolderId should match", "did:jwk:test123", result.get("_holderId"));
+            assertEquals("Issuer should match", "https://issuer.example.com/did", result.get("_issuer"));
+            assertEquals("ValidityInfo should match",  Map.of(
+                    "signed", Map.of(
+                            Constants.__CBOR_TAG, 0,
+                            Constants.__CBOR_VALUE, "2026-07-20T10:00:00.000Z"
+                    ),
+                    "validFrom", Map.of(
+                            Constants.__CBOR_TAG, 0,
+                            Constants.__CBOR_VALUE, "2026-07-20T10:00:00.000Z"
+                    ),
+                    "validUntil", Map.of(
+                            Constants.__CBOR_TAG, 0,
+                            Constants.__CBOR_VALUE, "2031-07-20T10:00:00.000Z"
+                    )
+            ), result.get("validityInfo"));
 
-        List<Map<String, Object>> items = (List<Map<String, Object>>) nameSpaces.get("org.iso.18013.5.1");
-        assertEquals("Should have 3 elements", 3, items.size());
+            Map<String, Object> nameSpaces = (Map<String, Object>) result.get("nameSpaces");
+            assertNotNull("NameSpaces should not be null", nameSpaces);
 
-        assertEquals("family_name", items.get(0).get("elementIdentifier"));
-        assertEquals("Doe", items.get(0).get("elementValue"));
-        assertEquals(0, items.get(0).get("digestID"));
+            List<Map<String, Object>> items = (List<Map<String, Object>>) nameSpaces.get("org.iso.18013.5.1");
+            assertEquals("Should have 3 elements", 3, items.size());
+
+            assertEquals("family_name", items.get(0).get("elementIdentifier"));
+            assertEquals("Doe", items.get(0).get("elementValue"));
+            assertEquals(0, items.get(0).get("digestID"));
+        }
     }
 
     @Test
@@ -619,6 +643,7 @@ public class MDocProcessorTest {
         Map<String, Object> validityInfo = new HashMap<>();
         validityInfo.put(VCDM2Constants.VALID_FROM, "2024-01-01T00:00:00Z");
         validityInfo.put(VCDM2Constants.VALID_UNTIL, "2025-01-01T00:00:00Z");
+        validityInfo.put(Constants.SIGNED, "2024-01-01T00:00:00Z");
         mDocJson.put("validityInfo", validityInfo);
 
         Map<String, Map<Integer, byte[]>> namespaceDigests = new HashMap<>();
@@ -634,7 +659,11 @@ public class MDocProcessorTest {
         assertEquals("Digest algorithm should match", "SHA-256", result.get("digestAlgorithm"));
         assertEquals("DocType should match", "org.iso.18013.5.1.mDL", result.get(Constants.DOCTYPE));
 
-        assertNotNull("Should have validityInfo", result.get("validityInfo"));
+        Map<String, Object> actualValidityInfo = (Map<String, Object>) result.get("validityInfo");
+        assertNotNull("Should have validityInfo", actualValidityInfo);
+        assertEquals("ValidFrom should match", "2024-01-01T00:00:00Z", actualValidityInfo.get(VCDM2Constants.VALID_FROM));
+        assertEquals("ValidUntil should match", "2025-01-01T00:00:00Z", actualValidityInfo.get(VCDM2Constants.VALID_UNTIL));
+        assertEquals("Signed should match", "2024-01-01T00:00:00Z", actualValidityInfo.get(Constants.SIGNED));
         assertNotNull("Should have valueDigests", result.get("valueDigests"));
         assertNotNull("Should have deviceKeyInfo", result.get("deviceKeyInfo"));
     }


### PR DESCRIPTION
Changes include
1. issuerAuth - untagged cose_sign1 of mso bytes
2. issuerAuth's sign payload - `#6.24(bstr .cbor mso)`
3. Update validityInfo with mandatory`signed` property
4. Return mdoc credential response as base64url-encoded representation of the CBOR-encoded IssuerSigned structure [ref](https://openid.github.io/OpenID4VCI/openid-4-verifiable-credential-issuance-1_1-wg-draft.html#name-credential-response-5)
5. Ensure the date format in validityInfo is following `tdate` format as per [RFC 8610](https://datatracker.ietf.org/doc/html/rfc8610#appendix-D)

Fixes: https://github.com/inji/inji-certify/issues/949

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tagged CBOR encoding support for mDoc signing payloads.
* **Bug Fixes**
  * Updated mDoc proof generation to encode the issuer-signed payload as expected.
  * Strengthened validity placeholder handling (`validFrom`, `validUntil`, and `signed`) using UTC-based RFC 3339 timestamps.
  * Improved device key parsing/validation and adjusted COSE signing request/payload handling.
* **Tests**
  * Refreshed and strengthened mDoc unit tests with more deterministic time assertions and clearer expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->