### PR TITLE
Add log to debug vp verification failure

### DIFF
--- a/certify-service/src/main/java/io/mosip/certify/services/IarPresentationService.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/IarPresentationService.java
@@ -187,11 +187,26 @@ public class IarPresentationService {
     private VpVerificationResponse getVpVerificationResult(String transactionId) throws CertifyException {
         try {
             List<String> requestIds = vpRequestService.getLatestRequestIdFor(transactionId);
-            log.debug("Fetching VP result for transactionId: {}, requestIds: {}", transactionId, requestIds);
+            log.info("Fetching VP result for transactionId: {}, requestIds: {}", transactionId, requestIds);
 
             VerificationRequestDto verificationRequest = new VerificationRequestDto();
             verificationRequest.setIncludeClaims(true);
             VPVerificationResultDto vpResult = vpSubmissionService.getVPResultV2(verificationRequest, requestIds, transactionId);
+            if (vpResult != null) {
+                log.info("VP check - allChecksOk: {}", vpResult.isAllChecksSuccessful());
+                List<CredentialResultsDto> credentialResults = vpResult.getCredentialResults();
+                if (credentialResults != null && !credentialResults.isEmpty()
+                        && credentialResults.get(0) != null
+                        && credentialResults.get(0).getHolderProofCheck() != null) {
+                    CredentialResultsDto cr = credentialResults.get(0);
+                    log.info("VP check - holderValid: {}", cr.getHolderProofCheck().isValid());
+                    if (cr.getHolderProofCheck().getError() != null) {
+                        log.info("VP check - holderErrorCode: {}, holderErrorMessage: {}",
+                                cr.getHolderProofCheck().getError().getErrorCode(),
+                                cr.getHolderProofCheck().getError().getErrorMessage());
+                    }
+                }
+            }
 
             VpVerificationResponse response = new VpVerificationResponse();
             response.setRequestId(transactionId);

--- a/certify-service/src/main/java/io/mosip/certify/services/IarVpRequestService.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/IarVpRequestService.java
@@ -47,10 +47,10 @@ public class IarVpRequestService {
     @Value("${mosip.certify.verify.service.verifier-client-id:}")
     private String verifierClientId;
 
-    @Value("${mosip.certify.iae.response-mode.post:iae-post}")
+    @Value("${mosip.certify.iae.response-mode.post:iae_post}")
     private String iaePostResponseMode;
 
-    @Value("${mosip.certify.iae.response-mode.post-jwt:iae-post.jwt}")
+    @Value("${mosip.certify.iae.response-mode.post-jwt:iae_post.jwt}")
     private String iaePostJwtResponseMode;
 
     @Value("${mosip.certify.oauth.interactive-authorization-endpoint:}")

--- a/certify-service/src/test/java/io/mosip/certify/controller/OAuthControllerTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/controller/OAuthControllerTest.java
@@ -118,7 +118,7 @@ class OAuthControllerTest {
                 .andExpect(jsonPath("$.type").value("urn:openid:dcp:iae:openid4vp_presentation"))
                 .andExpect(jsonPath("$.auth_session").value("test-session"))
                 .andExpect(jsonPath("$.openid4vp_request.response_type").value("vp_token"))
-                .andExpect(jsonPath("$.openid4vp_request.response_mode").value("iae-post.jwt"));
+                .andExpect(jsonPath("$.openid4vp_request.response_mode").value("iae_post.jwt"));
 
         verify(iarService, times(1)).handleIarRequest(any(IarRequest.class));
     }
@@ -779,7 +779,7 @@ class OAuthControllerTest {
             
             Map<String, Object> openId4VpRequest = new HashMap<>();
             openId4VpRequest.put("response_type", "vp_token");
-            openId4VpRequest.put("response_mode", "iae-post.jwt");
+            openId4VpRequest.put("response_mode", "iae_post.jwt");
             openId4VpRequest.put("client_id", "test-client");
             
             PresentationDefinition presentationDefinition = new PresentationDefinition();

--- a/certify-service/src/test/java/io/mosip/certify/services/IarVpRequestServiceTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/IarVpRequestServiceTest.java
@@ -1,0 +1,111 @@
+package io.mosip.certify.services;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.inji.verify.services.VerifiablePresentationRequestService;
+import io.mosip.certify.core.dto.InteractiveAuthorizationRequest;
+import io.mosip.certify.core.dto.PresentationDefinition;
+import io.mosip.certify.core.dto.VerifyVpResponse;
+import io.mosip.certify.core.exception.CertifyException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IarVpRequestServiceTest {
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @Mock
+    private VerifiablePresentationRequestService vpRequestService;
+
+    @InjectMocks
+    private IarVpRequestService iarVpRequestService;
+
+    @Before
+    public void setup() {
+        ReflectionTestUtils.setField(iarVpRequestService, "iaePostResponseMode", "iae_post");
+        ReflectionTestUtils.setField(iarVpRequestService, "iaePostJwtResponseMode", "iae_post.jwt");
+        ReflectionTestUtils.setField(iarVpRequestService, "certifyIaeEndpoint", "http://localhost:8090/v1/certify/oauth/iae");
+    }
+
+    @Test
+    public void should_mapDirectPostToIaePost_when_responseModeIsDirectPost() {
+        VerifyVpResponse verifyResponse = buildVerifyVpResponse("direct_post");
+        InteractiveAuthorizationRequest iarRequest = buildIarRequest();
+
+        Map<String, Object> result = (Map<String, Object>) iarVpRequestService.convertToOpenId4VpRequest(verifyResponse, iarRequest);
+
+        assertEquals("iae_post", result.get("response_mode"));
+        assertEquals("vp_token", result.get("response_type"));
+        assertEquals("test-client", result.get("client_id"));
+    }
+
+    @Test
+    public void should_mapDirectPostJwtToIaePostJwt_when_responseModeIsDirectPostJwt() {
+        VerifyVpResponse verifyResponse = buildVerifyVpResponse("direct_post.jwt");
+        InteractiveAuthorizationRequest iarRequest = buildIarRequest();
+
+        Map<String, Object> result = (Map<String, Object>) iarVpRequestService.convertToOpenId4VpRequest(verifyResponse, iarRequest);
+
+        assertEquals("iae_post.jwt", result.get("response_mode"));
+    }
+
+    @Test
+    public void should_passThroughResponseMode_when_modeIsUnknown() {
+        VerifyVpResponse verifyResponse = buildVerifyVpResponse("some_other_mode");
+        InteractiveAuthorizationRequest iarRequest = buildIarRequest();
+
+        Map<String, Object> result = (Map<String, Object>) iarVpRequestService.convertToOpenId4VpRequest(verifyResponse, iarRequest);
+
+        assertEquals("some_other_mode", result.get("response_mode"));
+    }
+
+    @Test(expected = CertifyException.class)
+    public void should_throwCertifyException_when_responseModeIsEmpty() {
+        VerifyVpResponse verifyResponse = buildVerifyVpResponse("");
+        InteractiveAuthorizationRequest iarRequest = buildIarRequest();
+
+        iarVpRequestService.convertToOpenId4VpRequest(verifyResponse, iarRequest);
+    }
+
+    @Test(expected = CertifyException.class)
+    public void should_throwCertifyException_when_authorizationDetailsAreNull() {
+        VerifyVpResponse verifyResponse = new VerifyVpResponse();
+        verifyResponse.setAuthorizationDetails(null);
+        InteractiveAuthorizationRequest iarRequest = buildIarRequest();
+
+        iarVpRequestService.convertToOpenId4VpRequest(verifyResponse, iarRequest);
+    }
+
+    private VerifyVpResponse buildVerifyVpResponse(String responseMode) {
+        VerifyVpResponse response = new VerifyVpResponse();
+        VerifyVpResponse.AuthorizationDetails authDetails = new VerifyVpResponse.AuthorizationDetails();
+        authDetails.setResponseType("vp_token");
+        authDetails.setResponseMode(responseMode);
+        authDetails.setClientId("test-client");
+        authDetails.setNonce("test-nonce");
+        authDetails.setPresentationDefinition(new PresentationDefinition());
+        response.setAuthorizationDetails(authDetails);
+        return response;
+    }
+
+    private InteractiveAuthorizationRequest buildIarRequest() {
+        InteractiveAuthorizationRequest request = new InteractiveAuthorizationRequest();
+        request.setClientId("test-client");
+        request.setResponseType("code");
+        request.setCodeChallenge("test-challenge");
+        request.setCodeChallengeMethod("S256");
+        return request;
+    }
+}
+

--- a/docs/Presentation-During-Issuance.md
+++ b/docs/Presentation-During-Issuance.md
@@ -49,8 +49,8 @@ sequenceDiagram
     IC->>IVP: 6. Create presentation request
     IVP-->>IC: 7. {request_id,transaction_id, {standard ovp request by value with response_mode as "direct_post" or "direct_post.jwt"}} (non-normative)
     IC->>IC: 8. store transaction id for the presentation request mapped to Auth Session
-    Note over IC: Map direct_post to iae-post and direct_post.jwt to iae-post.jwt and construct the response
-    IC-->>W: 9. 200 Interactive Authorization Response<br/>{status:"require_interaction", type:"urn:openid:dcp:iae:openid4vp_presentation", auth_session:"..random string", openid4vp_request: {standard ovp request by value with response_mode as "iae-post" or "iae-post.jwt"}}
+    Note over IC: Map direct_post to iae_post and direct_post.jwt to iae_post.jwt and construct the response
+    IC-->>W: 9. 200 Interactive Authorization Response<br/>{status:"require_interaction", type:"urn:openid:dcp:iae:openid4vp_presentation", auth_session:"..random string", openid4vp_request: {standard ovp request by value with response_mode as "iae_post" or "iae_post.jwt"}}
     
     Note over W,IC: 2. Presentation Flow with Issuer and VP Verifier
     W->>W: 10. Display and select credential(s) which satisfies presentation request criteria
@@ -97,7 +97,7 @@ The Wallet initiates the request, and the Issuer determines if a presentation is
 3. **Inji Certify to VP Verifier**: Instructs the VP Verifier to create a presentation request.
 4. **VP Verifier to Inji Certify**: Returns `request_id`, `transaction_id`, and `request` (e.g. `{response_type": "vp_token","response_mode": "direct_post"....}`). Inji Certify stores `transaction_id` mapped to the Auth Session.
 5. **Inji Certify to Wallet**: Responds with `200 Interactive Authorization Response`. Includes `status:"require_interaction"`, `type:"urn:openid:dcp:iae:openid4vp_presentation"`, `auth_session`, `openid4vp_request:{}`
-    - The `openid4vp_request` contains the standard OpenID4VP request by value, with `response_mode` set to either `iae-post` for unencrypted response or `iae-post.jwt` for encrypted response. [Refer](https://openid.github.io/OpenID4VCI/openid-4-verifiable-credential-issuance-1_1-wg-draft.html#name-interactive-authorization-e)
+    - The `openid4vp_request` contains the standard OpenID4VP request by value, with `response_mode` set to either `iae_post` for unencrypted response or `iae_post.jwt` for encrypted response. [Refer](https://openid.github.io/OpenID4VCI/openid-4-verifiable-credential-issuance-1_1-wg-draft.html#name-interactive-authorization)
 
 ### Phase 2: Presentation Flow with Issuer and VP Verifier
 
@@ -107,8 +107,8 @@ The Wallet interacts with the VP Verifier
 3. **User to Wallet**: User approves.
 4. **Wallet to Inji Certify**: Send VP response
     - POST Content-Type: application/x-www-form-urlencoded /iae<br/>{auth_session=...&openid4vp_response=...}
-    - if response_mode is `iae-post` then openid4vp_response is unencrypted, {"vp_token": "...", "presentation_submission": {...}}
-    - if response_mode is `iae-post.jwt` then openid4vp_response is encrypted, {response='...'}
+    - if response_mode is `iae_post` then openid4vp_response is unencrypted, {"vp_token": "...", "presentation_submission": {...}}
+    - if response_mode is `iae_post.jwt` then openid4vp_response is encrypted, {response='...'}
 5. **Inji Certify**: Validates `auth_session`
 6. **Inji Certify to VP Verifier**: Forward vp response to the VP Verifier for verification on response_uri shared in `openid4vp_request`
 7. **VP Verifier**: Verifies the VP response
@@ -126,8 +126,6 @@ This flow is based on concepts and standards from the following documents:
 
 * [RFC 8414 - OAuth 2.0 Authorization Server Metadata](https://tools.ietf.org/html/rfc8414)
 
-* [OpenID for Verifiable Credential Issuance (OID4VCI) - Editor Draft](https://openid.github.io/OpenID4VCI/openid-4-verifiable-credential-issuance-wg-draft.html)
-
-* [EUDI Wallet Blueprint - Presentation During Issuance (Conceptual basis for the Presentation During Issuance flow)](https://bmi.usercontent.opencode.de/eudi-wallet/eidas-2.0-architekturkonzept/flows/Presentation-During-Issuance/)
+* [OpenID for Verifiable Credential Issuance (OID4VCI) - Editor Draft](https://openid.github.io/OpenID4VCI/openid-4-verifiable-credential-issuance-1_1-wg-draft.html#name-interactive-authorization)
 
 * [GitHub issue from OpenID4VCI](https://github.com/openid/OpenID4VCI/issues/473)

--- a/docs/postman-collections/Inji Certify - Presentation During Issuance VCI.postman_collection.json
+++ b/docs/postman-collections/Inji Certify - Presentation During Issuance VCI.postman_collection.json
@@ -189,7 +189,7 @@
 			"name": "3. Interactive Auth Request with VP",
 			"item": [
 				{
-					"name": "3.1 Auth Request with VP (iae-post)",
+					"name": "3.1 Auth Request with VP (iae_post)",
 					"event": [
 						{
 							"listen": "test",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated presentation response modes to use the standardized underscore format (`iae_post` and `iae_post.jwt`).
  * Improved operational visibility during verifiable presentation verification with additional result logging.

* **Documentation**
  * Updated issuance guidance, diagrams, examples, and Postman collection labels to reflect the standardized response mode names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->