### PR TITLE
feat: clean up unused apis from api doc

### DIFF
--- a/docs/inji-certify-openapi.yaml
+++ b/docs/inji-certify-openapi.yaml
@@ -483,274 +483,12 @@ paths:
       servers:
         - url: 'http://localhost:8090/v1/certify'
           description: Generated server url
-  /issuance/vd12/credential:
-    post:
-      tags:
-        - VC Issuance
-      summary: Credential Issuance (as per OpenID VCI Draft 12 specification)
-      description: The endpoint specifically handles requests and responses according to the vd12 draft version of the credential format. It ensures compatibility with the OpenID VCI draft 12 specification and returns the credential in the requested format.
-      operationId: getCredentialV12Draft
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CredentialRequest'
-            examples:
-              example:
-                value:
-                  credential_configuration_id: MockVerifiableCredential
-                  proofs:
-                    jwt:
-                      - eyJ0eXAiOiJvcGVuaWQ0dmNpLXByb29mK2p3dC
-                      - eyJ0eXAiOiJvcGVuaWQ0dmNpKXByb59mK2p3dM
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CredentialResponse'
-              examples:
-                Example 1:
-                  value:
-                    credentials:
-                      - credential:
-                          credentialSubject:
-                            VID: 2154189532
-                            gender:
-                              - language: eng
-                                value: Male
-                            province:
-                              - language: eng
-                                value: ABC City
-                            phone: '+3725478456'
-                            postalCode: 10106
-                            fullName:
-                              - language: eng
-                                value: Gorge Cooper
-                            dateOfBirth: 1985/04/29
-                            id: 'did:jwk:eyJrdHkiOiJSU0EiLCJlIjoiQVFBQiIsInVzZSI6InNpZyIsImtpZCI6IndzbXVFM1EyaHUzT3hvRlhrRHFWaXdqMUFWeTZUQ2x0M1ZTZm9GcXZySE0iLCJhbGciOiJSUzI1NiIsIm4iOiJwTE9obUEyenBraHZlM0RDVlo4LU9kSDNZZlF3NEVmLXpWMTBqREt0SlFranlycS0yVzRadnFVYjdXSm9ZbV9jb3FPczEwMllsalE2UGpJMXJfU2haeldDZGFHT24ydFU2TGUxeEdNTlVaRXRRVmhINWpCV2Y0VTZKUDAxM1Q0bE5MOGZ0Wm1BRy1ZZGU4MW1rb0Nabm51RXdyQ0lyTWpLNWxodHJfSnpfbm9oSnMwUENaVFI2enJTWk44SVpuTldXQVZ2TmRIbHZKTEJMU0FZZXp0MHF3RlgzZkw1UXFKTm53c09YckNjVi1CNTR6VmxtT1ZiOG05d1hOODJGdkFZQUxiWFB2UGtuZ3JzVUhUdzlOMmlFR3VZU1JNbE1WLVFJSEtEMUdiTVNBWFNRbjlQaEctY2UtXzlWR2NwMkZkeHpWVTJFY1hqdXVPTWlHbmtGa3NBcVEifQ=='
-                            UIN: 2154189532
-                            region:
-                              - language: eng
-                                value: ABC Region
-                            email: gorgecooper@gmail.com
-                          validUntil: '2027-08-07T11:57:39.350Z'
-                          validFrom: '2025-08-07T11:57:39.349Z'
-                          type:
-                            - VerifiableCredential
-                            - MockVerifiableCredential
-                          '@context':
-                            - 'https://www.w3.org/ns/credentials/v2'
-                            - 'https://www.example.com/.well-known/mosip-ida-context.json'
-                            - 'https://w3id.org/security/suites/ed25519-2020/v1'
-                          issuer: 'did:web:www.example.com:inji-config:collab:mock-identity'
-                          credentialStatus:
-                            statusPurpose: revocation
-                            statusListIndex: '5'
-                            id: 'https://www.example.com/v1/certify/status-list/7bf52e81-f3bb-40ec-a0f9-a714847fd067#5'
-                            type: BitstringStatusListEntry
-                            statusListCredential: 'https://www.example.com/v1/certify/status-list/7bf52e81-f3bb-40ec-a0f9-a714847fd067'
-                          proof:
-                            type: EcdsaSecp256r1Signature2019
-                            created: '2025-08-07T11:57:39Z'
-                            proofPurpose: assertionMethod
-                            verificationMethod: 'did:web:www.example.com:inji-config:collab:mock-identity#b-yFcX3lbDH96eQUmUYHTYK5y5VE0ymJxmu-1CgM_AY'
-                            proofValue: z4qiRPtXgfE14sbZ6UogFbwMjiXKnviLBkbb2RinZyvub3wZHQVVhigiynuKuKSZCBpbeLckHrtxK4QCrzPPQXyWH
-                      - credential:
-                          credentialSubject:
-                            VID: 2154189532
-                            gender:
-                              - language: eng
-                                value: Male
-                            province:
-                              - language: eng
-                                value: ABC City
-                            phone: '+3725478456'
-                            postalCode: 10106
-                            fullName:
-                              - language: eng
-                                value: Gorge Cooper
-                            dateOfBirth: 1985/04/29
-                            id: 'did:jwk:eyJrdHkiOiJSU0EiLCJlIjoiQVFBQiIsInVzZSI6InNpZyIsImtpZCI6IndzbXVFM1EyaHUzT3hvRlhrRHFWaXdqMUFWeTZUQ2x0M1ZTZm9GcXZySE0iLCJhbGciOiJSUzI1NiIsIm4iOiJwTE9obUEyenBraHZlM0RDVlo4LU9kSDNZZlF3NEVmLXpWMTBqREt0SlFranlycS0yVzRadnFVYjdXSm9ZbV9jb3FPczEwMllsalE2UGpJMXJfU2haeldDZGFHT24ydFU2TGUxeEdNTlVaRXRRVmhINWpCV2Y0VTZKUDAxM1Q0bE5MOGZ0Wm1BRy1ZZGU4MW1rb0Nabm51RXdyQ0lyTWpLNWxodHJfSnpfbm9oSnMwUENaVFI2enJTWk44SVpuTldXQVZ2TmRIbHZKTEJMU0FZZXp0MHF3RlgzZkw1UXFKTm53c09YckNjVi1CNTR6VmxtT1ZiOG05d1hOODJGdkFZQUxiWFB2UGtuZ3JzVUhUdzlOMmlFR3VZU1JNbE1WLVFJSEtEMUdiTVNBWFNRbjlQaEctY2UtXzlWR2NwMkZkeHpWVTJFY1hqdXVPTWlHbmtGa3NBcVEifQ=='
-                            UIN: 2154189532
-                            region:
-                              - language: eng
-                                value: ABC Region
-                            email: gorgecooper@gmail.com
-                          validUntil: '2027-08-07T11:57:39.350Z'
-                          validFrom: '2025-08-07T11:57:39.349Z'
-                          type:
-                            - VerifiableCredential
-                            - MockVerifiableCredential
-                          '@context':
-                            - 'https://www.w3.org/ns/credentials/v2'
-                            - 'https://www.example.com/.well-known/mosip-ida-context.json'
-                            - 'https://w3id.org/security/suites/ed25519-2020/v1'
-                          issuer: 'did:web:www.example.com:inji-config:collab:mock-identity'
-                          credentialStatus:
-                            statusPurpose: revocation
-                            statusListIndex: '5'
-                            id: 'https://www.example.com/v1/certify/status-list/7bf52e81-f3bb-40ec-a0f9-a714847fd067#5'
-                            type: BitstringStatusListEntry
-                            statusListCredential: 'https://www.example.com/v1/certify/status-list/7bf52e81-f3bb-40ec-a0f9-a714847fd067'
-                          proof:
-                            type: EcdsaSecp256r1Signature2019
-                            created: '2025-08-07T11:57:39Z'
-                            proofPurpose: assertionMethod
-                            verificationMethod: 'did:web:www.example.com:inji-config:collab:mock-identity#b-yFcX3lbDH96eQUmUYHTYK5y5VE0ymJxmu-1CgM_AY'
-                            proofValue: z4qiRPtXgfE14sbZ6UogFbwMjiXKnviLBkbb2RinZyvub3wZHQVVhigiynuKuKSZCBpbeLckHrtxK4QCrzPPQXyWH
-                Example 2:
-                  value:
-                    credentials:
-                      - credential: eyJ4NXQjUzI1NiI6InAxRkps....
-        '400':
-          description: Bad Request
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/VCError'
-      servers:
-        - url: 'http://localhost:8090/v1/certify'
-          description: Generated server url
-  /issuance/vd11/credential:
-    post:
-      tags:
-        - VC Issuance
-      summary: Credential Issuance (as per OpenID VCI Draft 11 specification)
-      description: The endpoint specifically handles requests and responses according to the vd11 draft version of the credential format. It ensures compatibility with the OpenID VCI draft 11 specification and returns the credential in the requested format.
-      operationId: getCredentialV11Draft
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CredentialRequest'
-            examples:
-              Example:
-                value:
-                  credential_configuration_id: MockVerifiableCredential
-                  proofs:
-                    jwt:
-                      - eyJ0eXAiOiJvcGVuaWQ0dmNpLXByb29mK2p3d
-                      - eyJ0eXAiOiJvcGVuaWQ0dmNpLXByb29mK2p3dC
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CredentialResponse'
-              examples:
-                Example 1:
-                  value:
-                    credentials:
-                      - credential: eyJ4NXQjUzI1NiI6InAxRkps....
-                Example 2:
-                  value:
-                    credentials:
-                      - credential:
-                          credentialSubject:
-                            VID: 2154189532
-                            gender:
-                              - language: eng
-                                value: Male
-                            province:
-                              - language: eng
-                                value: ABC City
-                            phone: '+3725478456'
-                            postalCode: 10106
-                            fullName:
-                              - language: eng
-                                value: Gorge Cooper
-                            dateOfBirth: 1985/04/29
-                            id: 'did:jwk:eyJrdHkiOiJSU0EiLCJlIjoiQVFBQiIsInVzZSI6InNpZyIsImtpZCI6IndzbXVFM1EyaHUzT3hvRlhrRHFWaXdqMUFWeTZUQ2x0M1ZTZm9GcXZySE0iLCJhbGciOiJSUzI1NiIsIm4iOiJwTE9obUEyenBraHZlM0RDVlo4LU9kSDNZZlF3NEVmLXpWMTBqREt0SlFranlycS0yVzRadnFVYjdXSm9ZbV9jb3FPczEwMllsalE2UGpJMXJfU2haeldDZGFHT24ydFU2TGUxeEdNTlVaRXRRVmhINWpCV2Y0VTZKUDAxM1Q0bE5MOGZ0Wm1BRy1ZZGU4MW1rb0Nabm51RXdyQ0lyTWpLNWxodHJfSnpfbm9oSnMwUENaVFI2enJTWk44SVpuTldXQVZ2TmRIbHZKTEJMU0FZZXp0MHF3RlgzZkw1UXFKTm53c09YckNjVi1CNTR6VmxtT1ZiOG05d1hOODJGdkFZQUxiWFB2UGtuZ3JzVUhUdzlOMmlFR3VZU1JNbE1WLVFJSEtEMUdiTVNBWFNRbjlQaEctY2UtXzlWR2NwMkZkeHpWVTJFY1hqdXVPTWlHbmtGa3NBcVEifQ=='
-                            UIN: 2154189532
-                            region:
-                              - language: eng
-                                value: ABC Region
-                            email: gorgecooper@gmail.com
-                          validUntil: '2027-08-07T11:57:39.350Z'
-                          validFrom: '2025-08-07T11:57:39.349Z'
-                          type:
-                            - VerifiableCredential
-                            - MockVerifiableCredential
-                          '@context':
-                            - 'https://www.w3.org/ns/credentials/v2'
-                            - 'https://www.example.com/.well-known/mosip-ida-context.json'
-                            - 'https://w3id.org/security/suites/ed25519-2020/v1'
-                          issuer: 'did:web:www.example.com:inji-config:collab:mock-identity'
-                          credentialStatus:
-                            statusPurpose: revocation
-                            statusListIndex: '5'
-                            id: 'https://www.example.com/v1/certify/status-list/7bf52e81-f3bb-40ec-a0f9-a714847fd067#5'
-                            type: BitstringStatusListEntry
-                            statusListCredential: 'https://www.example.com/v1/certify/status-list/7bf52e81-f3bb-40ec-a0f9-a714847fd067'
-                          proof:
-                            type: EcdsaSecp256r1Signature2019
-                            created: '2025-08-07T11:57:39Z'
-                            proofPurpose: assertionMethod
-                            verificationMethod: 'did:web:www.example.com:inji-config:collab:mock-identity#b-yFcX3lbDH96eQUmUYHTYK5y5VE0ymJxmu-1CgM_AY'
-                            proofValue: z4qiRPtXgfE14sbZ6UogFbwMjiXKnviLBkbb2RinZyvub3wZHQVVhigiynuKuKSZCBpbeLckHrtxK4QCrzPPQXyWH
-                      - credential:
-                          credentialSubject:
-                            VID: 2154189532
-                            gender:
-                              - language: eng
-                                value: Male
-                            province:
-                              - language: eng
-                                value: ABC City
-                            phone: '+3725478456'
-                            postalCode: 10106
-                            fullName:
-                              - language: eng
-                                value: Gorge Cooper
-                            dateOfBirth: 1985/04/29
-                            id: 'did:jwk:eyJrdHkiOiJSU0EiLCJlIjoiQVFBQiIsInVzZSI6InNpZyIsImtpZCI6IndzbXVFM1EyaHUzT3hvRlhrRHFWaXdqMUFWeTZUQ2x0M1ZTZm9GcXZySE0iLCJhbGciOiJSUzI1NiIsIm4iOiJwTE9obUEyenBraHZlM0RDVlo4LU9kSDNZZlF3NEVmLXpWMTBqREt0SlFranlycS0yVzRadnFVYjdXSm9ZbV9jb3FPczEwMllsalE2UGpJMXJfU2haeldDZGFHT24ydFU2TGUxeEdNTlVaRXRRVmhINWpCV2Y0VTZKUDAxM1Q0bE5MOGZ0Wm1BRy1ZZGU4MW1rb0Nabm51RXdyQ0lyTWpLNWxodHJfSnpfbm9oSnMwUENaVFI2enJTWk44SVpuTldXQVZ2TmRIbHZKTEJMU0FZZXp0MHF3RlgzZkw1UXFKTm53c09YckNjVi1CNTR6VmxtT1ZiOG05d1hOODJGdkFZQUxiWFB2UGtuZ3JzVUhUdzlOMmlFR3VZU1JNbE1WLVFJSEtEMUdiTVNBWFNRbjlQaEctY2UtXzlWR2NwMkZkeHpWVTJFY1hqdXVPTWlHbmtGa3NBcVEifQ=='
-                            UIN: 2154189532
-                            region:
-                              - language: eng
-                                value: ABC Region
-                            email: gorgecooper@gmail.com
-                          validUntil: '2027-08-07T11:57:39.350Z'
-                          validFrom: '2025-08-07T11:57:39.349Z'
-                          type:
-                            - VerifiableCredential
-                            - MockVerifiableCredential
-                          '@context':
-                            - 'https://www.w3.org/ns/credentials/v2'
-                            - 'https://www.example.com/.well-known/mosip-ida-context.json'
-                            - 'https://w3id.org/security/suites/ed25519-2020/v1'
-                          issuer: 'did:web:www.example.com:inji-config:collab:mock-identity'
-                          credentialStatus:
-                            statusPurpose: revocation
-                            statusListIndex: '5'
-                            id: 'https://www.example.com/v1/certify/status-list/7bf52e81-f3bb-40ec-a0f9-a714847fd067#5'
-                            type: BitstringStatusListEntry
-                            statusListCredential: 'https://www.example.com/v1/certify/status-list/7bf52e81-f3bb-40ec-a0f9-a714847fd067'
-                          proof:
-                            type: EcdsaSecp256r1Signature2019
-                            created: '2025-08-07T11:57:39Z'
-                            proofPurpose: assertionMethod
-                            verificationMethod: 'did:web:www.example.com:inji-config:collab:mock-identity#b-yFcX3lbDH96eQUmUYHTYK5y5VE0ymJxmu-1CgM_AY'
-                            proofValue: z4qiRPtXgfE14sbZ6UogFbwMjiXKnviLBkbb2RinZyvub3wZHQVVhigiynuKuKSZCBpbeLckHrtxK4QCrzPPQXyWH
-        '400':
-          description: Bad Request
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/VCError'
-      servers:
-        - url: 'http://localhost:8090/v1/certify'
-          description: Generated server url
   /issuance/credential:
     post:
       tags:
         - VC Issuance
-      summary: Credential Issuance (as per OpenID VCI Draft 13 specification)
-      description: The endpoint specifically handles requests and responses according to the draft version of the credential format. It ensures compatibility with the OpenID VCI draft 13 specification and returns the credential in the requested format.
+      summary: Credential Issuance
+      description: The endpoint specifically handles requests and responses according to OpenId4VCI Spec 1.0 version. It returns the credential in the requested format.
       operationId: getCredential
       requestBody:
         required: true
@@ -1366,17 +1104,6 @@ paths:
       summary: Issuer metadata
       description: 'This endpoint provides metadata about the credential issuer and the supported credential configurations. The response structure adapts based on the version query parameter, allowing clients to discover issuer capabilities and supported credential types for different OID4VCI versions. The response will be as per the applicable OID4VCI specification, for e.g. for draft 13 of OID4VCI, the specification to be referred is https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-ID1.html#name-credential-issuer-metadata-p'
       operationId: getCredentialIssuerMetadata
-      parameters:
-        - name: version
-          in: query
-          required: false
-          schema:
-            type: string
-            default: latest
-            enum:
-              - latest
-              - vd11
-              - vd12
       responses:
         '200':
           description: OK
@@ -1420,127 +1147,13 @@ paths:
                 type: object
                 additionalProperties:
                   type: object
-  /issuance/.well-known/openid-credential-issuer:
-    get:
-      tags:
-        - VC Issuance
-      summary: Issuer metadata
-      description: 'This endpoint provides metadata about the credential issuer and the supported credential configurations. The response structure adapts based on the version query parameter, allowing clients to discover issuer capabilities and supported credential types for different OID4VCI versions. The response will be as per the applicable OID4VCI specification, for e.g. for draft 13 of OID4VCI, the specification to be referred is [https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-ID1.html#name-credential-issuer-metadata-p](url)'
-      operationId: getMetadata
-      parameters:
-        - name: version
-          in: query
-          required: false
-          schema:
-            type: string
-            default: latest
-            enum:
-              - latest
-              - vd12
-              - vd11
-          allowReserved: false
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties:
-                  type: object
-        '400':
-          description: Bad Request
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/VCError'
-      servers:
-        - url: 'http://localhost:8090/v1/certify'
-          description: Generated server url
-      deprecated: true
-  /issuance/.well-known/did.json:
-    get:
-      tags:
-        - VC Issuance
-      summary: Issuer DID document
-      description: 'This endpoint returns the DID document associated with the issuer. This document contains the decentralized identifier and related public keys, enabling clients to verify the issuer’s identity and interact securely. The response will be as per the specification provided here : [https://www.w3.org/ns/did/v1](url)'
-      operationId: getDIDDocument
-      responses:
-        '200':
-          description: OK
-          content:
-            '*/*':
-              schema:
-                type: object
-                additionalProperties:
-                  type: object
-        '400':
-          description: Bad Request
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/VCError'
-      servers:
-        - url: 'http://localhost:8090/v1/certify'
-          description: Generated server url
-      deprecated: true
   /ledger-search:
     post:
       tags:
         - 'Ledger Search'
-      summary: Search for Credential Status Records (Ledger Search)
-      description: 'Search based on credentialId, issuerId, credentialType and potentially indexedAttributes (via specific criteria) from the ledger. AND logic applied.'
-      operationId: searchLedgerRecords
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CredentialSearchCriteria'
-            examples:
-              Example 1:
-                value:
-                  credentialId: afce16e8-02ac-4210-80d9-a0a20132bda3
-                  issuerId: 'did:web:sample.github.io:my-files:sample'
-                  credentialType: 'FarmerCredential,VerifiableCredential'
-                  indexedAttributesEquals:
-                    district: Bengaluru
-                    state: Karnataka
-      responses:
-        '200':
-          description: List of matching credential status records.
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/CredentialStatusResponseDto'
-              examples:
-                Example 1:
-                  value:
-                    - credentialId: 52b55d02-613f-432f-b29e-ae842bc404a8
-                      issuerId: 'did:web:www.example.com:inji-config:collab:mock-identity'
-                      statusListCredentialUrl: 7bf52e81-f3bb-40ec-a0f9-a714847fd067
-                      statusListIndex: 5
-                      statusPurpose: revocation
-                      issueDate: '2025-08-07T11:57:39'
-                      expirationDate: null
-                      credentialType: 'MockVerifiableCredential,VerifiableCredential'
-                      statusTimestamp: '2025-08-07T11:57:39'
-        '204':
-          description: No matching records found.
-        '400':
-          description: Invalid search criteria provided.
-      servers:
-        - url: 'http://localhost:8090/v1/certify'
-          description: Generated server url
-  /v2/ledger-search:
-    post:
-      tags:
-        - 'Ledger Search'
       summary: Search for Credential Status Records (Ledger Search) - v2
-      description: '[V2] Search based on credentialId, issuerId, credentialType, and indexedAttributes. Returns matching credential status records.'
-      operationId: searchLedgerRecordsV2
+      description: 'Search based on credentialId, issuerId, credentialType, and indexedAttributes. Returns matching credential status records.'
+      operationId: searchLedgerRecords
       requestBody:
         required: true
         content:
@@ -1589,72 +1202,14 @@ paths:
       tags:
         - 'Credential Status'
       summary: Update Credential Status
-      description: |
-        Updates the status of an issued credential. This is the primary endpoint for changing a credential's status (e.g., revoking, suspending, activating by setting the 'status' boolean). It can potentially assign a credential to a status list index using fields within the 'credentialStatus' object. This operation is potentially complex: if a status list mechanism (like Bitstring Status List v1.0) is used, this may trigger fetching the relevant Status List VC, modifying its `encodedList`, calculating a new proof, and storing the updated Status List VC, in addition to updating the local credential status record. Requires appropriate authorization. This endpoint directly applies the status change. compliant to https://w3c-ccg.github.io/vc-api/#update-status
+      description: 'Updates the status of an issued credential. Returns the updated status record. This endpoint is no longer dependent on ledger. Hence it will not use credentialId to search for the credentialStatusDetails in Ledger but it will check if the statusListCredential with given statusListCredentialId is present in the status_list_credential table.'
       operationId: updateCredentialStatus
       requestBody:
-        description: 'Specifies the credential to update, the new status value, and associated status mechanism details.'
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/UpdateCredentialStatusRequestDto'
-            examples:
-              Example 1:
-                value:
-                  credentialId: 52b55d02-613f-432f-b29e-ae842bc404a8
-                  credentialStatus:
-                    statusPurpose: revocation
-                    statusListIndex: 5
-                    id: 'http://localhost:8090/v1/certify/status-list/7bf52e81-f3bb-40ec-a0f9-a714847fd067#5'
-                    type: BitstringStatusListEntry
-                    statusListCredential: 'http://localhost:8090/v1/certify/status-list/7bf52e81-f3bb-40ec-a0f9-a714847fd067'
-                  status: false
-                  indexAllocator: test
-      responses:
-        '200':
-          description: Credential status successfully updated. Returns the updated status record.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CredentialStatusResponseDto'
-              examples:
-                Example 1:
-                  value:
-                    credentialId: 52b55d02-613f-432f-b29e-ae842bc404a8
-                    issuerId: 'did:web:www.example.com:inji-config:collab:mock-identity'
-                    statusListCredentialUrl: 7bf52e81-f3bb-40ec-a0f9-a714847fd067
-                    statusListIndex: 5
-                    statusPurpose: revocation
-                    issueDate: '2025-08-07T12:18:55'
-                    credentialType: 'FarmerCredential,VerifiableCredential'
-                    statusTimestamp: '2025-08-07T12:18:55'
-        '400':
-          description: 'Bad Request - Invalid input data (e.g., missing required fields, invalid format).'
-        '403':
-          description: Forbidden - Caller does not have permission to update the status of this credential.
-        '404':
-          description: Not Found - The specified credentialId or referenced statusListCredential URL does not exist in the system.
-        '409':
-          description: 'Conflict - The requested status update cannot be performed (e.g., index already allocated and conflict occurs, state transition not allowed).'
-        '500':
-          description: 'Internal Server Error - An error occurred during the status update process (e.g., failed to update Status List VC).'
-      servers:
-        - url: 'http://localhost:8090/v1/certify'
-          description: Generated server url
-  /credentials/v2/status:
-    post:
-      tags:
-        - 'Credential Status'
-      summary: Update Credential Status - V2
-      description: '[V2] Updates the status of an issued credential. Returns the updated status record. The v2 endpoint for status update is no longer dependent on ledger. Hence it will not use credentialId to search for the credentialStatusDetails in Ledger but it will check if the statusListCredential with given statusListCredentialId is present in the status_list_credential table.'
-      operationId: updateCredentialStatusV2
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/UpdateCredentialStatusRequestV2Dto'
             examples:
               Example 1:
                 value:
@@ -1799,7 +1354,7 @@ paths:
       servers:
         - url: 'http://localhost:8090/v1/certify'
           description: Generated server url
-  /oauth/.well-known/jwks.json:
+  /.well-known/jwks.json:
     get:
       tags:
         - Well-known
@@ -2580,7 +2135,7 @@ components:
           type: string
           format: uri
           description: URL of the authorization server's JWK Set document
-          example: "http://localhost:8090/v1/certify/oauth/.well-known/jwks.json"
+          example: "http://localhost:8090/v1/certify/.well-known/jwks.json"
         grant_types_supported:
           type: array
           items:
@@ -2653,11 +2208,6 @@ components:
           type: string
           description: The purpose associated with the current status check (from credential_status.status_purpose where is_current=true).
           nullable: true
-        issueDate:
-          type: string
-          description: Issuance date of the credential being tracked (from ledger.issuance_date).
-          format: date-time
-          nullable: true
         issuanceDate:
           type: string
           description: Issuance date of the credential being tracked (from ledger.issuance_date).
@@ -2676,50 +2226,6 @@ components:
           description: Timestamp of when the current status became effective (from credential_status.status_timestamp where is_current=true).
           format: date-time
     UpdateCredentialStatusRequestDto:
-      type: object
-      properties:
-        credentialId:
-          type: string
-          description: System identifier for the credential status record to update.
-        credentialStatus:
-          type: object
-          description: 'Object containing details related to the credential''s status mechanism, especially if using a status list.'
-          properties:
-            id:
-              type: string
-              nullable: true
-              description: 'The identifier for the credential status entry itself (e.g., https://example.com/status/1#123). Optional, system may generate/manage.'
-              format: uri
-            type:
-              type: string
-              nullable: true
-              description: 'The type of the status mechanism being used (e.g., BitstringStatusList). Optional, may be inferred or managed by system.'
-            statusPurpose:
-              type: string
-              nullable: true
-              description: 'Indicates the purpose of the status (e.g., ''revocation'', ''suspension''). Determines interpretation of the ''status'' bit. Should align with system policy/list purpose.'
-            statusListIndex:
-              type: integer
-              nullable: true
-              description: The index assigned to this credential within the referenced status list. Required if using StatusList.
-              format: int64
-            statusListCredential:
-              type: string
-              nullable: true
-              description: The URL/ID of the Status List VC document to use. Required if using StatusList.
-              format: uri
-        status:
-          type: boolean
-          description: 'The new status value (true typically means ''status asserted'', e.g., revoked/suspended; false means ''status not asserted''). Interpretation depends on statusPurpose and system policy.'
-        indexAllocator:
-          type: string
-          nullable: true
-          description: Optional hint or identifier for index allocation strategy or service component. Usage is implementation-defined.
-      required:
-        - credentialId
-        - credentialStatus
-        - status
-    UpdateCredentialStatusRequestV2Dto:
       type: object
       properties:
         credentialStatus:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation / API Updates**
  * Updated the OpenAPI specification for credential issuance, simplifying the generic issuance endpoint and removing draft-specific issuance endpoints.
  * Removed deprecated issuer/DID discovery endpoints under issuance-scoped well-known routes.
  * Updated credential status documentation: renamed the date field to `issuanceDate` and tightened required request fields for status list details (with clearer optional handling for `statusPurpose`).
* **New Endpoint Conventions**
  * Moved the JWKS endpoint to `/.well-known/jwks.json` and refreshed related issuer metadata examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->