### PR TITLE
Add LICENSE_NAME parameter to maven build workflow to avoid license c…

### DIFF
--- a/.github/workflows/manual-docker-build.yml
+++ b/.github/workflows/manual-docker-build.yml
@@ -15,6 +15,7 @@ jobs:
     with:
       SERVICE_LOCATION: ./certify-service-with-plugins
       BUILD_ARTIFACT: certify-service-with-plugins
+      LICENSE_NAME: 'Apache 2.0'
       MAVEN_NON_EXEC_ARTIFACTS: "mock-certify-plugin.jar,mosip-identity-certify-plugin.jar,postgres-dataprovider-plugin.jar,sunbird-rc-certify-integration-impl.jar"
     secrets:
       OSSRH_USER: ${{ secrets.OSSRH_USER }}


### PR DESCRIPTION
…heck failure.,

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the manual build configuration to include the Apache 2.0 license name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->